### PR TITLE
feat: support custom installationId; fallback when crypto.randomUUID is missing

### DIFF
--- a/.changeset/installation-id-prop.md
+++ b/.changeset/installation-id-prop.md
@@ -1,7 +1,5 @@
 ---
-'@youversion/platform-core': minor
-'@youversion/platform-react-hooks': minor
-'@youversion/platform-react-ui': minor
+'@youversion/platform-core': patch
 ---
 
-Add optional `installationId` prop to `YouVersionProvider` and tolerate runtimes without `crypto.randomUUID` (such as Expo DOM components). When the consumer passes an `installationId` (via `<YouVersionProvider installationId="..." />`, `YouVersionPlatformConfiguration.installationId = ...`, or `new ApiClient({ installationId, ... })`), it is used directly. Otherwise the SDK uses `crypto.randomUUID()` when available, falling back to a non-secure timestamp+random id when it is not.
+Tolerate runtimes without `crypto.randomUUID` by falling back to a non-secure timestamp+random installation id.

--- a/.changeset/installation-id-prop.md
+++ b/.changeset/installation-id-prop.md
@@ -1,0 +1,7 @@
+---
+'@youversion/platform-core': minor
+'@youversion/platform-react-hooks': minor
+'@youversion/platform-react-ui': minor
+---
+
+Add optional `installationId` prop to `YouVersionProvider` and tolerate runtimes without `crypto.randomUUID` (such as Expo DOM components). When the consumer passes an `installationId` (via `<YouVersionProvider installationId="..." />`, `YouVersionPlatformConfiguration.installationId = ...`, or `new ApiClient({ installationId, ... })`), it is used directly. Otherwise the SDK uses `crypto.randomUUID()` when available, falling back to a non-secure timestamp+random id when it is not.

--- a/packages/core/src/YouVersionPlatformConfiguration.ts
+++ b/packages/core/src/YouVersionPlatformConfiguration.ts
@@ -25,7 +25,7 @@ export class YouVersionPlatformConfiguration {
     const newId =
       typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
         ? crypto.randomUUID()
-        : `yvp-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+        : `yvp-${new Date().toISOString()}-${Math.random().toString(36).slice(2, 10)}`;
     localStorage.setItem('x-yvp-installation-id', newId);
     return newId;
   }

--- a/packages/core/src/YouVersionPlatformConfiguration.ts
+++ b/packages/core/src/YouVersionPlatformConfiguration.ts
@@ -22,7 +22,10 @@ export class YouVersionPlatformConfiguration {
       return existingId;
     }
 
-    const newId = crypto.randomUUID();
+    const newId =
+      typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+        ? crypto.randomUUID()
+        : `yvp-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
     localStorage.setItem('x-yvp-installation-id', newId);
     return newId;
   }

--- a/packages/hooks/src/context/YouVersionProvider.test.tsx
+++ b/packages/hooks/src/context/YouVersionProvider.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { useContext } from 'react';
+import { YouVersionPlatformConfiguration } from '@youversion/platform-core';
+import { YouVersionProvider } from './YouVersionProvider';
+import { YouVersionContext } from './YouVersionContext';
+
+function ContextReader() {
+  const ctx = useContext(YouVersionContext);
+  return <div data-testid="installation-id">{ctx?.installationId ?? 'none'}</div>;
+}
+
+describe('YouVersionProvider', () => {
+  beforeEach(() => {
+    YouVersionPlatformConfiguration.installationId = null;
+  });
+
+  it('uses an explicit installationId prop when provided', async () => {
+    render(
+      <YouVersionProvider appKey="test" installationId="custom-id">
+        <ContextReader />
+      </YouVersionProvider>,
+    );
+
+    await waitFor(() => {
+      expect(YouVersionPlatformConfiguration.installationId).toBe('custom-id');
+    });
+    expect(screen.getByTestId('installation-id').textContent).toBe('custom-id');
+  });
+
+  it('falls back to a generated id when no prop is provided', () => {
+    render(
+      <YouVersionProvider appKey="test">
+        <ContextReader />
+      </YouVersionProvider>,
+    );
+
+    const id = screen.getByTestId('installation-id').textContent;
+    expect(id).toBeTruthy();
+    expect(id).not.toBe('none');
+  });
+});

--- a/packages/hooks/src/context/YouVersionProvider.test.tsx
+++ b/packages/hooks/src/context/YouVersionProvider.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { useContext } from 'react';
 import { YouVersionPlatformConfiguration } from '@youversion/platform-core';
 import { YouVersionProvider } from './YouVersionProvider';
@@ -13,19 +13,6 @@ function ContextReader() {
 describe('YouVersionProvider', () => {
   beforeEach(() => {
     YouVersionPlatformConfiguration.installationId = null;
-  });
-
-  it('uses an explicit installationId prop when provided', async () => {
-    render(
-      <YouVersionProvider appKey="test" installationId="custom-id">
-        <ContextReader />
-      </YouVersionProvider>,
-    );
-
-    await waitFor(() => {
-      expect(YouVersionPlatformConfiguration.installationId).toBe('custom-id');
-    });
-    expect(screen.getByTestId('installation-id').textContent).toBe('custom-id');
   });
 
   it('falls back to a generated id when no prop is provided', () => {

--- a/packages/hooks/src/context/YouVersionProvider.test.tsx
+++ b/packages/hooks/src/context/YouVersionProvider.test.tsx
@@ -15,7 +15,7 @@ describe('YouVersionProvider', () => {
     YouVersionPlatformConfiguration.installationId = null;
   });
 
-  it('falls back to a generated id when no prop is provided', () => {
+  it('provides a non-null installationId via context', () => {
     render(
       <YouVersionProvider appKey="test">
         <ContextReader />

--- a/packages/hooks/src/context/YouVersionProvider.tsx
+++ b/packages/hooks/src/context/YouVersionProvider.tsx
@@ -9,7 +9,6 @@ interface YouVersionProviderPropsBase {
   children: ReactNode;
   appKey: string;
   apiHost?: string;
-  installationId?: string;
   theme?: 'light' | 'dark' | 'system';
 }
 
@@ -56,14 +55,7 @@ function useResolvedTheme(theme: 'light' | 'dark' | 'system'): 'light' | 'dark' 
 export function YouVersionProvider(
   props: PropsWithChildren<YouVersionProviderPropsWithAuth | YouVersionProviderPropsWithoutAuth>,
 ): React.ReactElement {
-  const {
-    appKey,
-    apiHost = 'api.youversion.com',
-    installationId,
-    includeAuth,
-    theme = 'light',
-    children,
-  } = props;
+  const { appKey, apiHost = 'api.youversion.com', includeAuth, theme = 'light', children } = props;
   const resolvedTheme = useResolvedTheme(theme);
 
   // Sync props to YouVersionPlatformConfiguration so any code that reads the
@@ -73,15 +65,12 @@ export function YouVersionProvider(
   useEffect(() => {
     YouVersionPlatformConfiguration.appKey = appKey;
     YouVersionPlatformConfiguration.apiHost = apiHost;
-    if (installationId) {
-      YouVersionPlatformConfiguration.installationId = installationId;
-    }
-  }, [appKey, apiHost, installationId]);
+  }, [appKey, apiHost]);
 
   const contextValue = {
     appKey,
     apiHost,
-    installationId: installationId ?? YouVersionPlatformConfiguration.installationId,
+    installationId: YouVersionPlatformConfiguration.installationId,
     theme: resolvedTheme,
     authEnabled: !!includeAuth,
   };

--- a/packages/hooks/src/context/YouVersionProvider.tsx
+++ b/packages/hooks/src/context/YouVersionProvider.tsx
@@ -9,6 +9,7 @@ interface YouVersionProviderPropsBase {
   children: ReactNode;
   appKey: string;
   apiHost?: string;
+  installationId?: string;
   theme?: 'light' | 'dark' | 'system';
 }
 
@@ -55,34 +56,41 @@ function useResolvedTheme(theme: 'light' | 'dark' | 'system'): 'light' | 'dark' 
 export function YouVersionProvider(
   props: PropsWithChildren<YouVersionProviderPropsWithAuth | YouVersionProviderPropsWithoutAuth>,
 ): React.ReactElement {
-  const { appKey, apiHost = 'api.youversion.com', includeAuth, theme = 'light', children } = props;
+  const {
+    appKey,
+    apiHost = 'api.youversion.com',
+    installationId,
+    includeAuth,
+    theme = 'light',
+    children,
+  } = props;
   const resolvedTheme = useResolvedTheme(theme);
 
-  // Syncing appKey and apiHost to YouVersionPlatformConfiguration
-  // so that this can be in sync with any other code that uses
-  // the YouVersionPlatformConfiguration, of which a lot of our
-  // core package uses this configuration.
+  // Sync props to YouVersionPlatformConfiguration so any code that reads the
+  // static config (e.g. core's auth/PKCE flows, called from user actions) sees
+  // the same values. Children that read via context get the prop directly
+  // below, so they don't depend on this effect having run yet.
   useEffect(() => {
     YouVersionPlatformConfiguration.appKey = appKey;
     YouVersionPlatformConfiguration.apiHost = apiHost;
-  }, [appKey, apiHost]);
+    if (installationId) {
+      YouVersionPlatformConfiguration.installationId = installationId;
+    }
+  }, [appKey, apiHost, installationId]);
+
+  const contextValue = {
+    appKey,
+    apiHost,
+    installationId: installationId ?? YouVersionPlatformConfiguration.installationId,
+    theme: resolvedTheme,
+    authEnabled: !!includeAuth,
+  };
 
   if (includeAuth) {
-    const { authRedirectUrl } = props;
-
-    // Installation ID gets set automatically by YouVersionPlatformConfiguration
     return (
-      <YouVersionContext.Provider
-        value={{
-          appKey,
-          apiHost,
-          installationId: YouVersionPlatformConfiguration.installationId,
-          theme: resolvedTheme,
-          authEnabled: !!includeAuth,
-        }}
-      >
+      <YouVersionContext.Provider value={contextValue}>
         <Suspense>
-          <AuthProvider config={{ appKey, apiHost, redirectUri: authRedirectUrl }}>
+          <AuthProvider config={{ appKey, apiHost, redirectUri: props.authRedirectUrl }}>
             {children}
           </AuthProvider>
         </Suspense>
@@ -90,18 +98,5 @@ export function YouVersionProvider(
     );
   }
 
-  // Installation ID gets set automatically by YouVersionPlatformConfiguration
-  return (
-    <YouVersionContext.Provider
-      value={{
-        appKey,
-        apiHost,
-        installationId: YouVersionPlatformConfiguration.installationId,
-        theme: resolvedTheme,
-        authEnabled: !!includeAuth,
-      }}
-    >
-      {children}
-    </YouVersionContext.Provider>
-  );
+  return <YouVersionContext.Provider value={contextValue}>{children}</YouVersionContext.Provider>;
 }


### PR DESCRIPTION
## Summary

Fixes crashes in runtimes without `crypto.randomUUID` (e.g. Expo DOM components) by falling back to a non-secure installation id.

## Changes

- **core**: `YouVersionPlatformConfiguration` now uses `crypto.randomUUID()` when available, otherwise falls back to `yvp-<utc-iso-timestamp>-<random>`.
- **hooks**: **no public API change**. The previously proposed `installationId` prop on `YouVersionProvider` was intentionally dropped.
- **changeset**: core-only `patch` for the runtime fallback.

## Why no `installationId` prop

Consumers can already override the install identifier deliberately via:

- `YouVersionPlatformConfiguration.installationId = '...'`
- `new ApiClient({ installationId: '...' })`

Making it a prominent `YouVersionProvider` prop is an easy footgun (passing `userId`, a constant, or a fresh random per render breaks per-install metrics/observability).

## Verification

- `pnpm --filter @youversion/platform-core test`
- `pnpm --filter @youversion/platform-react-hooks test`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a crash in runtimes that lack `crypto.randomUUID` (e.g. Expo DOM components) by falling back to a `yvp-<iso-timestamp>-<random>` installation ID, and tidies `YouVersionProvider` by extracting the duplicated `contextValue` object into a single declaration.

<h3>Confidence Score: 5/5</h3>

Safe to merge; only P2 findings remain after previous review threads addressed the substantive concerns

No P0 or P1 findings. The one new finding (missing test coverage for the fallback path) is P2. All higher-severity issues were flagged in prior review rounds.

packages/core/src/YouVersionPlatformConfiguration.ts — fallback branch needs a dedicated test

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/YouVersionPlatformConfiguration.ts | Adds crypto.randomUUID availability check with a timestamp+random fallback; fallback path is never exercised by the existing test suite |
| packages/hooks/src/context/YouVersionProvider.tsx | Refactors duplicate contextValue creation into a single object; no functional changes to auth or non-auth paths |
| packages/hooks/src/context/YouVersionProvider.test.tsx | New test file verifying installationId is provided via context; beforeEach reset behaviour is subtly incorrect (setter generates an ID rather than clearing to null) |
| .changeset/installation-id-prop.md | Changeset only bumps platform-core; platform-hooks also received changes but is absent, risking version parity violation |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getOrSetInstallationId] --> B{window defined?}
    B -- No --> C[return empty string]
    B -- Yes --> D{localStorage has x-yvp-installation-id?}
    D -- Yes --> E[return existing ID]
    D -- No --> F{crypto defined AND crypto.randomUUID is a function?}
    F -- Yes --> G[crypto.randomUUID]
    F -- No --> H[yvp-ISO timestamp-Math.random base36]
    G --> I[localStorage.setItem]
    H --> I
    I --> J[return newId]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fcore%2Fsrc%2FYouVersionPlatformConfiguration.ts%3A25-28%0A**Fallback%20path%20has%20no%20test%20coverage**%0A%0AThe%20new%20fallback%20branch%20%28%60yvp-%24%7Bnew%20Date%28%29.toISOString%28%29%7D-...%60%29%20is%20never%20exercised%20by%20the%20test%20suite.%20%60YouVersionPlatformConfiguration.test.ts%60%20stubs%20%60crypto%60%20with%20a%20working%20%60randomUUID%60%20mock%20at%20the%20top%20of%20the%20file%2C%20so%20%60typeof%20crypto.randomUUID%20%3D%3D%3D%20'function'%60%20is%20always%20%60true%60%20in%20tests%20and%20the%20ternary's%20false%20branch%20is%20dead%20code%20from%20the%20test%20runner's%20perspective.%20Consider%20adding%20a%20test%20that%20removes%2Fstubs%20out%20%60crypto.randomUUID%60%20and%20asserts%20the%20fallback%20ID%20is%20generated%20and%20stored%20correctly.%0A%0A&repo=youversion%2Fplatform-sdk-react&pr=220&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fcore%2Fsrc%2FYouVersionPlatformConfiguration.ts%3A25-28%0A**Fallback%20path%20has%20no%20test%20coverage**%0A%0AThe%20new%20fallback%20branch%20%28%60yvp-%24%7Bnew%20Date%28%29.toISOString%28%29%7D-...%60%29%20is%20never%20exercised%20by%20the%20test%20suite.%20%60YouVersionPlatformConfiguration.test.ts%60%20stubs%20%60crypto%60%20with%20a%20working%20%60randomUUID%60%20mock%20at%20the%20top%20of%20the%20file%2C%20so%20%60typeof%20crypto.randomUUID%20%3D%3D%3D%20'function'%60%20is%20always%20%60true%60%20in%20tests%20and%20the%20ternary's%20false%20branch%20is%20dead%20code%20from%20the%20test%20runner's%20perspective.%20Consider%20adding%20a%20test%20that%20removes%2Fstubs%20out%20%60crypto.randomUUID%60%20and%20asserts%20the%20fallback%20ID%20is%20generated%20and%20stored%20correctly.%0A%0A&pr=220&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/core/src/YouVersionPlatformConfiguration.ts:25-28
**Fallback path has no test coverage**

The new fallback branch (`yvp-${new Date().toISOString()}-...`) is never exercised by the test suite. `YouVersionPlatformConfiguration.test.ts` stubs `crypto` with a working `randomUUID` mock at the top of the file, so `typeof crypto.randomUUID === 'function'` is always `true` in tests and the ternary's false branch is dead code from the test runner's perspective. Consider adding a test that removes/stubs out `crypto.randomUUID` and asserts the fallback ID is generated and stored correctly.

`````

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(core): use UTC timestamp in installa..."](https://github.com/youversion/platform-sdk-react/commit/e5efed90a1058ba74400d39989828e980b874c94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30478473)</sub>

<!-- /greptile_comment -->