### PR TITLE
fix(core): decode JWT payload as UTF-8

### DIFF
--- a/.changeset/khaki-dots-push.md
+++ b/.changeset/khaki-dots-push.md
@@ -1,0 +1,5 @@
+---
+"@youversion/platform-core": patch
+---
+
+fix(core): decode JWT payload claims as UTF-8 to prevent mojibake in non-ASCII user names.

--- a/packages/core/src/Users.ts
+++ b/packages/core/src/Users.ts
@@ -222,8 +222,11 @@ export class YouVersionAPIUsers {
     try {
       if (base64) {
         const data = atob(base64);
+        // atob() returns a byte string (Latin-1); decode bytes as UTF-8 before JSON.parse.
+        const bytes = Uint8Array.from(data, (char) => char.charCodeAt(0));
+        const decodedPayload = new TextDecoder('utf-8').decode(bytes);
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-        return JSON.parse(data);
+        return JSON.parse(decodedPayload);
       } else {
         return {};
       }

--- a/packages/core/src/__tests__/Users.test.ts
+++ b/packages/core/src/__tests__/Users.test.ts
@@ -333,6 +333,23 @@ describe('YouVersionAPIUsers', () => {
       expect(result).toEqual(payload);
     });
 
+    it('should decode UTF-8 characters from JWT payload', () => {
+      const payload = {
+        sub: '123',
+        name: 'Marcônio Романов',
+      };
+      const base64UrlPayload = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+      const token = `header.${base64UrlPayload}.signature`;
+      const binaryPayload = Buffer.from(base64UrlPayload, 'base64url').toString('latin1');
+
+      vi.mocked(atob).mockReturnValue(binaryPayload);
+
+      // @ts-expect-error - accessing private method for testing
+      const result = YouVersionAPIUsers.decodeJWT(token);
+
+      expect(result).toEqual(payload);
+    });
+
     it('should return empty object for invalid token format', () => {
       // @ts-expect-error - accessing private method for testing
       const result = YouVersionAPIUsers.decodeJWT('invalid.token');


### PR DESCRIPTION
## Summary
- Decode JWT payload bytes as UTF-8 in `YouVersionAPIUsers.decodeJWT()` before `JSON.parse` to prevent mojibake for non-ASCII claims.
- Keep existing behavior for invalid tokens by preserving the same error-handling path and empty-object fallback.
- Add a regression test that validates accented + Cyrillic names decode correctly from base64url JWT payloads.

## Test plan
- [x] `YVP_API_HOST=api.youversion.com pnpm --filter @youversion/platform-core test -- src/__tests__/Users.test.ts`

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes mojibake for non-ASCII JWT claims by converting the Latin-1 byte string returned by `atob` into a `Uint8Array` and re-decoding it as UTF-8 via `TextDecoder` before passing to `JSON.parse`. The change is minimal, correctly scoped, and the previous `TextDecoder` conditional-fallback concern from earlier review rounds has been resolved — the implementation now relies solely on the existing `try/catch` to handle any decode failure gracefully.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no P0 or P1 findings; fix is correct, well-tested, and non-breaking.

The implementation correctly addresses the mojibake bug with a standard `atob` → `Uint8Array` → `TextDecoder` pattern. All existing tests continue to pass (ASCII payloads are valid UTF-8), a dedicated regression test covers the non-ASCII case, and error paths remain unchanged. No P1 or P0 issues were identified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/Users.ts | Adds UTF-8 decoding step after `atob` in `decodeJWT` using `Uint8Array` + `TextDecoder`; fix is correct and the try/catch handles any unavailability gracefully. |
| packages/core/src/__tests__/Users.test.ts | Adds a regression test for non-ASCII claims (accented + Cyrillic); mock correctly simulates `atob` returning a Latin-1 byte string of the UTF-8 payload. |
| .changeset/khaki-dots-push.md | Patch-level changeset entry for `@youversion/platform-core`; version bump type is appropriate for a bug fix. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[decodeJWT token] --> B{3 segments?}
    B -- No --> C[return empty object]
    B -- Yes --> D[base64url to standard base64 replace dashes and pad]
    D --> E{base64 truthy?}
    E -- No --> C
    E -- Yes --> F[atob base64 - Latin-1 byte string]
    F --> G[Uint8Array.from data via charCodeAt]
    G --> H[TextDecoder utf-8 .decode bytes]
    H --> I[JSON.parse decodedPayload]
    I --> J[return parsed object]
    I -- throws --> K[catch - return empty object]
```

<sub>Reviews (3): Last reviewed commit: ["chore: add changeset for UTF-8 JWT decod..."](https://github.com/youversion/platform-sdk-react/commit/5b50456a57e18a05d9975fba0db1e9137a88d9b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30051996)</sub>

<!-- /greptile_comment -->