### PR TITLE
Package README simplification in favor of dev docs

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,6 +4,18 @@
 
 A type-safe TypeScript SDK for accessing the YouVersion Platform APIs. Get Bible content and build Bible-based applications.
 
+## When to use this package
+
+Use `@youversion/platform-core` when you need:
+- ✅ Direct access to YouVersion Platform APIs
+- ✅ Server-side/Node.js Bible data fetching
+- ✅ Full control over API calls and data handling
+- ✅ Minimal dependencies (works anywhere JavaScript runs)
+
+**Use other packages instead if:**
+- ❌ Building React components → Use [@youversion/platform-react-hooks](../hooks/README.md) for hooks with state management
+- ❌ Need ready-made UI → Use [@youversion/platform-react-ui](../ui/README.md) for production-ready components
+
 ## Install
 
 ```bash
@@ -35,4 +47,4 @@ console.log(passage.content) // "For God so loved the world..."
 
 ---
 
-**API Reference:** [developers.youversion.com/sdks/react](https://developers.youversion.com/sdks/react)
+**API Reference:** [developers.youversion.com/sdks/typescript](https://developers.youversion.com/sdks/typescript)

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -4,6 +4,18 @@
 
 React hooks for accessing YouVersion Platform APIs with automatic loading/error states.
 
+## When to use this package
+
+Use `@youversion/platform-react-hooks` when you need:
+- ✅ Building custom React components with Bible features
+- ✅ Declarative data fetching with automatic loading/error states
+- ✅ Control over component UI while using reusable hooks
+- ✅ Server-side rendering compatible hooks
+
+**Use other packages instead if:**
+- ❌ Need direct API access → Use [@youversion/platform-core](../core/README.md) for low-level client
+- ❌ Want ready-made UI → Use [@youversion/platform-react-ui](../ui/README.md) for production components
+
 ## Install
 
 ```bash

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -4,6 +4,19 @@
 
 Pre-built React components for Bible applications with styling included.
 
+## When to use this package
+
+Use `@youversion/platform-react-ui` when you need:
+- ✅ Production-ready Bible components for your React app
+- ✅ Pre-styled components with light/dark mode
+- ✅ Minimal setup. Wrap your app with providers and use the components
+- ✅ Consistent, accessible UI out of the box
+Get your App Key at [platform.youversion.com](https://platform.youversion.com/)
+
+**Use other packages instead if:**
+- ❌ Need low-level API access → Use [@youversion/platform-core](../core/README.md)
+- ❌ Want custom UI → Use [@youversion/platform-react-hooks](../hooks/README.md)
+
 ## Install
 
 ```bash


### PR DESCRIPTION
I've updated the README's of each package, so that we can direct the users to the dev docs (that will be available shortly at https://developers.youversion.com/sdks/react.

These changes were deeply influenced by https://www.mintlify.com/blog/how-to-write-documentation-that-developers-want-to-read

> [!important]
> ~~These cannot be pushed until https://github.com/youversion/youversion-platform-developer-hub/pull/42 is pushed and live.~~

This is a complement to #19, but it's separate because that can be pushed now and this relies on https://github.com/youversion/youversion-platform-developer-hub/pull/42