### PR TITLE
fix(ui): remove the need to import our css styles

### DIFF
--- a/.changeset/shiny-items-build.md
+++ b/.changeset/shiny-items-build.md
@@ -1,0 +1,7 @@
+---
+'@youversion/platform-react-ui': patch
+'@youversion/platform-core': patch
+'@youversion/platform-react-hooks': patch
+---
+
+fix(ui): remove the need to import css file

--- a/examples/nextjs/src/app/layout.tsx
+++ b/examples/nextjs/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import { Providers } from './providers';
 import React, { type JSX } from 'react';
 import './globals.css';
-import '@youversion/platform-react-ui/styles.css';
 
 export const viewport = {
   width: 'device-width',

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,5 +1,8 @@
 // React SDK main entry point
 
+// Import processed styles for injection
+import '../dist/tailwind.css';
+
 export * from './components';
 export * from './hooks';
 export * from './providers';

--- a/packages/ui/tsup.config.ts
+++ b/packages/ui/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: ['src/index.ts'],
   sourcemap: false,
   splitting: false,
-  injectStyle: false,
+  injectStyle: true,
   clean: process.env.NODE_ENV === 'production',
   format: ['esm', 'cjs'],
   target: 'es2020',


### PR DESCRIPTION
- Users had to import our css file and this caused post processing by the users build tools.
- This removes the need to import the css file and will fix the post processing issues that users were having.

This is a simplified solution based on the work that @cameronapak in #45.