### PR TITLE
YPE-1000: feat(verse-of-the-day): update default bible version to niv

### DIFF
--- a/packages/ui/src/components/verse-of-the-day.stories.tsx
+++ b/packages/ui/src/components/verse-of-the-day.stories.tsx
@@ -79,7 +79,7 @@ export const Default: Story = {
     const callArgs = mockSpy.mock.calls[0]?.[0];
     await expect(callArgs).toHaveProperty('text');
     await expect(callArgs?.text).toContain('For I am about to do something new');
-    await expect(callArgs?.text).toContain('Isaiah 43:19 KJV');
+    await expect(callArgs?.text).toContain('Isaiah 43:19 NIV');
   },
 };
 

--- a/packages/ui/src/components/verse-of-the-day.tsx
+++ b/packages/ui/src/components/verse-of-the-day.tsx
@@ -19,7 +19,7 @@ export type VerseOfTheDayProps = {
    */
   background?: 'light' | 'dark';
   /**
-   * The Bible Translation version id to use, defaults to 1 (KJV).
+   * The Bible Translation version id to use, defaults to 111 (NIV).
    */
   versionId?: number;
   /**
@@ -69,7 +69,7 @@ async function share({ title, text, url }: { title?: string; text: string; url?:
  * @example
  * ```tsx
  * <VerseOfTheDay
- *   versionId={1}
+ *   versionId={111}
  *   showSunIcon={true}
  *   showShareButton={false}
  *   showBibleAppAttribution={true}
@@ -80,7 +80,7 @@ async function share({ title, text, url }: { title?: string; text: string; url?:
 export function VerseOfTheDay({
   background,
   dayOfYear,
-  versionId = 1, // KJV by default
+  versionId = 111, // NIV by default
   showSunIcon = true,
   showShareButton = true,
   showBibleAppAttribution = true,

--- a/packages/ui/src/test/mock-data/passages.json
+++ b/packages/ui/src/test/mock-data/passages.json
@@ -56,7 +56,7 @@
   "ISA.43.19": {
     "id": "ISA.43.19",
     "content": "<div><div class=\"q1\"><span class=\"yv-v\" v=\"19\"></span><span class=\"yv-vlbl\">19</span>For I am about to do something new.</div><div class=\"q2\">See, I have already begun! Do you not see it?</div><div class=\"q1\">I will make a pathway through the wilderness.</div><div class=\"q2\">I will create rivers in the dry wasteland.</div></div>",
-    "version_id": 1,
+    "version_id": 111,
     "reference": "Isaiah 43:19"
   },
   "JHN.1.51": {

--- a/packages/ui/src/test/mocks/handlers.ts
+++ b/packages/ui/src/test/mocks/handlers.ts
@@ -47,17 +47,13 @@ export const globalHandlers = [
   }),
 
   // Isaiah passage for verse of the day
-  http.get('*/v1/bibles/1/passages/ISA.43.19', () => {
+  http.get('*/v1/bibles/111/passages/ISA.43.19', () => {
     return HttpResponse.json(mockPassages['ISA.43.19']);
   }),
 
   // Specific Bible versions
   http.get('*/v1/bibles/111', () => {
     return HttpResponse.json(mockBibles.individual['111']);
-  }),
-
-  http.get('*/v1/bibles/1', () => {
-    return HttpResponse.json(mockBibles.individual['1']);
   }),
 
   http.get('*/v1/bibles/1588', () => {


### PR DESCRIPTION
Ticket: https://lifechurch.atlassian.net/browse/YPE-1000

The default Bible version for the VerseOfTheDay component has been updated from KJV (version ID 1) to NIV (version ID 111). This change reflects the new required default version for the application.

Mock data and handlers have been updated to reflect the new default version.

I accidentally borked https://github.com/youversion/platform-sdk-react/pull/92 so this is a re-do of it... 