### PR TITLE
YPE-1594: Return footnotes by default

### DIFF
--- a/packages/hooks/src/usePassage.test.tsx
+++ b/packages/hooks/src/usePassage.test.tsx
@@ -46,7 +46,7 @@ describe('usePassage', () => {
         expect(result.current.loading).toBe(false);
       });
 
-      expect.soft(mockGetPassage).toHaveBeenCalledWith(3034, 'JHN.3.16', 'html', false, false);
+      expect.soft(mockGetPassage).toHaveBeenCalledWith(3034, 'JHN.3.16', 'html', true, true);
     });
   });
 
@@ -76,7 +76,7 @@ describe('usePassage', () => {
         expect(result.current.loading).toBe(false);
       });
 
-      expect.soft(mockGetPassage).toHaveBeenCalledWith(3034, 'JHN.3.16', 'text', false, false);
+      expect.soft(mockGetPassage).toHaveBeenCalledWith(3034, 'JHN.3.16', 'text', true, true);
     });
   });
 
@@ -92,7 +92,7 @@ describe('usePassage', () => {
         expect(result.current.loading).toBe(false);
       });
 
-      expect.soft(mockGetPassage).toHaveBeenCalledWith(3034, 'JHN.3.16', 'html', true, false);
+      expect.soft(mockGetPassage).toHaveBeenCalledWith(3034, 'JHN.3.16', 'html', true, true);
     });
 
     it('should pass include_notes=true', async () => {
@@ -106,7 +106,7 @@ describe('usePassage', () => {
         expect(result.current.loading).toBe(false);
       });
 
-      expect.soft(mockGetPassage).toHaveBeenCalledWith(3034, 'JHN.3.16', 'html', false, true);
+      expect.soft(mockGetPassage).toHaveBeenCalledWith(3034, 'JHN.3.16', 'html', true, true);
     });
 
     it('should pass all options combined', async () => {
@@ -139,8 +139,8 @@ describe('usePassage', () => {
           usePassage({ versionId: val as number, usfm: 'JHN.3.16' }),
         initial: { val: 1 },
         updated: { val: 3034 },
-        expectedInitial: [1, 'JHN.3.16', 'html', false, false],
-        expectedUpdated: [3034, 'JHN.3.16', 'html', false, false],
+        expectedInitial: [1, 'JHN.3.16', 'html', true, true],
+        expectedUpdated: [3034, 'JHN.3.16', 'html', true, true],
       },
       {
         param: 'usfm',
@@ -148,8 +148,8 @@ describe('usePassage', () => {
           usePassage({ versionId: 3034, usfm: val as string }),
         initial: { val: 'JHN.3.16' },
         updated: { val: 'GEN.1.1' },
-        expectedInitial: [3034, 'JHN.3.16', 'html', false, false],
-        expectedUpdated: [3034, 'GEN.1.1', 'html', false, false],
+        expectedInitial: [3034, 'JHN.3.16', 'html', true, true],
+        expectedUpdated: [3034, 'GEN.1.1', 'html', true, true],
       },
       {
         param: 'format',
@@ -157,8 +157,8 @@ describe('usePassage', () => {
           usePassage({ versionId: 3034, usfm: 'JHN.3.16', format: val as 'html' | 'text' }),
         initial: { val: 'html' },
         updated: { val: 'text' },
-        expectedInitial: [3034, 'JHN.3.16', 'html', false, false],
-        expectedUpdated: [3034, 'JHN.3.16', 'text', false, false],
+        expectedInitial: [3034, 'JHN.3.16', 'html', true, true],
+        expectedUpdated: [3034, 'JHN.3.16', 'text', true, true],
       },
     ])(
       'should refetch when $param changes',

--- a/packages/hooks/src/usePassage.ts
+++ b/packages/hooks/src/usePassage.ts
@@ -17,8 +17,8 @@ export function usePassage({
   versionId,
   usfm,
   format = 'html',
-  include_headings = false,
-  include_notes = false,
+  include_headings = true,
+  include_notes = true,
   options,
 }: usePassageProps): {
   passage: BiblePassage | null;


### PR DESCRIPTION
Biblica license requires all footnotes be included and accessible. usePassage previously defaulted include_notes=false, actively suppressing footnotes the API would otherwise return for chapters.

> "All footnotes to the TRANSLATIONS text must be included along with the TRANSLATIONS text and accessible to the end-user." — Biblica License Section V (Duties and Obligations)

So what this solves is when people use our BibleTextView component, then footnotes will appear, and this will please Biblica. What this does not do is make it where if someone's using our usePassage hook and gets HTML back, it does not make it where that HTML renders a proper footnote yet. Long story short, the HTML doesn't come back in a popover-friendly way. So it can't be rendered without some sort of JavaScript in a popover way. So there still remain issues on that end, that the user, if they get this HTML, will have to figure out how in the world to properly style things, which is why we point people to BibleTextView, but nevertheless, it's still an option on the usePassage. 