### PR TITLE
YPE-1157: test(hooks) - useChapterNavigation

### DIFF
--- a/packages/hooks/src/useChapterNavigation.test.tsx
+++ b/packages/hooks/src/useChapterNavigation.test.tsx
@@ -181,7 +181,7 @@ describe('useChapterNavigation', () => {
   });
 
   it('isLoading is true and both canNavigate are false while loading', () => {
-    setMockBooks([], true);
+    setMockBooks(allBooks, true);
 
     const { result } = renderHook(useNavWithContext, {
       wrapper: createWrapper(genBook, genChapters[0]!),

--- a/packages/hooks/src/useChapterNavigation.test.tsx
+++ b/packages/hooks/src/useChapterNavigation.test.tsx
@@ -278,7 +278,7 @@ describe('useChapterNavigation', () => {
     expect(result.current.nav.currentChapterIndex).toBe(-1);
   });
 
-  it('navigate is no-op when target chapter not in chapters or intro', () => {
+  it('navigateToNext is no-op when next book has no canonical chapters', () => {
     const bookNoIntro = createMockBook({
       id: 'GEN',
       title: 'Genesis',

--- a/packages/hooks/src/useChapterNavigation.test.tsx
+++ b/packages/hooks/src/useChapterNavigation.test.tsx
@@ -15,45 +15,13 @@ function makeChapters(bookId: string, count: number): BibleChapter[] {
   }));
 }
 
-const genChapters = makeChapters('GEN', 50);
-const exoChapters = makeChapters('EXO', 40);
-const revChapters = makeChapters('REV', 22);
-
-const mockBooks: BibleBook[] = [
-  createMockBook({
-    id: 'GEN',
-    title: 'Genesis',
-    chapters: genChapters,
-    intro: { id: 'INTRO', passage_id: 'GEN.INTRO', title: 'Intro' },
-  }),
-  createMockBook({
-    id: 'EXO',
-    title: 'Exodus',
-    canon: 'old_testament',
-    chapters: exoChapters,
-  }),
-  createMockBook({
-    id: 'REV',
-    title: 'Revelation',
-    canon: 'new_testament',
-    chapters: revChapters,
-  }),
-];
-
-const { mockUseBooks } = vi.hoisted(() => ({
-  mockUseBooks: vi.fn(),
-}));
-vi.mock('./useBooks', () => ({
-  useBooks: mockUseBooks,
-}));
-
 function useNavWithContext() {
   const nav = useChapterNavigation();
   const ctx = useReaderContext();
   return { nav, ctx };
 }
 
-function wrapper(book: BibleBook, chapter: BibleChapter) {
+function createWrapper(book: BibleBook, chapter: BibleChapter) {
   return ({ children }: { children: React.ReactNode }) => (
     <ReaderProvider
       currentVersion={createMockVersion()}
@@ -66,56 +34,100 @@ function wrapper(book: BibleBook, chapter: BibleChapter) {
   );
 }
 
-const genBook = mockBooks[0]!;
-const exoBook = mockBooks[1]!;
-const revBook = mockBooks[2]!;
+const genChapters = makeChapters('GEN', 50);
+const exoChapters = makeChapters('EXO', 40);
+const revChapters = makeChapters('REV', 22);
+
+const introChapter: BibleChapter = {
+  id: 'INTRO',
+  passage_id: 'GEN.INTRO',
+  title: 'Intro',
+};
+
+const genBook = createMockBook({
+  id: 'GEN',
+  title: 'Genesis',
+  chapters: genChapters,
+  intro: { id: 'INTRO', passage_id: 'GEN.INTRO', title: 'Intro' },
+});
+
+const exoBook = createMockBook({
+  id: 'EXO',
+  title: 'Exodus',
+  canon: 'old_testament',
+  chapters: exoChapters,
+});
+
+const revBook = createMockBook({
+  id: 'REV',
+  title: 'Revelation',
+  canon: 'new_testament',
+  chapters: revChapters,
+});
+
+const allBooks: BibleBook[] = [genBook, exoBook, revBook];
+
+const { mockUseBooks } = vi.hoisted(() => ({
+  mockUseBooks: vi.fn(),
+}));
+
+vi.mock('./useBooks', () => ({
+  useBooks: mockUseBooks,
+}));
+
+function setMockBooks(books: BibleBook[], loading = false) {
+  mockUseBooks.mockReturnValue({
+    books: { data: books },
+    loading,
+    error: null,
+    refetch: vi.fn(),
+  });
+}
 
 describe('useChapterNavigation', () => {
   beforeEach(() => {
-    mockUseBooks.mockReturnValue({
-      books: { data: mockBooks },
-      loading: false,
-      error: null,
-      refetch: vi.fn(),
-    });
+    setMockBooks(allBooks);
   });
 
-  it('navigateToNext within same book updates chapter, keeps book', () => {
+  it('canNavigatePrevious is false at Bible start (GEN INTRO)', () => {
     const { result } = renderHook(useNavWithContext, {
-      wrapper: wrapper(genBook, genChapters[0]!),
+      wrapper: createWrapper(genBook, introChapter),
     });
 
-    act(() => result.current.nav.navigateToNext());
-
-    expect(result.current.ctx.currentChapter.id).toBe('2');
-    expect(result.current.ctx.currentBook.id).toBe('GEN');
+    expect(result.current.nav.canNavigatePrevious).toBe(false);
   });
 
-  it('navigateToNext cross-book updates both book and chapter', () => {
+  it('canNavigateNext is false at Bible end (REV last chapter)', () => {
     const { result } = renderHook(useNavWithContext, {
-      wrapper: wrapper(genBook, genChapters.at(-1)!),
+      wrapper: createWrapper(revBook, revChapters[21]!),
     });
 
-    act(() => result.current.nav.navigateToNext());
-
-    expect(result.current.ctx.currentBook.id).toBe('EXO');
-    expect(result.current.ctx.currentChapter.id).toBe('1');
+    expect(result.current.nav.canNavigateNext).toBe(false);
   });
 
-  it('navigateToPrevious to intro sets chapter to INTRO, keeps book', () => {
+  it('both canNavigatePrevious and canNavigateNext are true for middle chapter', () => {
     const { result } = renderHook(useNavWithContext, {
-      wrapper: wrapper(genBook, genChapters[0]!),
+      wrapper: createWrapper(exoBook, exoChapters[19]!),
+    });
+
+    expect(result.current.nav.canNavigatePrevious).toBe(true);
+    expect(result.current.nav.canNavigateNext).toBe(true);
+  });
+
+  it('navigateToPrevious within same book decrements chapter', () => {
+    const { result } = renderHook(useNavWithContext, {
+      wrapper: createWrapper(genBook, genChapters[4]!),
     });
 
     act(() => result.current.nav.navigateToPrevious());
 
-    expect(result.current.ctx.currentChapter.id).toBe('INTRO');
+    expect(result.current.ctx.currentChapter.id).toBe('4');
     expect(result.current.ctx.currentBook.id).toBe('GEN');
   });
 
-  it('navigateToPrevious cross-book updates both book and chapter', () => {
+  it('navigateToPrevious cross-book goes to last chapter of previous book', () => {
     const { result } = renderHook(useNavWithContext, {
-      wrapper: wrapper(exoBook, exoChapters[0]!),
+      wrapper: createWrapper(exoBook, exoChapters[0]!),
     });
 
     act(() => result.current.nav.navigateToPrevious());
@@ -124,38 +136,168 @@ describe('useChapterNavigation', () => {
     expect(result.current.ctx.currentChapter.id).toBe('50');
   });
 
-  it('canNavigatePrevious is false at Bible start', () => {
-    const introChapter: BibleChapter = { id: 'INTRO', passage_id: 'GEN.INTRO', title: 'Intro' };
-
+  it('navigateToPrevious from first canonical chapter goes to intro', () => {
     const { result } = renderHook(useNavWithContext, {
-      wrapper: wrapper(genBook, introChapter),
+      wrapper: createWrapper(genBook, genChapters[0]!),
     });
 
-    expect(result.current.nav.canNavigatePrevious).toBe(false);
+    act(() => result.current.nav.navigateToPrevious());
+
+    expect(result.current.ctx.currentChapter.id).toBe('INTRO');
+    expect(result.current.ctx.currentBook.id).toBe('GEN');
   });
 
-  it('canNavigateNext is false at Bible end', () => {
+  it('navigateToNext within same book increments chapter', () => {
     const { result } = renderHook(useNavWithContext, {
-      wrapper: wrapper(revBook, revChapters[21]!),
+      wrapper: createWrapper(genBook, genChapters[0]!),
     });
 
-    expect(result.current.nav.canNavigateNext).toBe(false);
+    act(() => result.current.nav.navigateToNext());
+
+    expect(result.current.ctx.currentChapter.id).toBe('2');
+    expect(result.current.ctx.currentBook.id).toBe('GEN');
   });
 
-  it('both disabled while loading', () => {
-    mockUseBooks.mockReturnValue({
-      books: null,
-      loading: true,
-      error: null,
-      refetch: vi.fn(),
+  it('navigateToNext cross-book goes to first chapter of next book', () => {
+    const { result } = renderHook(useNavWithContext, {
+      wrapper: createWrapper(genBook, genChapters[49]!),
     });
+
+    act(() => result.current.nav.navigateToNext());
+
+    expect(result.current.ctx.currentBook.id).toBe('EXO');
+    expect(result.current.ctx.currentChapter.id).toBe('1');
+  });
+
+  it('navigateToNext from intro goes to chapter 1 of same book', () => {
+    const { result } = renderHook(useNavWithContext, {
+      wrapper: createWrapper(genBook, introChapter),
+    });
+
+    act(() => result.current.nav.navigateToNext());
+
+    expect(result.current.ctx.currentChapter.id).toBe('1');
+    expect(result.current.ctx.currentBook.id).toBe('GEN');
+  });
+
+  it('isLoading is true and both canNavigate are false while loading', () => {
+    setMockBooks([], true);
 
     const { result } = renderHook(useNavWithContext, {
-      wrapper: wrapper(genBook, genChapters[0]!),
+      wrapper: createWrapper(genBook, genChapters[0]!),
     });
 
-    expect(result.current.nav.canNavigateNext).toBe(false);
-    expect(result.current.nav.canNavigatePrevious).toBe(false);
     expect(result.current.nav.isLoading).toBe(true);
+    expect(result.current.nav.canNavigateNext).toBe(false);
+    expect(result.current.nav.canNavigatePrevious).toBe(false);
+  });
+
+  it('empty books array disables navigation', () => {
+    setMockBooks([]);
+
+    const { result } = renderHook(useNavWithContext, {
+      wrapper: createWrapper(genBook, genChapters[0]!),
+    });
+
+    expect(result.current.nav.canNavigateNext).toBe(false);
+    expect(result.current.nav.canNavigatePrevious).toBe(false);
+  });
+
+  it('navigateToNext is no-op when books array is empty', () => {
+    setMockBooks([]);
+
+    const { result } = renderHook(useNavWithContext, {
+      wrapper: createWrapper(genBook, genChapters[0]!),
+    });
+
+    act(() => result.current.nav.navigateToNext());
+
+    expect(result.current.ctx.currentChapter.id).toBe('1');
+    expect(result.current.ctx.currentBook.id).toBe('GEN');
+  });
+
+  it('currentChapterIndex reflects correct position for middle chapter', () => {
+    const { result } = renderHook(useNavWithContext, {
+      wrapper: createWrapper(genBook, genChapters[9]!),
+    });
+
+    expect(result.current.nav.currentChapterIndex).toBe(9);
+  });
+
+  it('currentChapterIndex is -1 when chapter not in book chapters list', () => {
+    const { result } = renderHook(useNavWithContext, {
+      wrapper: createWrapper(genBook, introChapter),
+    });
+
+    expect(result.current.nav.currentChapterIndex).toBe(-1);
+  });
+
+  it('navigateToNext is no-op at last book last chapter', () => {
+    const { result } = renderHook(useNavWithContext, {
+      wrapper: createWrapper(revBook, revChapters[21]!),
+    });
+
+    act(() => result.current.nav.navigateToNext());
+
+    expect(result.current.ctx.currentChapter.id).toBe('22');
+    expect(result.current.ctx.currentBook.id).toBe('REV');
+  });
+
+  it('navigateToPrevious is no-op at absolute Bible start', () => {
+    const { result } = renderHook(useNavWithContext, {
+      wrapper: createWrapper(genBook, introChapter),
+    });
+
+    act(() => result.current.nav.navigateToPrevious());
+
+    expect(result.current.ctx.currentChapter.id).toBe('INTRO');
+    expect(result.current.ctx.currentBook.id).toBe('GEN');
+  });
+
+  it('book without intro: navigateToPrevious from ch1 crosses to previous book', () => {
+    const { result } = renderHook(useNavWithContext, {
+      wrapper: createWrapper(exoBook, exoChapters[0]!),
+    });
+
+    act(() => result.current.nav.navigateToPrevious());
+
+    expect(result.current.ctx.currentBook.id).toBe('GEN');
+    expect(result.current.ctx.currentChapter.id).toBe('50');
+  });
+
+  it('currentChapterIndex is -1 when book has no chapters array', () => {
+    const noChaptersBook = createMockBook({ id: 'GEN', chapters: undefined });
+    setMockBooks([noChaptersBook]);
+
+    const { result } = renderHook(useNavWithContext, {
+      wrapper: createWrapper(noChaptersBook, genChapters[0]!),
+    });
+
+    expect(result.current.nav.currentChapterIndex).toBe(-1);
+  });
+
+  it('navigate is no-op when target chapter not in chapters or intro', () => {
+    const bookNoIntro = createMockBook({
+      id: 'GEN',
+      title: 'Genesis',
+      chapters: genChapters,
+      intro: undefined,
+    });
+    const bookWithMismatch = createMockBook({
+      id: 'EXO',
+      title: 'Exodus',
+      chapters: [],
+      intro: undefined,
+    });
+    setMockBooks([bookNoIntro, bookWithMismatch]);
+
+    const { result } = renderHook(useNavWithContext, {
+      wrapper: createWrapper(bookNoIntro, genChapters[49]!),
+    });
+
+    act(() => result.current.nav.navigateToNext());
+
+    expect(result.current.ctx.currentBook.id).toBe('GEN');
+    expect(result.current.ctx.currentChapter.id).toBe('50');
   });
 });

--- a/packages/hooks/src/useChapterNavigation.test.tsx
+++ b/packages/hooks/src/useChapterNavigation.test.tsx
@@ -254,15 +254,17 @@ describe('useChapterNavigation', () => {
     expect(result.current.ctx.currentBook.id).toBe('GEN');
   });
 
-  it('book without intro: navigateToPrevious from ch1 crosses to previous book', () => {
+  it('navigateToPrevious is no-op when books array is empty', () => {
+    setMockBooks([]);
+
     const { result } = renderHook(useNavWithContext, {
-      wrapper: createWrapper(exoBook, exoChapters[0]!),
+      wrapper: createWrapper(genBook, genChapters[4]!),
     });
 
     act(() => result.current.nav.navigateToPrevious());
 
+    expect(result.current.ctx.currentChapter.id).toBe('5');
     expect(result.current.ctx.currentBook.id).toBe('GEN');
-    expect(result.current.ctx.currentChapter.id).toBe('50');
   });
 
   it('currentChapterIndex is -1 when book has no chapters array', () => {


### PR DESCRIPTION
Rewrites `useChapterNavigation.test.tsx` from 7 tests to 19, covering: boundary navigation (Bible start/end), middle-chapter bidirectional nav, cross-book transitions, intro chapter handling, loading state, empty books array, `currentChapterIndex` calculation, and no-op edge cases.

93%+ statement coverage, 100% function/line coverage.

Completes [YPE-1157](https://lifechurch.atlassian.net/browse/YPE-1157)

[YPE-1157]: https://lifechurch.atlassian.net/browse/YPE-1157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ