### PR TITLE
chore: new tests for localization

### DIFF
--- a/packages/ui/src/components/verse-of-the-day.test.tsx
+++ b/packages/ui/src/components/verse-of-the-day.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 /* eslint-disable @typescript-eslint/no-empty-function */
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import type * as PlatformHooks from '@youversion/platform-react-hooks';
 
@@ -15,7 +15,6 @@ class ResizeObserverMock {
 globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
 
 import { VerseOfTheDay } from './verse-of-the-day';
-import i18n from '@/i18n';
 import en from '@/i18n/locales/en.json';
 import {
   getDayOfYear,
@@ -67,27 +66,8 @@ describe('VerseOfTheDay i18n integration', () => {
     stubHooks();
   });
 
-  afterEach(async () => {
-    if (i18n.language !== 'en') {
-      await i18n.changeLanguage('en');
-    }
-    if (i18n.hasResourceBundle('es', 'translation')) {
-      i18n.removeResourceBundle('es', 'translation');
-    }
-    vi.resetAllMocks();
-  });
-
-  it('renders the translated English label by default', () => {
+  it('renders the translated label from the i18n instance', () => {
     render(<VerseOfTheDay />);
     expect(screen.getByText(en.verseOfTheDay)).toBeInTheDocument();
-  });
-
-  it('renders the localized label after changeLanguage', async () => {
-    const spanishLabel = 'Versículo del día';
-    i18n.addResourceBundle('es', 'translation', { verseOfTheDay: spanishLabel });
-    await i18n.changeLanguage('es');
-
-    render(<VerseOfTheDay />);
-    expect(screen.getByText(spanishLabel)).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/verse-of-the-day.test.tsx
+++ b/packages/ui/src/components/verse-of-the-day.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * @vitest-environment jsdom
+ */
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type * as PlatformHooks from '@youversion/platform-react-hooks';
+
+// ResizeObserver is used by downstream components (BibleTextView, AnimatedHeight).
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+
+import { VerseOfTheDay } from './verse-of-the-day';
+import i18n from '@/i18n';
+import en from '@/i18n/locales/en.json';
+import {
+  getDayOfYear,
+  usePassage,
+  useTheme,
+  useVerseOfTheDay,
+  useVersion,
+} from '@youversion/platform-react-hooks';
+
+vi.mock('@youversion/platform-react-hooks', async (importActual) => {
+  const actual = await importActual<typeof PlatformHooks>();
+  return {
+    ...actual,
+    getDayOfYear: vi.fn(),
+    usePassage: vi.fn(),
+    useTheme: vi.fn(),
+    useVerseOfTheDay: vi.fn(),
+    useVersion: vi.fn(),
+  };
+});
+
+function stubHooks(): void {
+  vi.mocked(getDayOfYear).mockReturnValue(1);
+  vi.mocked(useVerseOfTheDay).mockReturnValue({
+    data: { day: 1, passage_id: 'JHN.3.16' },
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  });
+  vi.mocked(usePassage).mockReturnValue({
+    passage: { id: 'JHN.3.16', reference: 'John 3:16', content: '' },
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  });
+  // useVersion returns a full BibleVersion shape; keep the cast to avoid reproducing
+  // every field the component does not read.
+  vi.mocked(useVersion).mockReturnValue({
+    version: { localized_abbreviation: 'NIV' },
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  } as unknown as ReturnType<typeof useVersion>);
+  vi.mocked(useTheme).mockReturnValue('light');
+}
+
+describe('VerseOfTheDay i18n integration', () => {
+  beforeEach(() => {
+    stubHooks();
+  });
+
+  afterEach(async () => {
+    if (i18n.language !== 'en') {
+      await i18n.changeLanguage('en');
+    }
+    if (i18n.hasResourceBundle('es', 'translation')) {
+      i18n.removeResourceBundle('es', 'translation');
+    }
+    vi.resetAllMocks();
+  });
+
+  it('renders the translated English label by default', () => {
+    render(<VerseOfTheDay />);
+    expect(screen.getByText(en.verseOfTheDay)).toBeInTheDocument();
+  });
+
+  it('renders the localized label after changeLanguage', async () => {
+    const spanishLabel = 'Versículo del día';
+    i18n.addResourceBundle('es', 'translation', { verseOfTheDay: spanishLabel });
+    await i18n.changeLanguage('es');
+
+    render(<VerseOfTheDay />);
+    expect(screen.getByText(spanishLabel)).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/i18n/index.test.ts
+++ b/packages/ui/src/i18n/index.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import i18next from 'i18next';
+import i18n, { resources } from './index';
+import en from './locales/en.json';
+
+async function ensureInitialized(): Promise<void> {
+  if (i18n.isInitialized) return;
+  await new Promise<void>((resolve) => {
+    i18n.on('initialized', () => resolve());
+  });
+}
+
+describe('i18n instance', () => {
+  beforeAll(async () => {
+    await ensureInitialized();
+  });
+
+  afterEach(async () => {
+    if (i18n.language !== 'en') {
+      await i18n.changeLanguage('en');
+    }
+    // Remove any bundles added by individual tests so module state stays en-only.
+    if (i18n.hasResourceBundle('fr', 'translation')) {
+      i18n.removeResourceBundle('fr', 'translation');
+    }
+    if (i18n.hasResourceBundle('zz', 'translation')) {
+      i18n.removeResourceBundle('zz', 'translation');
+    }
+  });
+
+  describe('initialization', () => {
+    it('is initialized after module load', () => {
+      expect(i18n.isInitialized).toBe(true);
+    });
+
+    it('uses "en" as the fallback language', () => {
+      expect(i18n.options.fallbackLng).toEqual(['en']);
+    });
+
+    it('uses "translation" as the default namespace', () => {
+      expect(i18n.options.defaultNS).toBe('translation');
+    });
+
+    it('exposes the English resource bundle via the named export', () => {
+      expect(resources.en.translation).toEqual(en);
+    });
+
+    it('registers the English bundle on the instance', () => {
+      expect(i18n.getResourceBundle('en', 'translation')).toEqual(en);
+    });
+
+    it('is an isolated instance, not the global i18next singleton', () => {
+      expect(i18n).not.toBe(i18next);
+    });
+  });
+
+  describe('translation resolution', () => {
+    it('resolves the known "verseOfTheDay" key', () => {
+      expect(i18n.t('verseOfTheDay')).toBe(en.verseOfTheDay);
+    });
+
+    it('returns the key itself when the translation is missing', () => {
+      expect(i18n.t('doesNotExist')).toBe('doesNotExist');
+    });
+  });
+
+  describe('changeLanguage', () => {
+    it('switches the active language when a bundle is registered', async () => {
+      i18n.addResourceBundle('fr', 'translation', { verseOfTheDay: 'Verset du jour' });
+      await i18n.changeLanguage('fr');
+      expect(i18n.language).toBe('fr');
+      expect(i18n.t('verseOfTheDay')).toBe('Verset du jour');
+    });
+
+    it('falls back to English for unknown languages', async () => {
+      await i18n.changeLanguage('zz');
+      expect(i18n.t('verseOfTheDay')).toBe(en.verseOfTheDay);
+    });
+  });
+});

--- a/packages/ui/src/i18n/index.test.ts
+++ b/packages/ui/src/i18n/index.test.ts
@@ -1,83 +1,17 @@
 /**
  * @vitest-environment jsdom
  */
-import { afterEach, beforeAll, describe, expect, it } from 'vitest';
-import i18next from 'i18next';
-import i18n, { resources } from './index';
+import { describe, expect, it } from 'vitest';
+import i18n from './index';
 import en from './locales/en.json';
 
-async function ensureInitialized(): Promise<void> {
-  if (i18n.isInitialized) return;
-  await new Promise<void>((resolve) => {
-    i18n.on('initialized', () => resolve());
-  });
-}
-
 describe('i18n instance', () => {
-  beforeAll(async () => {
-    await ensureInitialized();
-  });
-
-  afterEach(async () => {
-    if (i18n.language !== 'en') {
-      await i18n.changeLanguage('en');
+  it('resolves keys from the English bundle once initialized', async () => {
+    if (!i18n.isInitialized) {
+      await new Promise<void>((resolve) => {
+        i18n.on('initialized', () => resolve());
+      });
     }
-    // Remove any bundles added by individual tests so module state stays en-only.
-    if (i18n.hasResourceBundle('fr', 'translation')) {
-      i18n.removeResourceBundle('fr', 'translation');
-    }
-    if (i18n.hasResourceBundle('zz', 'translation')) {
-      i18n.removeResourceBundle('zz', 'translation');
-    }
-  });
-
-  describe('initialization', () => {
-    it('is initialized after module load', () => {
-      expect(i18n.isInitialized).toBe(true);
-    });
-
-    it('uses "en" as the fallback language', () => {
-      expect(i18n.options.fallbackLng).toEqual(['en']);
-    });
-
-    it('uses "translation" as the default namespace', () => {
-      expect(i18n.options.defaultNS).toBe('translation');
-    });
-
-    it('exposes the English resource bundle via the named export', () => {
-      expect(resources.en.translation).toEqual(en);
-    });
-
-    it('registers the English bundle on the instance', () => {
-      expect(i18n.getResourceBundle('en', 'translation')).toEqual(en);
-    });
-
-    it('is an isolated instance, not the global i18next singleton', () => {
-      expect(i18n).not.toBe(i18next);
-    });
-  });
-
-  describe('translation resolution', () => {
-    it('resolves the known "verseOfTheDay" key', () => {
-      expect(i18n.t('verseOfTheDay')).toBe(en.verseOfTheDay);
-    });
-
-    it('returns the key itself when the translation is missing', () => {
-      expect(i18n.t('doesNotExist')).toBe('doesNotExist');
-    });
-  });
-
-  describe('changeLanguage', () => {
-    it('switches the active language when a bundle is registered', async () => {
-      i18n.addResourceBundle('fr', 'translation', { verseOfTheDay: 'Verset du jour' });
-      await i18n.changeLanguage('fr');
-      expect(i18n.language).toBe('fr');
-      expect(i18n.t('verseOfTheDay')).toBe('Verset du jour');
-    });
-
-    it('falls back to English for unknown languages', async () => {
-      await i18n.changeLanguage('zz');
-      expect(i18n.t('verseOfTheDay')).toBe(en.verseOfTheDay);
-    });
+    expect(i18n.t('verseOfTheDay')).toBe(en.verseOfTheDay);
   });
 });

--- a/packages/ui/src/i18n/index.test.ts
+++ b/packages/ui/src/i18n/index.test.ts
@@ -9,7 +9,11 @@ describe('i18n instance', () => {
   it('resolves keys from the English bundle once initialized', async () => {
     if (!i18n.isInitialized) {
       await new Promise<void>((resolve) => {
-        i18n.on('initialized', () => resolve());
+        const handler = () => {
+          i18n.off('initialized', handler);
+          resolve();
+        };
+        i18n.on('initialized', handler);
       });
     }
     expect(i18n.t('verseOfTheDay')).toBe(en.verseOfTheDay);


### PR DESCRIPTION
This PR adds the tests for localization

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two new test files covering the `i18n` module and the `VerseOfTheDay` component's localization integration. Both previous review concerns (orphaned event listener, hardcoded locale cleanup) have been addressed in this iteration.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both prior concerns are resolved and no new issues are present.

All findings are P2 or lower; prior P1 concerns (orphaned listener, fragile afterEach cleanup) have been addressed. The tests are correct and serve their stated purpose.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/i18n/index.test.ts | New test verifying English bundle key resolution; handler cleanup (i18n.off) is now present, addressing the prior orphaned-listener concern. |
| packages/ui/src/components/verse-of-the-day.test.tsx | New i18n integration smoke test for VerseOfTheDay; all hooks stubbed correctly, hardcoded-locale afterEach from the prior version has been removed. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant T as Test Runner
    participant I as i18n index.test.ts
    participant V as verse-of-the-day.test.tsx
    participant i18n as i18n Instance
    participant VOTD as VerseOfTheDay Component

    T->>I: run i18n instance tests
    I->>i18n: check isInitialized
    i18n-->>I: true (synchronous resources)
    I->>i18n: t('verseOfTheDay')
    i18n-->>I: "Verse of The Day"
    I-->>T: ✓ key resolves correctly

    T->>V: run VerseOfTheDay i18n tests
    V->>V: stubHooks() (mock all platform hooks)
    V->>VOTD: render(<VerseOfTheDay />)
    VOTD->>i18n: useTranslation({ i18n }) → t('verseOfTheDay')
    i18n-->>VOTD: "Verse of The Day"
    VOTD-->>V: DOM with translated label
    V->>V: screen.getByText(en.verseOfTheDay)
    V-->>T: ✓ translated label in document
```

<sub>Reviews (3): Last reviewed commit: ["fix greptile request"](https://github.com/youversion/platform-sdk-react/commit/c9072ec460b411f0cf91c27a57b5ab70756c410c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29515238)</sub>

<!-- /greptile_comment -->