### PR TITLE
fix: scope Tailwind preflight to prevent style bleeding between SDK and consumer apps

### DIFF
--- a/packages/ui/src/lib/inject-styles.ts
+++ b/packages/ui/src/lib/inject-styles.ts
@@ -7,9 +7,9 @@ export function injectStyles() {
   const id = '__yv-sdk-styles';
   if (document.getElementById(id)) return; // Already injected
 
-  // Create and append style tag to DOM
+  // Prepend style tag so consumer styles take cascade priority
   const style = document.createElement('style');
   style.id = id;
   style.textContent = __YV_STYLES__;
-  document.head.appendChild(style);
+  document.head.prepend(style);
 }

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -20,7 +20,7 @@
  * Note: CSS linter warnings on these imports are a known issue and do not
  * affect functionality.
  */
-@import 'tailwindcss/preflight.css' prefix(yv);
+@import './preflight-scoped.css';
 @import 'tailwindcss/theme.css' prefix(yv);
 @import 'tailwindcss/utilities.css' prefix(yv);
 

--- a/packages/ui/src/styles/preflight-scoped.css
+++ b/packages/ui/src/styles/preflight-scoped.css
@@ -1,0 +1,262 @@
+/*
+ * Scoped Preflight
+ * ================
+ * Tailwind v4 preflight scoped to [data-yv-sdk] so SDK styles don't
+ * reset the consumer's page. All rules are nested under [data-yv-sdk]
+ * using CSS nesting.
+ *
+ * Based on: tailwindcss@4.1.16/preflight.css
+ */
+
+[data-yv-sdk] {
+  /*
+    Base properties (replaces html/:host rules).
+    Applied to each SDK component root.
+  */
+  line-height: 1.5;
+  -webkit-text-size-adjust: 100%;
+  tab-size: 4;
+  font-family: --theme(
+    --default-font-family,
+    ui-sans-serif,
+    system-ui,
+    sans-serif,
+    'Apple Color Emoji',
+    'Segoe UI Emoji',
+    'Segoe UI Symbol',
+    'Noto Color Emoji'
+  );
+  font-feature-settings: --theme(--default-font-feature-settings, normal);
+  font-variation-settings: --theme(--default-font-variation-settings, normal);
+  -webkit-tap-highlight-color: transparent;
+
+  /*
+    1. Prevent padding and border from affecting element width.
+    2. Remove default margins and padding.
+    3. Reset all borders.
+  */
+  & *,
+  & ::after,
+  & ::before,
+  & ::file-selector-button {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    border: 0 solid;
+  }
+
+  & hr {
+    height: 0;
+    color: inherit;
+    border-top-width: 1px;
+  }
+
+  & abbr:where([title]) {
+    -webkit-text-decoration: underline dotted;
+    text-decoration: underline dotted;
+  }
+
+  & h1,
+  & h2,
+  & h3,
+  & h4,
+  & h5,
+  & h6 {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+
+  & a {
+    color: inherit;
+    -webkit-text-decoration: inherit;
+    text-decoration: inherit;
+  }
+
+  & b,
+  & strong {
+    font-weight: bolder;
+  }
+
+  & code,
+  & kbd,
+  & samp,
+  & pre {
+    font-family: --theme(
+      --default-mono-font-family,
+      ui-monospace,
+      SFMono-Regular,
+      Menlo,
+      Monaco,
+      Consolas,
+      'Liberation Mono',
+      'Courier New',
+      monospace
+    );
+    font-feature-settings: --theme(
+      --default-mono-font-feature-settings,
+      normal
+    );
+    font-variation-settings: --theme(
+      --default-mono-font-variation-settings,
+      normal
+    );
+    font-size: 1em;
+  }
+
+  & small {
+    font-size: 80%;
+  }
+
+  & sub,
+  & sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+
+  & sub {
+    bottom: -0.25em;
+  }
+
+  & sup {
+    top: -0.5em;
+  }
+
+  & table {
+    text-indent: 0;
+    border-color: inherit;
+    border-collapse: collapse;
+  }
+
+  & :-moz-focusring {
+    outline: auto;
+  }
+
+  & progress {
+    vertical-align: baseline;
+  }
+
+  & summary {
+    display: list-item;
+  }
+
+  & ol,
+  & ul,
+  & menu {
+    list-style: none;
+  }
+
+  & img,
+  & svg,
+  & video,
+  & canvas,
+  & audio,
+  & iframe,
+  & embed,
+  & object {
+    display: block;
+    vertical-align: middle;
+  }
+
+  & img,
+  & video {
+    max-width: 100%;
+    height: auto;
+  }
+
+  & button,
+  & input,
+  & select,
+  & optgroup,
+  & textarea,
+  & ::file-selector-button {
+    font: inherit;
+    font-feature-settings: inherit;
+    font-variation-settings: inherit;
+    letter-spacing: inherit;
+    color: inherit;
+    border-radius: 0;
+    background-color: transparent;
+    opacity: 1;
+  }
+
+  & :where(select:is([multiple], [size])) optgroup {
+    font-weight: bolder;
+  }
+
+  & :where(select:is([multiple], [size])) optgroup option {
+    padding-inline-start: 20px;
+  }
+
+  & ::file-selector-button {
+    margin-inline-end: 4px;
+  }
+
+  & ::placeholder {
+    opacity: 1;
+  }
+
+  @supports (not (-webkit-appearance: -apple-pay-button)) or
+    (contain-intrinsic-size: 1px) {
+    & ::placeholder {
+      color: color-mix(in oklab, currentcolor 50%, transparent);
+    }
+  }
+
+  & textarea {
+    resize: vertical;
+  }
+
+  & ::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+
+  & ::-webkit-date-and-time-value {
+    min-height: 1lh;
+    text-align: inherit;
+  }
+
+  & ::-webkit-datetime-edit {
+    display: inline-flex;
+  }
+
+  & ::-webkit-datetime-edit-fields-wrapper {
+    padding: 0;
+  }
+
+  & ::-webkit-datetime-edit,
+  & ::-webkit-datetime-edit-year-field,
+  & ::-webkit-datetime-edit-month-field,
+  & ::-webkit-datetime-edit-day-field,
+  & ::-webkit-datetime-edit-hour-field,
+  & ::-webkit-datetime-edit-minute-field,
+  & ::-webkit-datetime-edit-second-field,
+  & ::-webkit-datetime-edit-millisecond-field,
+  & ::-webkit-datetime-edit-meridiem-field {
+    padding-block: 0;
+  }
+
+  & ::-webkit-calendar-picker-indicator {
+    line-height: 1;
+  }
+
+  & :-moz-ui-invalid {
+    box-shadow: none;
+  }
+
+  & button,
+  & input:where([type='button'], [type='reset'], [type='submit']),
+  & ::file-selector-button {
+    appearance: button;
+  }
+
+  & ::-webkit-inner-spin-button,
+  & ::-webkit-outer-spin-button {
+    height: auto;
+  }
+
+  & [hidden]:where(:not([hidden='until-found'])) {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
## Problem

When a consumer app imports any component from `@youversion/platform-react-ui`, the SDK auto-injects its styles via a `<style>` tag. This includes **Tailwind v4's preflight.css** — a CSS reset that targets bare element selectors like `*`, `h1`, `a`, `button`, `img`, `ul`, etc.

The issue: **`prefix(yv)` only prefixes utility class names** (e.g., `yv:flex`). It has **zero effect on preflight's element-level resets** because those are element selectors, not classes. The entire reset passes through unscoped and nukes the consumer's page styles.

Making things worse, the style tag was **appended to the end of `<head>`**, giving it maximum cascade priority — so even if the consumer had their own styles, the SDK's reset won on ordering alone.

**Result:** consumers embedding SDK components saw their page layouts break — margins/padding stripped, headings unstyled, links losing colors, images forced to `display: block`, lists losing bullets, buttons losing backgrounds, etc.

### Before (DevTools showing the damage)

The universal reset hitting every element on the consumer's page:
```
*, :after, :before, ::backdrop {
  box-sizing: border-box;
  border: 0 solid;
  margin: 0;
  padding: 0;
}
```

## Solution

### 1. Scope preflight under `[data-yv-sdk]`

Replaced `@import 'tailwindcss/preflight.css' prefix(yv)` with a hand-scoped `preflight-scoped.css` that nests every reset rule under `[data-yv-sdk]` using CSS nesting:

- `*, ::after, ::before` → `[data-yv-sdk] *, [data-yv-sdk] ::after, ...`
- `html, :host` → properties applied directly to `[data-yv-sdk]` (each component root)
- `h1-h6`, `a`, `button`, `img`, `ul`, etc. → all scoped to SDK descendants only

This means the reset **only affects elements inside SDK components** — the consumer's page is untouched.

### 2. Prepend instead of append

Changed `document.head.appendChild(style)` → `document.head.prepend(style)` so the SDK's style tag loads **first** in `<head>`. Consumer styles loaded after get natural cascade priority for any specificity ties.

### What this protects against

| Direction | Attack vector | Protected? |
|---|---|---|
| SDK → Consumer | Preflight resets consumer's page elements | **Yes** — scoping eliminates this entirely |
| Consumer → SDK | Bare element selectors (e.g., `h1 { color: red }`) | **Yes** — `[data-yv-sdk] h1` has higher specificity |
| Consumer → SDK | Compound selectors (e.g., `.app h1 { ... }`) | **Mostly** — prepend gives consumer cascade priority, and SDK utilities override preflight anyway |

## Changes

- **New:** `packages/ui/src/styles/preflight-scoped.css` — full TW4 preflight scoped to `[data-yv-sdk]`
- **Edit:** `packages/ui/src/styles/global.css` — swap preflight import
- **Edit:** `packages/ui/src/lib/inject-styles.ts` — `appendChild` → `prepend`

## Test plan

- [x] `pnpm build` passes (all 4 packages)
- [x] `pnpm test` passes (283 tests across core/hooks/ui)
- [x] Built `dist/tailwind.css` contains zero unscoped element selectors
- [ ] Manual: embed SDK component in a consumer app, verify no style bleed in either direction

🤖 Generated with [Claude Code](https://claude.com/claude-code)