### PR TITLE
Docs: Add contributing section and app key setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,27 @@ cd platform-sdk-react
 pnpm install
 ```
 
+### Get an app key
+
+You'll need to obtain an app key from https://platform.youversion.com
+
+### Set up environment variables
+
+Create an .env.local file in the `./packages/core` package and update the app key variable. 
+
+```bash
+cp ./packages/core/.env.example ./packages/core/.env.local
+```
+
+Create an .env.local file in the `./packages/ui` package and update the app key variable. 
+
+```bash
+cp ./packages/ui/.env.example ./packages/ui/.env.local
+```
+
+> [!NOTE]
+> Our React hooks package does not require environment variables at this time.
+
 ### Build Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ const passage = await bibleClient.getPassage(versions.data[0].id, 'JHN.3.16');
 console.log(passage.content);
 ```
 
+## Contributing
+
+Want to contribute? See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup instructions, development workflow, and guidelines.
+
 ## License
 
 This SDK is licensed under [Apache 2.0](./LICENSE). 


### PR DESCRIPTION
When I was onboarding Kyle and Jared into the React Web SDK, I tried to go through the docs and make sure that it was instructing people properly. But one thing that it was missing is it wasn't telling anyone what environment variables to or how to get the environment variables set up. I've added that section and just added a little clarity so that it's easier if you're a developer wanting to contribute to find out how to get the repo set up. 