### PR TITLE
WIP: YPE-2197: Extract standalone popover content components for native sheet rendering

### DIFF
--- a/packages/ui/src/components/bible-chapter-picker.stories.tsx
+++ b/packages/ui/src/components/bible-chapter-picker.stories.tsx
@@ -23,6 +23,7 @@ const meta = {
             versionId={args.versionId}
           >
             <BibleChapterPicker.Trigger />
+            <BibleChapterPicker.Content />
           </BibleChapterPicker.Root>
         </div>
       );

--- a/packages/ui/src/components/bible-chapter-picker.tsx
+++ b/packages/ui/src/components/bible-chapter-picker.tsx
@@ -5,6 +5,7 @@ import {
   useEffect,
   useMemo,
   useRef,
+  type ReactElement,
   type ReactNode,
 } from 'react';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
@@ -13,9 +14,151 @@ import { type BibleBook } from '@youversion/platform-core';
 import { InfoIcon } from './icons/info';
 import { SearchIcon } from './icons/search';
 import { Button } from './ui/button';
-import { Popover, PopoverTrigger, PopoverContent, PopoverClose } from './ui/popover';
+import { Popover, PopoverTrigger, PopoverContent } from './ui/popover';
 import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from './ui/accordion';
 import { InputGroup, InputGroupInput, InputGroupAddon } from './ui/input-group';
+
+export type BibleChapterPickerContentProps = {
+  versionId: number;
+  defaultBook?: string;
+  onSelectChapter: (bookId: string, chapterId: string) => void;
+  background?: 'light' | 'dark';
+};
+
+export function BibleChapterPickerContent({
+  versionId,
+  defaultBook,
+  onSelectChapter,
+}: BibleChapterPickerContentProps): ReactElement {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [expandedBook, setExpandedBook] = useState<string | null>(defaultBook || null);
+  const bookElementsRef = useRef<Record<string, HTMLDivElement | null>>({});
+
+  const { books } = useBooks(versionId);
+
+  const filteredBooks = useMemo(() => {
+    if (!books?.data) return null;
+    if (searchQuery.trim() === '') return books.data;
+    return books.data.filter((book) =>
+      book.title?.toLowerCase().includes(searchQuery.toLowerCase()),
+    );
+  }, [books?.data, searchQuery]);
+
+  useEffect(() => {
+    if (!expandedBook) return;
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      if (!controller.signal.aborted) {
+        bookElementsRef.current[expandedBook]?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'start',
+        });
+      }
+    }, 200);
+
+    return () => {
+      controller.abort();
+      clearTimeout(timeoutId);
+    };
+  }, [expandedBook]);
+
+  const handleChapterClick = (bookId: string, passageId: string) => {
+    const chapterId = passageId.split('.').pop() || '';
+    if (chapterId && bookId) {
+      onSelectChapter(bookId, chapterId);
+      setSearchQuery('');
+    }
+  };
+
+  return (
+    <>
+      <Accordion
+        className="yv:relative yv:overflow-y-auto yv:bg-background yv:px-6"
+        type="single"
+        collapsible
+        defaultValue={defaultBook || 'GEN'}
+        onValueChange={setExpandedBook}
+      >
+        {filteredBooks && filteredBooks.length > 0 ? (
+          filteredBooks.map((bookItem) => (
+            <AccordionItem
+              className="yv:border-b yv:border-border"
+              key={bookItem.id}
+              value={bookItem.id}
+              id={bookItem.id}
+              ref={(node) => {
+                if (node) {
+                  bookElementsRef.current[bookItem.id] = node;
+                } else {
+                  delete bookElementsRef.current[bookItem.id];
+                }
+              }}
+            >
+              <AccordionTrigger className="yv:rounded-none">{bookItem.title}</AccordionTrigger>
+              <AccordionContent>
+                {bookItem.chapters && bookItem.chapters.length > 0 ? (
+                  <div className="yv:grid yv:grid-cols-5 yv:gap-2">
+                    {bookItem.intro?.id && bookItem.intro?.passage_id ? (
+                      <Button
+                        key={`${bookItem.id}-${bookItem.intro.passage_id}`}
+                        variant="secondary"
+                        size="icon"
+                        className="yv:aspect-square yv:w-full yv:h-full yv:flex yv:items-center yv:justify-center yv:rounded-[4px]"
+                        onClick={() =>
+                          handleChapterClick(bookItem.id, bookItem.intro?.passage_id || '')
+                        }
+                      >
+                        <InfoIcon />
+                      </Button>
+                    ) : null}
+                    {bookItem.chapters.map((chapterRef) => {
+                      const chapterId = chapterRef.passage_id.split('.').pop() || '';
+                      return (
+                        <Button
+                          key={`${bookItem.id}-${chapterRef.passage_id}`}
+                          variant="secondary"
+                          size="icon"
+                          className="yv:aspect-square yv:w-full yv:h-full yv:flex yv:items-center yv:justify-center yv:rounded-[4px]"
+                          onClick={() => handleChapterClick(bookItem.id, chapterRef.passage_id)}
+                        >
+                          {chapterId}
+                        </Button>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <div className="yv:w-full yv:flex yv:items-center yv:justify-center yv:py-4 yv:text-muted-foreground yv:text-sm">
+                    No chapters available
+                  </div>
+                )}
+              </AccordionContent>
+            </AccordionItem>
+          ))
+        ) : (
+          <div className="yv:w-full yv:h-full yv:flex yv:items-center yv:justify-center yv:py-4 yv:text-center yv:text-balance yv:text-muted-foreground yv:text-sm">
+            We're sorry, there are no Bible results for this search.
+          </div>
+        )}
+      </Accordion>
+
+      <section className="yv:bg-muted yv:border-s yv:border-muted yv:p-4 yv:w-full">
+        <InputGroup className="yv:rounded-3xl yv:bg-background yv:shadow-none yv:border-border">
+          <InputGroupInput
+            tabIndex={1}
+            type="text"
+            placeholder="Search"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+          />
+          <InputGroupAddon align="inline-start">
+            <SearchIcon className="yv:size-5 yv:text-muted-foreground" />
+          </InputGroupAddon>
+        </InputGroup>
+      </section>
+    </>
+  );
+}
 
 type BibleChapterPickerContextType = {
   book: string;
@@ -24,7 +167,10 @@ type BibleChapterPickerContextType = {
   setChapter: (chapter: string) => void;
   versionId: number;
   background: 'light' | 'dark';
-  scrollToCurrentBook: () => void;
+  defaultBook: string;
+  onContentClick?: (props: BibleChapterPickerContentProps) => void;
+  isPopoverOpen: boolean;
+  setIsPopoverOpen: (open: boolean) => void;
 };
 
 const BibleChapterPickerContext = createContext<BibleChapterPickerContextType | null>(null);
@@ -46,6 +192,7 @@ export type RootProps = {
   onChapterChange?: (chapter: string) => void;
   versionId: number;
   background?: 'light' | 'dark';
+  onContentClick?: (props: BibleChapterPickerContentProps) => void;
   children?: ReactNode;
 };
 
@@ -60,6 +207,7 @@ function Root({
   onChapterChange,
   versionId,
   background,
+  onContentClick,
   children,
 }: RootProps) {
   const [book, setBook] = useControllableState({
@@ -77,170 +225,33 @@ function Root({
   const providerTheme = useTheme();
   const theme = background || providerTheme;
 
-  const [searchQuery, setSearchQuery] = useState('');
-  const [expandedBook, setExpandedBook] = useState<string | null>(book || null);
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
-  const { books } = useBooks(versionId);
+  const contextValue: BibleChapterPickerContextType = {
+    book,
+    chapter,
+    setBook,
+    setChapter,
+    versionId,
+    background: theme,
+    defaultBook,
+    onContentClick,
+    isPopoverOpen,
+    setIsPopoverOpen,
+  };
 
-  const filteredBooks = useMemo(() => {
-    if (!books?.data) return null;
-    if (searchQuery.trim() === '') return books.data;
-    return books.data.filter((book) =>
-      book.title?.toLowerCase().includes(searchQuery.toLowerCase()),
+  if (onContentClick) {
+    return (
+      <BibleChapterPickerContext.Provider value={contextValue}>
+        {children}
+      </BibleChapterPickerContext.Provider>
     );
-  }, [books?.data, searchQuery]);
-
-  const bookElementsRef = useRef<Record<string, HTMLDivElement | null>>({});
-
-  const scrollToCurrentBook = () => {
-    if (book) {
-      setExpandedBook(book);
-      setTimeout(() => {
-        bookElementsRef.current[book]?.scrollIntoView({
-          behavior: 'smooth',
-          block: 'start',
-        });
-      }, 200);
-    }
-  };
-
-  // When an accordion is expanded, scroll that book into view
-  useEffect(() => {
-    if (!expandedBook) return;
-
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => {
-      if (!controller.signal.aborted) {
-        bookElementsRef.current[expandedBook]?.scrollIntoView({
-          behavior: 'smooth',
-          block: 'start',
-        });
-      }
-    }, 200);
-
-    return () => {
-      controller.abort();
-      clearTimeout(timeoutId);
-    };
-  }, [expandedBook]);
-
-  const handleChapterButtonClick = (bookId: string, passageId: string) => {
-    const chapterId = passageId.split('.').pop() || '';
-    if (chapterId && bookId) {
-      setBook(bookId);
-      setChapter(chapterId);
-      setSearchQuery('');
-    }
-  };
+  }
 
   return (
-    <Popover>
-      <BibleChapterPickerContext.Provider
-        value={{
-          book,
-          chapter,
-          setBook,
-          setChapter,
-          versionId,
-          background: theme,
-          scrollToCurrentBook,
-        }}
-      >
+    <Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
+      <BibleChapterPickerContext.Provider value={contextValue}>
         {children}
-
-        {/* data-yv-sdk for styles is needed because the popover gets rendered outside of the providers scope **/}
-        <PopoverContent sideOffset={16} heading="Books" theme={theme} side="top">
-          <Accordion
-            className="yv:relative yv:overflow-y-auto yv:bg-background yv:px-6"
-            type="single"
-            collapsible
-            defaultValue={defaultBook || book || 'GEN'}
-            onValueChange={setExpandedBook}
-          >
-            {filteredBooks && filteredBooks.length > 0 ? (
-              filteredBooks.map((bookItem) => (
-                <AccordionItem
-                  className="yv:border-b yv:border-border"
-                  key={bookItem.id}
-                  value={bookItem.id}
-                  id={bookItem.id}
-                  ref={(node) => {
-                    if (node) {
-                      bookElementsRef.current[bookItem.id] = node;
-                    } else {
-                      delete bookElementsRef.current[bookItem.id];
-                    }
-                  }}
-                >
-                  <AccordionTrigger className="yv:rounded-none">{bookItem.title}</AccordionTrigger>
-                  <AccordionContent>
-                    {bookItem.chapters && bookItem.chapters.length > 0 ? (
-                      <div className="yv:grid yv:grid-cols-5 yv:gap-2">
-                        {bookItem.intro?.id && bookItem.intro?.passage_id ? (
-                          <PopoverClose asChild key={`${bookItem.id}-${bookItem.intro.passage_id}`}>
-                            <Button
-                              variant="secondary"
-                              size="icon"
-                              className="yv:aspect-square yv:w-full yv:h-full yv:flex yv:items-center yv:justify-center yv:rounded-[4px]"
-                              onClick={() =>
-                                handleChapterButtonClick(
-                                  bookItem.id,
-                                  bookItem.intro?.passage_id || '',
-                                )
-                              }
-                            >
-                              <InfoIcon />
-                            </Button>
-                          </PopoverClose>
-                        ) : null}
-                        {bookItem.chapters.map((chapterRef) => {
-                          const chapterId = chapterRef.passage_id.split('.').pop() || '';
-                          return (
-                            <PopoverClose asChild key={`${bookItem.id}-${chapterRef.passage_id}`}>
-                              <Button
-                                variant="secondary"
-                                size="icon"
-                                className="yv:aspect-square yv:w-full yv:h-full yv:flex yv:items-center yv:justify-center yv:rounded-[4px]"
-                                onClick={() =>
-                                  handleChapterButtonClick(bookItem.id, chapterRef.passage_id)
-                                }
-                              >
-                                {chapterId}
-                              </Button>
-                            </PopoverClose>
-                          );
-                        })}
-                      </div>
-                    ) : (
-                      <div className="yv:w-full yv:flex yv:items-center yv:justify-center yv:py-4 yv:text-muted-foreground yv:text-sm">
-                        No chapters available
-                      </div>
-                    )}
-                  </AccordionContent>
-                </AccordionItem>
-              ))
-            ) : (
-              <div className="yv:w-full yv:h-full yv:flex yv:items-center yv:justify-center yv:py-4 yv:text-center yv:text-balance yv:text-muted-foreground yv:text-sm">
-                We're sorry, there are no Bible results for this search.
-              </div>
-            )}
-          </Accordion>
-
-          <section className="yv:bg-muted yv:border-s yv:border-muted yv:p-4 yv:w-full">
-            <InputGroup className="yv:rounded-3xl yv:bg-background yv:shadow-none yv:border-border">
-              <InputGroupInput
-                tabIndex={1}
-                type="text"
-                placeholder="Search"
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-              />
-              <InputGroupAddon align="inline-start">
-                <SearchIcon className="yv:size-5 yv:text-muted-foreground" />
-              </InputGroupAddon>
-            </InputGroup>
-          </section>
-        </PopoverContent>
       </BibleChapterPickerContext.Provider>
     </Popover>
   );
@@ -261,7 +272,7 @@ export type TriggerProps = Omit<React.ComponentProps<typeof PopoverTrigger>, 'ch
 };
 
 function Trigger({ asChild = true, children, ...props }: TriggerProps) {
-  const { book, chapter, background, versionId, scrollToCurrentBook } =
+  const { book, chapter, background, versionId, defaultBook, setBook, setChapter, onContentClick } =
     useBibleChapterPickerContext();
   const { books, loading } = useBooks(versionId);
   const providerTheme = useTheme();
@@ -282,17 +293,63 @@ function Trigger({ asChild = true, children, ...props }: TriggerProps) {
       ? children({ book, chapter, chapterLabel, currentBook, loading })
       : children || <Button variant="secondary">{buttonText}</Button>;
 
+  if (onContentClick) {
+    const contentProps: BibleChapterPickerContentProps = {
+      versionId,
+      defaultBook: defaultBook || book || undefined,
+      onSelectChapter: (bookId, chapterId) => {
+        setBook(bookId);
+        setChapter(chapterId);
+      },
+      background: theme,
+    };
+    return (
+      <div
+        data-yv-sdk
+        data-yv-theme={theme}
+        onClick={() => onContentClick(contentProps)}
+        className="yv:inline-flex yv:cursor-pointer"
+      >
+        {content}
+      </div>
+    );
+  }
+
   return (
-    <PopoverTrigger
-      data-yv-sdk
-      data-yv-theme={theme}
-      asChild={asChild}
-      onClick={scrollToCurrentBook}
-      {...props}
-    >
+    <PopoverTrigger data-yv-sdk data-yv-theme={theme} asChild={asChild} {...props}>
       {content}
     </PopoverTrigger>
   );
 }
 
-export const BibleChapterPicker = Object.assign({}, { Root, Trigger });
+function Content() {
+  const {
+    book,
+    setBook,
+    setChapter,
+    versionId,
+    background,
+    defaultBook,
+    onContentClick,
+    setIsPopoverOpen,
+  } = useBibleChapterPickerContext();
+
+  if (onContentClick) return null;
+
+  return (
+    <PopoverContent sideOffset={16} heading="Books" theme={background} side="top">
+      <BibleChapterPickerContent
+        versionId={versionId}
+        defaultBook={defaultBook || book || undefined}
+        onSelectChapter={(bookId, chapterId) => {
+          setBook(bookId);
+          setChapter(chapterId);
+          setIsPopoverOpen(false);
+        }}
+        background={background}
+      />
+    </PopoverContent>
+  );
+}
+
+export const BibleChapterPicker = Object.assign({}, { Root, Trigger, Content });

--- a/packages/ui/src/components/bible-reader.tsx
+++ b/packages/ui/src/components/bible-reader.tsx
@@ -33,6 +33,111 @@ import { INTER_FONT, SOURCE_SERIF_FONT, type FontFamily } from '@/lib/verse-html
 import { ChevronLeftIcon } from './icons/chevron-left';
 import { ChevronRightIcon } from './icons/chevron-right';
 
+const MIN_FONT_SIZE = 12;
+const MAX_FONT_SIZE = 20;
+const DEFAULT_FONT_SIZE = 16;
+
+export type BibleReaderSettingsContentProps = {
+  currentFontSize: number;
+  onFontSizeChange: React.Dispatch<React.SetStateAction<number>>;
+  currentFontFamily: FontFamily;
+  onFontFamilyChange: React.Dispatch<React.SetStateAction<FontFamily>>;
+  background?: 'light' | 'dark';
+};
+
+export function BibleReaderSettingsContent({
+  currentFontSize: _currentFontSize,
+  onFontSizeChange,
+  currentFontFamily,
+  onFontFamilyChange,
+}: BibleReaderSettingsContentProps): React.ReactElement {
+  return (
+    <div className="yv:flex yv:flex-col yv:gap-4 yv:p-4">
+      <div className="yv:grid yv:grid-cols-2">
+        <Button
+          className="yv:text-xs yv:text-black yv:dark:text-muted-foreground yv:rounded-l-[8px] yv:rounded-r-none yv:border yv:border-white yv:dark:border-border yv:h-auto yv:py-2"
+          onClick={() =>
+            onFontSizeChange((prev) => {
+              if (prev > MIN_FONT_SIZE) return prev - 2;
+              return prev;
+            })
+          }
+          size="lg"
+          variant="secondary"
+          data-testid="decrease-font-size"
+        >
+          A
+        </Button>
+        <Button
+          className="yv:text-3xl yv:text-black yv:dark:text-muted-foreground yv:rounded-r-[8px] yv:rounded-l-none yv:border yv:border-white yv:dark:border-border yv:h-auto yv:py-2"
+          onClick={() =>
+            onFontSizeChange((prev) => {
+              if (prev < MAX_FONT_SIZE) return prev + 2;
+              return prev;
+            })
+          }
+          size="lg"
+          variant="secondary"
+          data-testid="increase-font-size"
+        >
+          A
+        </Button>
+      </div>
+
+      <div className="yv:grid yv:grid-cols-2">
+        <Button
+          className={cn(
+            'yv:group yv:dark:bg-muted yv:rounded-r-none yv:border-r-0.5 yv:dark:border-border yv:rounded-l-[8px] yv:h-auto',
+            currentFontFamily === INTER_FONT
+              ? 'yv:bg-primary yv:border-primary yv:dark:bg-inherit yv:text-primary-foreground yv:hover:text-primary-foreground yv:hover:bg-primary/80'
+              : '',
+          )}
+          onClick={() => onFontFamilyChange(INTER_FONT)}
+          variant="outline"
+        >
+          <div className="yv:flex yv:flex-col yv:w-full yv:items-start">
+            <span
+              className={cn(
+                'yv:text-xs yv:text-muted-foreground',
+                currentFontFamily === INTER_FONT
+                  ? 'yv:text-muted yv:dark:text-muted-foreground yv:group-hover:text-muted'
+                  : '',
+              )}
+            >
+              Font
+            </span>
+            <span className="yv:sm:text-xl yv:text-base">Inter</span>
+          </div>
+        </Button>
+        <Button
+          className={cn(
+            'yv:group yv:dark:bg-muted yv:border-l-0.5 yv:rounded-l-none yv:rounded-r-[8px] yv:h-auto',
+            currentFontFamily === SOURCE_SERIF_FONT
+              ? 'yv:bg-primary yv:border-primary yv:dark:bg-inherit yv:text-primary-foreground yv:hover:text-primary-foreground yv:hover:bg-primary/80'
+              : '',
+          )}
+          onClick={() => onFontFamilyChange(SOURCE_SERIF_FONT)}
+          variant="outline"
+        >
+          <div className="yv:flex yv:flex-col yv:w-full yv:items-start">
+            <span
+              className={cn(
+                'yv:text-xs yv:text-muted-foreground',
+                currentFontFamily === SOURCE_SERIF_FONT
+                  ? 'yv:text-muted yv:dark:text-muted-foreground yv:group-hover:text-muted'
+                  : '',
+              )}
+            >
+              Font
+            </span>
+            <span className="yv:sm:text-xl yv:text-base yv:font-serif">Source Serif</span>
+          </div>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 type BibleReaderContextType = {
   book: string;
   chapter: string;
@@ -49,6 +154,7 @@ type BibleReaderContextType = {
   lineHeight?: number;
   showVerseNumbers: boolean;
   background: 'light' | 'dark';
+  onSettingsContentClick?: (props: BibleReaderSettingsContentProps) => void;
 };
 
 const BibleReaderContext = createContext<BibleReaderContextType | null>(null);
@@ -76,12 +182,9 @@ export type RootProps = {
   lineHeight?: number;
   showVerseNumbers?: boolean;
   background?: 'light' | 'dark';
+  onSettingsContentClick?: (props: BibleReaderSettingsContentProps) => void;
   children?: ReactNode;
 };
-
-const MIN_FONT_SIZE = 12;
-const MAX_FONT_SIZE = 20;
-const DEFAULT_FONT_SIZE = 16;
 
 function Root({
   book: controlledBook,
@@ -98,6 +201,7 @@ function Root({
   lineHeight,
   showVerseNumbers = true,
   background,
+  onSettingsContentClick,
   children,
 }: RootProps) {
   const [book, setBook] = useControllableState({
@@ -124,7 +228,6 @@ function Root({
   const [currentFontSize, setCurrentFontSize] = useState(validatedFontSize);
   const [currentFontFamily, setCurrentFontFamily] = useState(fontFamily);
 
-  // Load saved preferences from localStorage before paint (avoids flash of default values)
   useLayoutEffect(() => {
     const savedFontSize = localStorage.getItem('youversion-platform:reader:font-size');
     if (savedFontSize) {
@@ -140,7 +243,6 @@ function Root({
     }
   }, []);
 
-  // Save preferences to localStorage when they change
   useEffect(() => {
     localStorage.setItem('youversion-platform:reader:font-size', currentFontSize.toString());
   }, [currentFontSize]);
@@ -171,6 +273,7 @@ function Root({
     lineHeight,
     showVerseNumbers,
     background: theme,
+    onSettingsContentClick,
   };
 
   return (
@@ -206,7 +309,6 @@ function Content() {
 
   const usfmReference = `${book}.${chapter}`;
 
-  // Check if the current chapter is available in this version
   const chapterUnavailable = useMemo(() => {
     if (!bookData || !chapter) return false;
     const inChapters = bookData.chapters?.some((ch) => ch.passage_id.split('.').pop() === chapter);
@@ -237,7 +339,6 @@ function Content() {
       </h1>
 
       {chapterUnavailable ? (
-        // This copy was taken from bible.com (e.g. https://www.bible.com/bible/4253/ACT.INTRO1.AFV)
         <p className="yv:text-center yv:text-balance yv:text-muted-foreground">
           This chapter is not available in this version. Please choose a different chapter or
           version.
@@ -326,6 +427,28 @@ function UserMenu() {
   );
 }
 
+function SettingsContent() {
+  const {
+    currentFontFamily,
+    setCurrentFontFamily,
+    currentFontSize,
+    setCurrentFontSize,
+    background,
+  } = useBibleReaderContext();
+
+  return (
+    <PopoverContent sideOffset={16} heading="Reader Settings" theme={background}>
+      <BibleReaderSettingsContent
+        currentFontSize={currentFontSize}
+        onFontSizeChange={setCurrentFontSize}
+        currentFontFamily={currentFontFamily}
+        onFontFamilyChange={setCurrentFontFamily}
+        background={background}
+      />
+    </PopoverContent>
+  );
+}
+
 function Toolbar({ border = 'top' }: { border?: 'top' | 'bottom' }) {
   const {
     book,
@@ -338,8 +461,10 @@ function Toolbar({ border = 'top' }: { border?: 'top' | 'bottom' }) {
     booksLoading,
     currentFontFamily,
     setCurrentFontFamily,
+    currentFontSize,
     setCurrentFontSize,
     background,
+    onSettingsContentClick,
   } = useBibleReaderContext();
   const yvContext = useContext(YouVersionContext);
 
@@ -347,6 +472,14 @@ function Toolbar({ border = 'top' }: { border?: 'top' | 'bottom' }) {
   const nextResult = getAdjacentChapter(booksData, book, chapter, 'next');
   const canNavigatePrevious = !booksLoading && prevResult !== null;
   const canNavigateNext = !booksLoading && nextResult !== null;
+
+  const settingsContentProps: BibleReaderSettingsContentProps = {
+    currentFontSize,
+    onFontSizeChange: setCurrentFontSize,
+    currentFontFamily,
+    onFontFamilyChange: setCurrentFontFamily,
+    background,
+  };
 
   return (
     <section
@@ -437,6 +570,7 @@ function Toolbar({ border = 'top' }: { border?: 'top' | 'bottom' }) {
               </div>
             )}
           </BibleChapterPicker.Trigger>
+          <BibleChapterPicker.Content />
         </BibleChapterPicker.Root>
 
         <BibleVersionPicker.Root
@@ -453,7 +587,6 @@ function Toolbar({ border = 'top' }: { border?: 'top' | 'bottom' }) {
                 disabled={loading}
                 aria-label={loading ? 'Loading Bible version' : 'Change Bible version'}
               >
-                {/* This div exists merely as a wrapper to minimize width layout shifting */}
                 <div className="yv:min-w-[3ch] yv:flex yv:justify-center">
                   {loading ? (
                     <LoaderIcon className="yv:size-4 yv:animate-spin yv:text-muted-foreground" />
@@ -469,103 +602,29 @@ function Toolbar({ border = 'top' }: { border?: 'top' | 'bottom' }) {
           <BibleVersionPicker.Content />
         </BibleVersionPicker.Root>
 
-        <Popover>
-          <PopoverTrigger asChild aria-label="Settings">
-            <Button size="sm" variant="secondary">
-              <GearIcon className="yv:text-foreground" />
-            </Button>
-          </PopoverTrigger>
-
-          <PopoverContent sideOffset={16} heading="Reader Settings" theme={background}>
-            <div className="yv:flex yv:flex-col yv:gap-4 yv:p-4">
-              <div className="yv:grid yv:grid-cols-2">
-                <Button
-                  className="yv:text-xs yv:text-black yv:dark:text-muted-foreground yv:rounded-l-[8px] yv:rounded-r-none yv:border yv:border-white yv:dark:border-border yv:h-auto yv:py-2"
-                  onClick={() =>
-                    setCurrentFontSize((prev) => {
-                      if (prev > MIN_FONT_SIZE) return prev - 2;
-                      return prev;
-                    })
-                  }
-                  size="lg"
-                  variant="secondary"
-                  data-testid="decrease-font-size"
-                >
-                  A
-                </Button>
-                <Button
-                  className="yv:text-3xl yv:text-black yv:dark:text-muted-foreground yv:rounded-r-[8px] yv:rounded-l-none yv:border yv:border-white yv:dark:border-border yv:h-auto yv:py-2"
-                  onClick={() =>
-                    setCurrentFontSize((prev) => {
-                      if (prev < MAX_FONT_SIZE) return prev + 2;
-                      return prev;
-                    })
-                  }
-                  size="lg"
-                  variant="secondary"
-                  data-testid="increase-font-size"
-                >
-                  A
-                </Button>
-              </div>
-
-              <div className="yv:grid yv:grid-cols-2">
-                <Button
-                  className={cn(
-                    'yv:group yv:dark:bg-muted yv:rounded-r-none yv:border-r-0.5 yv:dark:border-border yv:rounded-l-[8px] yv:h-auto',
-                    currentFontFamily === INTER_FONT
-                      ? 'yv:bg-primary yv:border-primary yv:dark:bg-inherit yv:text-primary-foreground yv:hover:text-primary-foreground yv:hover:bg-primary/80'
-                      : '',
-                  )}
-                  onClick={() => setCurrentFontFamily(INTER_FONT)}
-                  variant="outline"
-                >
-                  <div className="yv:flex yv:flex-col yv:w-full yv:items-start">
-                    <span
-                      className={cn(
-                        'yv:text-xs yv:text-muted-foreground',
-                        currentFontFamily === INTER_FONT
-                          ? 'yv:text-muted yv:dark:text-muted-foreground yv:group-hover:text-muted'
-                          : '',
-                      )}
-                    >
-                      Font
-                    </span>
-                    <span className="yv:sm:text-xl yv:text-base">Inter</span>
-                  </div>
-                </Button>
-                <Button
-                  className={cn(
-                    'yv:group yv:dark:bg-muted yv:border-l-0.5 yv:rounded-l-none yv:rounded-r-[8px] yv:h-auto',
-                    currentFontFamily === SOURCE_SERIF_FONT
-                      ? 'yv:bg-primary yv:border-primary yv:dark:bg-inherit yv:text-primary-foreground yv:hover:text-primary-foreground yv:hover:bg-primary/80'
-                      : '',
-                  )}
-                  onClick={() => setCurrentFontFamily(SOURCE_SERIF_FONT)}
-                  variant="outline"
-                >
-                  <div className="yv:flex yv:flex-col yv:w-full yv:items-start">
-                    <span
-                      className={cn(
-                        'yv:text-xs yv:text-muted-foreground',
-                        currentFontFamily === SOURCE_SERIF_FONT
-                          ? 'yv:text-muted yv:dark:text-muted-foreground yv:group-hover:text-muted'
-                          : '',
-                      )}
-                    >
-                      Font
-                    </span>
-                    <span className="yv:sm:text-xl yv:text-base yv:font-serif">Source Serif</span>
-                  </div>
-                </Button>
-              </div>
-            </div>
-          </PopoverContent>
-        </Popover>
+        {onSettingsContentClick ? (
+          <Button
+            size="sm"
+            variant="secondary"
+            aria-label="Settings"
+            onClick={() => onSettingsContentClick(settingsContentProps)}
+          >
+            <GearIcon className="yv:text-foreground" />
+          </Button>
+        ) : (
+          <Popover>
+            <PopoverTrigger asChild aria-label="Settings">
+              <Button size="sm" variant="secondary">
+                <GearIcon className="yv:text-foreground" />
+              </Button>
+            </PopoverTrigger>
+            <SettingsContent />
+          </Popover>
+        )}
       </div>
     </section>
   );
 }
 
-export const BibleReader = Object.assign({}, { Root, Content, Toolbar });
+export const BibleReader = Object.assign({}, { Root, Content, Toolbar, SettingsContent, UserMenu });
 export type BibleReaderRootProps = RootProps;

--- a/packages/ui/src/components/bible-version-picker.tsx
+++ b/packages/ui/src/components/bible-version-picker.tsx
@@ -10,6 +10,7 @@ import {
 } from '@youversion/platform-react-hooks';
 import {
   createContext,
+  type ReactElement,
   type ReactNode,
   useCallback,
   useContext,
@@ -51,14 +52,11 @@ function saveRecentVersions(versions: RecentVersion[]): void {
   localStorage.setItem(RECENT_VERSIONS_KEY, JSON.stringify(versions));
 }
 
-// Displays a version abbreviation (e.g., "NIV", "KJV2") centered within a fixed-size icon.
-// Dynamically scales the font size to fit the text within the container with padding.
 function VersionAbbreviationIcon({ text }: { text: string }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const prefixRef = useRef<HTMLDivElement>(null);
   const [prefixSize, setPrefixSize] = useState(20);
 
-  // Split abbreviation into letters and numbers (e.g., "KJV2" → "KJV", "2")
   const match = /^(.+?)(\d+)$/.exec(text) || [];
   const prefix = match[1] || text;
   const digits = match[2];
@@ -68,20 +66,17 @@ function VersionAbbreviationIcon({ text }: { text: string }) {
     const prefixElement = prefixRef.current;
     if (!container || !prefixElement) return;
 
-    // Calculate the maximum font size that fits the text within container bounds
     const calculateSize = (element: HTMLElement | null) => {
       if (!element) return 20;
 
       const containerWidth = container.offsetWidth;
       const containerHeight = container.offsetHeight;
-      // Target 70% of width for horizontal padding, max 40% height for vertical spacing
       const targetWidth = containerWidth * 0.7;
       const maxHeight = containerHeight * 0.4;
 
       let currentSize = 20;
       let ratio = 1;
 
-      // Iteratively converge on the optimal size (5 iterations sufficient for convergence)
       for (let i = 0; i < 5; i++) {
         element.style.fontSize = `${currentSize}px`;
         const currentWidth = element.scrollWidth;
@@ -90,13 +85,11 @@ function VersionAbbreviationIcon({ text }: { text: string }) {
         if (currentWidth > 0) {
           const widthRatio = targetWidth / currentWidth;
           const heightRatio = maxHeight / currentHeight;
-          // Use the more restrictive constraint (width or height)
           ratio = Math.min(widthRatio, heightRatio);
           currentSize = currentSize * ratio;
         }
       }
 
-      // Ensure minimum readable size of 12px
       return Math.max(12, currentSize);
     };
 
@@ -105,7 +98,6 @@ function VersionAbbreviationIcon({ text }: { text: string }) {
       setPrefixSize(newPrefixSize);
     };
 
-    // Recalculate when container size changes (e.g., window resize, theme switch)
     const resizeObserver = new ResizeObserver(updateSizes);
     resizeObserver.observe(container);
     updateSizes();
@@ -132,80 +124,22 @@ function VersionAbbreviationIcon({ text }: { text: string }) {
   );
 }
 
-type BibleVersionPickerContextType = {
+export type BibleVersionPickerContentProps = {
   versionId: number;
-  setVersionId: (versionId: number) => void;
-  background: 'light' | 'dark';
-  side: 'top' | 'right' | 'bottom' | 'left';
-  languages: Pick<Language, 'id' | 'display_names' | 'speaking_population'>[];
-  totalLanguages: number;
-  selectedLanguageId: string;
-  setSelectedLanguageId: (id: string) => void;
-  searchQuery: string;
-  setSearchQuery: (query: string) => void;
-  suggestedLanguages: Pick<Language, 'id' | 'display_names'>[];
-  filteredVersions: BibleVersion[];
-  isLanguagesOpen: boolean;
-  setIsLanguagesOpen: (open: boolean) => void;
-  recentVersions: RecentVersion[];
-  addRecentVersion: (version: RecentVersion) => void;
-  isPopoverOpen: boolean;
-  setIsPopoverOpen: (open: boolean) => void;
-  versionsLoading: boolean;
-};
-
-const BibleVersionPickerContext = createContext<BibleVersionPickerContextType | null>(null);
-
-function useBibleVersionPickerContext() {
-  const context = useContext(BibleVersionPickerContext);
-  if (!context) {
-    throw new Error('BibleVersionPicker components must be used within BibleVersionPicker.Root');
-  }
-  return context;
-}
-
-export type RootProps = {
-  versionId: number;
-  onVersionChange?: (versionId: number) => void;
+  onSelectVersion: (versionId: number) => void;
   background?: 'light' | 'dark';
-  side?: 'top' | 'right' | 'bottom' | 'left';
-  children?: ReactNode;
 };
 
-function Root({
-  versionId: controlledVersionId,
-  onVersionChange,
-  background,
-  side = 'top',
-  children,
-}: RootProps) {
-  const [versionId, setVersionIdState] = useControllableState({
-    prop: controlledVersionId,
-    defaultProp: controlledVersionId,
-    onChange: onVersionChange,
-  });
-
-  const providerTheme = useTheme();
-  const theme = background || providerTheme;
-
+export function BibleVersionPickerContent({
+  versionId,
+  onSelectVersion,
+}: BibleVersionPickerContentProps): ReactElement {
   const [selectedLanguageId, setSelectedLanguageId] = useState(
     (typeof navigator !== 'undefined' && navigator.languages[0]?.split('-')[0]) || 'en',
   );
   const [searchQuery, setSearchQuery] = useState('');
   const [isLanguagesOpen, setIsLanguagesOpen] = useState(false);
   const [recentVersions, setRecentVersions] = useState<RecentVersion[]>(getRecentVersions);
-  const [isPopoverOpen, setIsPopoverOpenRaw] = useState(false);
-
-  const setIsPopoverOpen = useCallback(
-    (open: boolean) => {
-      setIsPopoverOpenRaw(open);
-      if (!open) {
-        setSearchQuery('');
-        setIsLanguagesOpen(false);
-      }
-    },
-    [setSearchQuery],
-  );
 
   const addRecentVersion = useCallback((version: RecentVersion) => {
     setRecentVersions((prev) => {
@@ -262,21 +196,13 @@ function Root({
     return [];
   }, [languages, versionsLanguageInfo?.data, getLanguageDisplayName]);
 
-  // pass zz to get the country languages based on IP Address
   const { languages: countryLanguages } = useLanguages({
     country: 'zz',
     fields: ['id', 'display_names'],
     page_size: '*',
   });
 
-  // Suggested languages = browser preference languages first, then API country
-  // languages (via country:'zz' which detects country by IP). Both lists are
-  // filtered to only languages that have at least one Bible version (uniqueLanguages).
-  // The API's order is preserved for country languages; browser order is preserved
-  // for user languages. Duplicates are removed (first occurrence wins).
   const suggestedLanguages = useMemo(() => {
-    // Extract language codes from browser (e.g., 'en-US' -> 'en')
-    // Map over userLanguageCodes to preserve browser preference order
     const userLanguageCodes = (typeof navigator !== 'undefined' ? navigator.languages : []).map(
       (code) => code.split('-')[0]?.toLowerCase(),
     );
@@ -294,90 +220,6 @@ function Root({
     return [...new Map(combined.map((lang) => [lang.id, lang])).values()];
   }, [uniqueLanguages, countryLanguages]);
 
-  const contextValue: BibleVersionPickerContextType = {
-    versionId,
-    setVersionId: setVersionIdState,
-    background: theme,
-    side,
-    languages: uniqueLanguages,
-    totalLanguages: uniqueLanguages.length || 0,
-    selectedLanguageId,
-    setSelectedLanguageId,
-    searchQuery,
-    setSearchQuery,
-    suggestedLanguages,
-    filteredVersions,
-    isLanguagesOpen,
-    setIsLanguagesOpen,
-    recentVersions,
-    addRecentVersion,
-    isPopoverOpen,
-    setIsPopoverOpen,
-    versionsLoading,
-  };
-
-  return (
-    <BibleVersionPickerContext.Provider value={contextValue}>
-      <Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
-        {children}
-      </Popover>
-    </BibleVersionPickerContext.Provider>
-  );
-}
-
-export type BibleVersionPickerTriggerProps = Omit<
-  React.ComponentProps<typeof PopoverTrigger>,
-  'children'
-> & {
-  children?:
-    | React.ReactNode
-    | ((props: { version: BibleVersion | null; loading: boolean }) => React.ReactNode);
-};
-
-function Trigger({ asChild = true, children, ...props }: BibleVersionPickerTriggerProps) {
-  const { versionId, background } = useBibleVersionPickerContext();
-  const { version, loading } = useVersion(versionId);
-
-  const content =
-    typeof children === 'function'
-      ? children({ version, loading })
-      : children || (
-          <Button variant={'secondary'} className="yv:cursor-pointer yv:font-bold yv:text-base">
-            {version?.localized_abbreviation || 'Select'}
-          </Button>
-        );
-
-  return (
-    <PopoverTrigger data-yv-sdk data-yv-theme={background} asChild={asChild} {...props}>
-      {content}
-    </PopoverTrigger>
-  );
-}
-
-function Content() {
-  const {
-    searchQuery,
-    setSearchQuery,
-    filteredVersions,
-    versionId,
-    setVersionId,
-    background,
-    side,
-    setIsLanguagesOpen,
-    isLanguagesOpen,
-    totalLanguages,
-    selectedLanguageId,
-    setSelectedLanguageId,
-    recentVersions,
-    addRecentVersion,
-    suggestedLanguages,
-    languages,
-    setIsPopoverOpen,
-    versionsLoading,
-  } = useBibleVersionPickerContext();
-  const providerTheme = useTheme();
-  const theme = background || providerTheme;
-
   const filteredRecentVersions = useMemo(() => {
     if (!searchQuery.trim()) return recentVersions;
     const query = searchQuery.trim().toLowerCase();
@@ -388,7 +230,7 @@ function Content() {
         v.abbreviation?.toLowerCase().includes(query),
     );
   }, [recentVersions, searchQuery]);
-  // Fetch the selected language details (may not be in the paginated languages list)
+
   const { language: selectedLanguage } = useLanguage(selectedLanguageId);
 
   const handleSelectLanguage = (languageId: string) => {
@@ -397,7 +239,7 @@ function Content() {
   };
 
   const handleSelectVersion = (version: BibleVersion | RecentVersion) => {
-    setVersionId(version.id);
+    onSelectVersion(version.id);
     addRecentVersion({
       id: version.id,
       title: version.title,
@@ -405,55 +247,43 @@ function Content() {
       abbreviation: version.abbreviation,
     });
     setIsLanguagesOpen(false);
-    setIsPopoverOpen(false);
   };
 
-  function LanguagePicker() {
-    return (
-      <Button
-        aria-label="Select language"
-        className="yv:ml-auto yv:bg-card yv:border yv:border-transparent yv:hover:bg-card yv:hover:border-border yv:max-w-40"
-        size="sm"
-        onClick={() => setIsLanguagesOpen(true)}
-        variant="secondary"
-      >
-        <GlobeIcon className="yv:size-4" />
-        <span className="yv:text-sm yv:font-medium yv:truncate">
-          {selectedLanguage?.display_names?.en || selectedLanguage?.language}
-        </span>
-        <Badge
-          variant="secondary"
-          className="yv:h-5 yv:min-w-5 yv:rounded-full yv:px-1 yv:font-mono yv:tabular-nums"
-        >
-          {versionsLoading ? (
-            <LoaderIcon className="yv:size-3 yv:animate-spin" />
-          ) : (
-            filteredVersions.length + filteredRecentVersions.length
-          )}
-        </Badge>
-      </Button>
-    );
-  }
-
   return (
-    <PopoverContent
-      sideOffset={16}
-      className="yv:h-[66svh]"
-      heading="Bible Versions"
-      headerChild={<LanguagePicker />}
-      theme={theme}
-      side={side}
-    >
-      {/* Versions View */}
+    <>
       <div
-        className={`yv:overflow-y-auto yv:h-full yv:flex yv:flex-col yv:transition-all yv:duration-300 yv:rounded-2xl yv:origin-center ${
+        className={`yv:h-full yv:flex yv:flex-col yv:transition-all yv:duration-300 yv:rounded-2xl yv:origin-center ${
           isLanguagesOpen
             ? 'yv:opacity-0 yv:pointer-events-none yv:blur-sm yv:scale-95'
             : 'yv:opacity-100 yv:pointer-events-auto yv:blur-none yv:scale-100'
         }`}
       >
+        <div className="yv:flex yv:items-center yv:gap-2 yv:px-4 yv:py-1">
+          <Button
+            aria-label="Select language"
+            className="yv:ml-auto yv:bg-card yv:border yv:border-transparent yv:hover:bg-card yv:hover:border-border yv:max-w-40"
+            size="sm"
+            onClick={() => setIsLanguagesOpen(true)}
+            variant="secondary"
+          >
+            <GlobeIcon className="yv:size-4" />
+            <span className="yv:text-sm yv:font-medium yv:truncate">
+              {selectedLanguage?.display_names?.en || selectedLanguage?.language}
+            </span>
+            <Badge
+              variant="secondary"
+              className="yv:h-5 yv:min-w-5 yv:rounded-full yv:px-1 yv:font-mono yv:tabular-nums"
+            >
+              {versionsLoading ? (
+                <LoaderIcon className="yv:size-3 yv:animate-spin" />
+              ) : (
+                filteredVersions.length + filteredRecentVersions.length
+              )}
+            </Badge>
+          </Button>
+        </div>
+
         <div className="yv:flex-1 yv:overflow-y-auto yv:py-2">
-          {/* Recent Versions */}
           {filteredRecentVersions.length > 0 && (
             <>
               <h2 className="yv:px-4 yv:py-2 yv:text-lg yv:font-bold">Recently Used Versions</h2>
@@ -493,7 +323,6 @@ function Content() {
               </ItemGroup>
             </>
           )}
-          {/* All Versions */}
           {filteredVersions.length > 0 ? (
             <ItemGroup data-testid="version-list">
               <h3 className="yv:px-4 yv:py-2 yv:font-bold">All Versions</h3>
@@ -557,7 +386,6 @@ function Content() {
         </section>
       </div>
 
-      {/* Languages View */}
       <div
         className={`yv:h-full yv:absolute yv:inset-0 yv:flex yv:flex-col yv:transition-all yv:duration-300 yv:rounded-2xl yv:origin-center ${
           isLanguagesOpen
@@ -587,7 +415,7 @@ function Content() {
               Suggested
             </TabsTrigger>
             <TabsTrigger className="yv:p-0" value="all">
-              All ({totalLanguages})
+              All ({uniqueLanguages.length})
             </TabsTrigger>
           </TabsList>
 
@@ -637,7 +465,7 @@ function Content() {
           <TabsContent value="all" className="yv:overflow-y-auto yv:flex-1 yv:min-h-0">
             <h3 className="yv:bg-popover yv:px-4 yv:pb-2 yv:text-lg yv:font-bold">All Languages</h3>
             <ItemGroup className="yv:gap-1">
-              {languages.map((language) => (
+              {uniqueLanguages.map((language) => (
                 <Item
                   key={language.id}
                   className={cn(
@@ -670,6 +498,163 @@ function Content() {
           </TabsContent>
         </Tabs>
       </div>
+    </>
+  );
+}
+
+type BibleVersionPickerContextType = {
+  versionId: number;
+  setVersionId: (versionId: number) => void;
+  background: 'light' | 'dark';
+  side: 'top' | 'right' | 'bottom' | 'left';
+  onContentClick?: (props: BibleVersionPickerContentProps) => void;
+  isPopoverOpen: boolean;
+  setIsPopoverOpen: (open: boolean) => void;
+  openCount: number;
+};
+
+const BibleVersionPickerContext = createContext<BibleVersionPickerContextType | null>(null);
+
+function useBibleVersionPickerContext() {
+  const context = useContext(BibleVersionPickerContext);
+  if (!context) {
+    throw new Error('BibleVersionPicker components must be used within BibleVersionPicker.Root');
+  }
+  return context;
+}
+
+export type RootProps = {
+  versionId: number;
+  onVersionChange?: (versionId: number) => void;
+  background?: 'light' | 'dark';
+  side?: 'top' | 'right' | 'bottom' | 'left';
+  onContentClick?: (props: BibleVersionPickerContentProps) => void;
+  children?: ReactNode;
+};
+
+function Root({
+  versionId: controlledVersionId,
+  onVersionChange,
+  background,
+  side = 'top',
+  onContentClick,
+  children,
+}: RootProps) {
+  const [versionId, setVersionIdState] = useControllableState({
+    prop: controlledVersionId,
+    defaultProp: controlledVersionId,
+    onChange: onVersionChange,
+  });
+
+  const providerTheme = useTheme();
+  const theme = background || providerTheme;
+
+  const [isPopoverOpen, setIsPopoverOpenRaw] = useState(false);
+  const [openCount, setOpenCount] = useState(0);
+
+  const setIsPopoverOpen = useCallback((open: boolean) => {
+    setIsPopoverOpenRaw(open);
+    if (open) setOpenCount((c) => c + 1);
+  }, []);
+
+  const contextValue: BibleVersionPickerContextType = {
+    versionId,
+    setVersionId: setVersionIdState,
+    background: theme,
+    side,
+    onContentClick,
+    isPopoverOpen,
+    setIsPopoverOpen,
+    openCount,
+  };
+
+  if (onContentClick) {
+    return (
+      <BibleVersionPickerContext.Provider value={contextValue}>
+        {children}
+      </BibleVersionPickerContext.Provider>
+    );
+  }
+
+  return (
+    <BibleVersionPickerContext.Provider value={contextValue}>
+      <Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
+        {children}
+      </Popover>
+    </BibleVersionPickerContext.Provider>
+  );
+}
+
+export type BibleVersionPickerTriggerProps = Omit<
+  React.ComponentProps<typeof PopoverTrigger>,
+  'children'
+> & {
+  children?:
+    | React.ReactNode
+    | ((props: { version: BibleVersion | null; loading: boolean }) => React.ReactNode);
+};
+
+function Trigger({ asChild = true, children, ...props }: BibleVersionPickerTriggerProps) {
+  const { versionId, background, onContentClick, setVersionId } = useBibleVersionPickerContext();
+  const { version, loading } = useVersion(versionId);
+
+  const content =
+    typeof children === 'function'
+      ? children({ version, loading })
+      : children || (
+          <Button variant={'secondary'} className="yv:cursor-pointer yv:font-bold yv:text-base">
+            {version?.localized_abbreviation || 'Select'}
+          </Button>
+        );
+
+  if (onContentClick) {
+    const contentProps: BibleVersionPickerContentProps = {
+      versionId,
+      onSelectVersion: (id) => setVersionId(id),
+      background,
+    };
+    return (
+      <div
+        data-yv-sdk
+        data-yv-theme={background}
+        onClick={() => onContentClick(contentProps)}
+        className="yv:inline-flex yv:cursor-pointer"
+      >
+        {content}
+      </div>
+    );
+  }
+
+  return (
+    <PopoverTrigger data-yv-sdk data-yv-theme={background} asChild={asChild} {...props}>
+      {content}
+    </PopoverTrigger>
+  );
+}
+
+function Content() {
+  const { versionId, setVersionId, background, side, onContentClick, setIsPopoverOpen, openCount } =
+    useBibleVersionPickerContext();
+
+  if (onContentClick) return null;
+
+  return (
+    <PopoverContent
+      sideOffset={16}
+      className="yv:h-[66svh]"
+      heading="Bible Versions"
+      theme={background}
+      side={side}
+    >
+      <BibleVersionPickerContent
+        key={openCount}
+        versionId={versionId}
+        onSelectVersion={(id) => {
+          setVersionId(id);
+          setIsPopoverOpen(false);
+        }}
+        background={background}
+      />
     </PopoverContent>
   );
 }

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -1,18 +1,32 @@
 export {
   BibleChapterPicker,
+  BibleChapterPickerContent,
   type RootProps,
   type BibleChapterPickerRootProps,
+  type BibleChapterPickerContentProps,
   type TriggerProps,
 } from './bible-chapter-picker';
-export { BibleReader, type BibleReaderRootProps } from './bible-reader';
+export {
+  BibleReader,
+  BibleReaderSettingsContent,
+  type BibleReaderRootProps,
+  type BibleReaderSettingsContentProps,
+} from './bible-reader';
 export {
   BibleVersionPicker,
+  BibleVersionPickerContent,
   type BibleVersionPickerRootProps,
+  type BibleVersionPickerContentProps,
   type BibleVersionPickerTriggerProps,
 } from './bible-version-picker';
 export { YouVersionAuthButton, type YouVersionAuthButtonProps } from './YouVersionAuthButton';
 export { VerseOfTheDay, type VerseOfTheDayProps } from './verse-of-the-day';
-export { BibleTextView, type BibleTextViewProps } from './verse';
+export {
+  BibleTextView,
+  FootnoteContent,
+  type BibleTextViewProps,
+  type FootnoteContentProps,
+} from './verse';
 export { BibleCard, type BibleCardProps } from './bible-card';
 export { BibleWidgetView, type BibleWidgetViewProps } from './bible-widget-view';
 export { Separator } from './ui/separator';

--- a/packages/ui/src/components/verse.tsx
+++ b/packages/ui/src/components/verse.tsx
@@ -77,6 +77,56 @@ function getVerseHtmlFromDom(container: HTMLElement, verseNum: string): string {
   return parts.join('');
 }
 
+export type FootnoteContentProps = {
+  verseNum: string;
+  notes: string[];
+  verseHtml: string;
+  hasVerseContext: boolean;
+  reference?: string;
+  fontSize?: number;
+};
+
+export function FootnoteContent({
+  verseNum,
+  notes,
+  verseHtml,
+  hasVerseContext,
+  reference,
+  fontSize,
+}: FootnoteContentProps): React.ReactElement {
+  const verseReference = reference ? `${reference}:${verseNum}` : `Verse ${verseNum}`;
+  return (
+    <div className="yv:p-3 yv:overflow-y-auto yv:max-h-[33svh]">
+      {hasVerseContext && (
+        <>
+          <div className="yv:font-bold yv:mb-2">{verseReference}</div>
+          <div
+            className="yv:mb-3 yv:font-serif yv:*:font-serif"
+            style={{ fontSize: fontSize ? `${fontSize}px` : '1.25rem' }}
+            // biome-ignore lint/security/noDangerouslySetInnerHtml: Bible footnote HTML comes from our YouVersion APIs and is safe
+            dangerouslySetInnerHTML={{ __html: verseHtml }}
+          />
+        </>
+      )}
+      <ul className="yv:list-none yv:p-0 yv:m-0 yv:space-y-1">
+        {notes.map((note, index) => {
+          const marker = getFootnoteMarker(index);
+          return (
+            <li
+              key={marker}
+              className="yv:flex yv:gap-2 yv:text-xs yv:border-b yv:border-border yv:py-2"
+            >
+              <span className="">{marker}.</span>
+              {/** biome-ignore lint/security/noDangerouslySetInnerHtml: Bible footnote HTML comes from our YouVersion APIs and is safe */}
+              <span dangerouslySetInnerHTML={{ __html: note }} />
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
 const VerseFootnoteButton = memo(function VerseFootnoteButton({
   verseNum,
   notes,
@@ -85,6 +135,7 @@ const VerseFootnoteButton = memo(function VerseFootnoteButton({
   reference,
   fontSize,
   theme,
+  onFootnoteContentClick,
 }: {
   verseNum: string;
   notes: string[];
@@ -93,8 +144,31 @@ const VerseFootnoteButton = memo(function VerseFootnoteButton({
   reference?: string;
   fontSize?: number;
   theme: 'light' | 'dark';
+  onFootnoteContentClick?: (props: FootnoteContentProps) => void;
 }) {
-  const verseReference = reference ? `${reference}:${verseNum}` : `Verse ${verseNum}`;
+  if (onFootnoteContentClick) {
+    return (
+      <button
+        type="button"
+        data-yv-sdk
+        data-yv-theme={theme}
+        className="yv:inline-flex yv:align-middle yv:cursor-pointer yv:ml-1! yv:text-(--yv-gray-20)"
+        onClick={() =>
+          onFootnoteContentClick({
+            verseNum,
+            notes,
+            verseHtml,
+            hasVerseContext,
+            reference,
+            fontSize,
+          })
+        }
+      >
+        <Footnote className="yv:size-[1.5em]" />
+      </button>
+    );
+  }
+
   return (
     <Popover>
       <PopoverTrigger data-yv-sdk data-yv-theme={theme} asChild>
@@ -110,34 +184,14 @@ const VerseFootnoteButton = memo(function VerseFootnoteButton({
         heading="Footnotes"
         theme={theme}
       >
-        <div className="yv:p-3 yv:overflow-y-auto yv:max-h-[33svh]">
-          {hasVerseContext && (
-            <>
-              <div className="yv:font-bold yv:mb-2">{verseReference}</div>
-              <div
-                className="yv:mb-3 yv:font-serif yv:*:font-serif"
-                style={{ fontSize: fontSize ? `${fontSize}px` : '1.25rem' }}
-                // biome-ignore lint/security/noDangerouslySetInnerHtml: Bible footnote HTML comes from our YouVersion APIs and is safe
-                dangerouslySetInnerHTML={{ __html: verseHtml }}
-              />
-            </>
-          )}
-          <ul className="yv:list-none yv:p-0 yv:m-0 yv:space-y-1">
-            {notes.map((note, index) => {
-              const marker = getFootnoteMarker(index);
-              return (
-                <li
-                  key={marker}
-                  className="yv:flex yv:gap-2 yv:text-xs yv:border-b yv:border-border yv:py-2"
-                >
-                  <span className="">{marker}.</span>
-                  {/** biome-ignore lint/security/noDangerouslySetInnerHtml: Bible footnote HTML comes from our YouVersion APIs and is safe */}
-                  <span dangerouslySetInnerHTML={{ __html: note }} />
-                </li>
-              );
-            })}
-          </ul>
-        </div>
+        <FootnoteContent
+          verseNum={verseNum}
+          notes={notes}
+          verseHtml={verseHtml}
+          hasVerseContext={hasVerseContext}
+          reference={reference}
+          fontSize={fontSize}
+        />
       </PopoverContent>
     </Popover>
   );
@@ -168,6 +222,7 @@ function BibleTextHtml({
   selectedVerses = [],
   onVerseSelect,
   highlightedVerses = {},
+  onFootnoteContentClick,
 }: {
   html: string;
   reference?: string;
@@ -176,6 +231,7 @@ function BibleTextHtml({
   selectedVerses?: number[];
   onVerseSelect?: (verses: number[]) => void;
   highlightedVerses?: Record<number, boolean>;
+  onFootnoteContentClick?: (props: FootnoteContentProps) => void;
 }) {
   const contentRef = useRef<HTMLDivElement>(null);
   const [footnoteData, setFootnoteData] = useState<VerseFootnoteData[]>([]);
@@ -252,6 +308,7 @@ function BibleTextHtml({
             reference={reference}
             fontSize={fontSize}
             theme={currentTheme}
+            onFootnoteContentClick={onFootnoteContentClick}
           />,
           el,
           `${verseNum}-${index}`,
@@ -291,6 +348,7 @@ type VerseHtmlProps = {
   selectedVerses?: number[];
   onVerseSelect?: (verses: number[]) => void;
   highlightedVerses?: Record<number, boolean>;
+  onFootnoteContentClick?: (props: FootnoteContentProps) => void;
 };
 
 /**
@@ -342,6 +400,7 @@ export const Verse = {
         selectedVerses,
         onVerseSelect,
         highlightedVerses,
+        onFootnoteContentClick,
       }: VerseHtmlProps,
       ref,
     ): ReactNode => {
@@ -378,6 +437,7 @@ export const Verse = {
             selectedVerses={selectedVerses}
             onVerseSelect={onVerseSelect}
             highlightedVerses={highlightedVerses}
+            onFootnoteContentClick={onFootnoteContentClick}
           />
         </section>
       );
@@ -398,6 +458,7 @@ export type BibleTextViewProps = {
   onVerseSelect?: (verses: number[]) => void;
   highlightedVerses?: Record<number, boolean>;
   passageState?: Partial<BibleTextViewPassageState>;
+  onFootnoteContentClick?: (props: FootnoteContentProps) => void;
 };
 
 /**
@@ -418,6 +479,7 @@ export const BibleTextView = forwardRef<HTMLDivElement, BibleTextViewProps>(
       onVerseSelect,
       highlightedVerses,
       passageState,
+      onFootnoteContentClick,
     },
     ref,
   ): React.ReactElement => {
@@ -493,6 +555,7 @@ export const BibleTextView = forwardRef<HTMLDivElement, BibleTextViewProps>(
           selectedVerses={selectedVerses}
           onVerseSelect={onVerseSelect}
           highlightedVerses={highlightedVerses}
+          onFootnoteContentClick={onFootnoteContentClick}
         />
       </div>
     );


### PR DESCRIPTION
## Summary

- Extract `BibleChapterPickerContent`, `BibleVersionPickerContent`, `BibleReaderSettingsContent`, and `FootnoteContent` as standalone exported components that can be rendered outside of popovers (e.g., in native bottom sheets via Expo DOM components)
- Add `onContentClick` callbacks to `BibleChapterPicker.Root`, `BibleVersionPicker.Root`, and `BibleReader.Root` that intercept trigger clicks and pass content props to the callback instead of opening a popover
- Add `onFootnoteContentClick` prop threaded through `BibleTextView` → `Verse.Html` → `BibleTextHtml` → `VerseFootnoteButton`
- Add `UserMenu` to `BibleReader` compound export
- All content components are self-contained (call hooks internally, manage their own state)

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] 63 unit tests pass
- [x] 99 integration tests pass (including "Search Resets After Selection" regression fix via `openCount` key)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts `BibleChapterPickerContent`, `BibleVersionPickerContent`, `BibleReaderSettingsContent`, and `FootnoteContent` as standalone exported components so they can be rendered outside of popovers (e.g., in Expo DOM native bottom sheets). An `onContentClick` callback pattern is added to each `Root` component that intercepts trigger clicks and passes content props to the caller instead of opening a popover.

- The `background` prop is part of the public API for all three new content components but is never applied inside the component implementations — consumers using `background=\"dark\"` in a native sheet will see no theming effect.
- Both `BibleChapterPicker.Trigger` and `BibleVersionPicker.Trigger` replace `<PopoverTrigger>` with a `<div onClick>` when `onContentClick` is set, breaking keyboard accessibility.

<h3>Confidence Score: 3/5</h3>

Safe to merge after resolving the background theming gap in the standalone content components; accessibility issues should also be addressed.

A P1 finding (background prop part of public API but silently no-ops in all three content components) could mislead consumers of the new standalone API, particularly for the stated native-sheet use-case. Multiple P2 accessibility issues (div-based triggers) reinforce the need for a follow-up. Score sits at 3 to reflect the P1 API correctness gap.

packages/ui/src/components/bible-chapter-picker.tsx and packages/ui/src/components/bible-version-picker.tsx — background prop and keyboard-accessibility on the new div triggers.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/ui/src/components/bible-chapter-picker.tsx | Extracts BibleChapterPickerContent as standalone component and adds onContentClick bypass; background prop declared in public type but never applied inside the component, and div-based trigger lacks keyboard accessibility. |
| packages/ui/src/components/bible-version-picker.tsx | Major refactor moving all picker state into BibleVersionPickerContent; background prop silently ignored; openCount key mechanism cleanly fixes search-reset regression; div trigger has same keyboard-accessibility gap. |
| packages/ui/src/components/bible-reader.tsx | Extracts BibleReaderSettingsContent and adds onSettingsContentClick bypass; background prop unused in content component; _currentFontSize discarded without display or documentation. |
| packages/ui/src/components/verse.tsx | Cleanly extracts FootnoteContent and threads onFootnoteContentClick through BibleTextView → Verse.Html → BibleTextHtml → VerseFootnoteButton; no issues found. |
| packages/ui/src/components/index.ts | Correctly exports all new standalone content components and their prop types; no issues. |
| packages/ui/src/components/bible-chapter-picker.stories.tsx | Adds BibleChapterPicker.Content to the existing story; trivial change, no issues. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Root["Root (onContentClick?)"]
    Root -->|"onContentClick provided"| CtxOnly["Context.Provider only\n(no Popover wrapper)"]
    Root -->|"no onContentClick"| PopoverRoot["Popover + Context.Provider"]

    CtxOnly --> Trigger
    PopoverRoot --> Trigger
    PopoverRoot --> Content["Compound Content\n(PopoverContent wrapper)"]

    Trigger{"onContentClick\nin context?"}
    Trigger -->|yes| DivBtn["div onClick\n→ calls onContentClick(contentProps)\n(native sheet caller renders StandaloneContent)"]
    Trigger -->|no| PopoverTrigger["PopoverTrigger\n(opens popover)"]

    Content --> StandaloneContent["Standalone Content Component\n(BibleChapterPickerContent /\nBibleVersionPickerContent /\nBibleReaderSettingsContent)"]

    DivBtn -.->|"consumer renders standalone"| StandaloneContent
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `packages/ui/src/components/bible-chapter-picker.tsx`, line 422-431 ([link](https://github.com/youversion/platform-sdk-react/blob/01777919905e2785f91005c44811d271b1417904/packages/ui/src/components/bible-chapter-picker.tsx#L422-L431)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Div trigger not keyboard-accessible**

   When `onContentClick` is provided, `BibleChapterPicker.Trigger` replaces `<PopoverTrigger>` with a plain `<div onClick>`. A `<div>` is not in the tab order by default and receives no `Enter`/`Space` key events, so keyboard-only users cannot open the picker. Switch to `<button type="button">` or add `role="button"`, `tabIndex={0}`, and an `onKeyDown` handler to restore keyboard accessibility.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/ui/src/components/bible-chapter-picker.tsx
   Line: 422-431

   Comment:
   **Div trigger not keyboard-accessible**

   When `onContentClick` is provided, `BibleChapterPicker.Trigger` replaces `<PopoverTrigger>` with a plain `<div onClick>`. A `<div>` is not in the tab order by default and receives no `Enter`/`Space` key events, so keyboard-only users cannot open the picker. Switch to `<button type="button">` or add `role="button"`, `tabIndex={0}`, and an `onKeyDown` handler to restore keyboard accessibility.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fui%2Fsrc%2Fcomponents%2Fbible-chapter-picker.tsx%0ALine%3A%20422-431%0A%0AComment%3A%0A**Div%20trigger%20not%20keyboard-accessible**%0A%0AWhen%20%60onContentClick%60%20is%20provided%2C%20%60BibleChapterPicker.Trigger%60%20replaces%20%60%3CPopoverTrigger%3E%60%20with%20a%20plain%20%60%3Cdiv%20onClick%3E%60.%20A%20%60%3Cdiv%3E%60%20is%20not%20in%20the%20tab%20order%20by%20default%20and%20receives%20no%20%60Enter%60%2F%60Space%60%20key%20events%2C%20so%20keyboard-only%20users%20cannot%20open%20the%20picker.%20Switch%20to%20%60%3Cbutton%20type%3D%22button%22%3E%60%20or%20add%20%60role%3D%22button%22%60%2C%20%60tabIndex%3D%7B0%7D%60%2C%20and%20an%20%60onKeyDown%60%20handler%20to%20restore%20keyboard%20accessibility.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%3Cbutton%0A%20%20%20%20%20%20%20%20type%3D%22button%22%0A%20%20%20%20%20%20%20%20data-yv-sdk%0A%20%20%20%20%20%20%20%20data-yv-theme%3D%7Btheme%7D%0A%20%20%20%20%20%20%20%20onClick%3D%7B%28%29%20%3D%3E%20onContentClick%28contentProps%29%7D%0A%20%20%20%20%20%20%20%20className%3D%22yv%3Ainline-flex%20yv%3Acursor-pointer%22%0A%20%20%20%20%20%20%3E%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-react&pr=222&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fui%2Fsrc%2Fcomponents%2Fbible-chapter-picker.tsx%0ALine%3A%20422-431%0A%0AComment%3A%0A**Div%20trigger%20not%20keyboard-accessible**%0A%0AWhen%20%60onContentClick%60%20is%20provided%2C%20%60BibleChapterPicker.Trigger%60%20replaces%20%60%3CPopoverTrigger%3E%60%20with%20a%20plain%20%60%3Cdiv%20onClick%3E%60.%20A%20%60%3Cdiv%3E%60%20is%20not%20in%20the%20tab%20order%20by%20default%20and%20receives%20no%20%60Enter%60%2F%60Space%60%20key%20events%2C%20so%20keyboard-only%20users%20cannot%20open%20the%20picker.%20Switch%20to%20%60%3Cbutton%20type%3D%22button%22%3E%60%20or%20add%20%60role%3D%22button%22%60%2C%20%60tabIndex%3D%7B0%7D%60%2C%20and%20an%20%60onKeyDown%60%20handler%20to%20restore%20keyboard%20accessibility.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%3Cbutton%0A%20%20%20%20%20%20%20%20type%3D%22button%22%0A%20%20%20%20%20%20%20%20data-yv-sdk%0A%20%20%20%20%20%20%20%20data-yv-theme%3D%7Btheme%7D%0A%20%20%20%20%20%20%20%20onClick%3D%7B%28%29%20%3D%3E%20onContentClick%28contentProps%29%7D%0A%20%20%20%20%20%20%20%20className%3D%22yv%3Ainline-flex%20yv%3Acursor-pointer%22%0A%20%20%20%20%20%20%3E%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=222&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>


2. `packages/ui/src/components/bible-version-picker.tsx`, line 1380-1395 ([link](https://github.com/youversion/platform-sdk-react/blob/01777919905e2785f91005c44811d271b1417904/packages/ui/src/components/bible-version-picker.tsx#L1380-L1395)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Same div-trigger accessibility gap in `BibleVersionPicker.Trigger`**

   When `onContentClick` is set, `BibleVersionPicker.Trigger` also renders a `<div onClick>` wrapper without `role`, `tabIndex`, or keyboard handlers. The same `<button type="button">` fix applies here.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/ui/src/components/bible-version-picker.tsx
   Line: 1380-1395

   Comment:
   **Same div-trigger accessibility gap in `BibleVersionPicker.Trigger`**

   When `onContentClick` is set, `BibleVersionPicker.Trigger` also renders a `<div onClick>` wrapper without `role`, `tabIndex`, or keyboard handlers. The same `<button type="button">` fix applies here.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fui%2Fsrc%2Fcomponents%2Fbible-version-picker.tsx%0ALine%3A%201380-1395%0A%0AComment%3A%0A**Same%20div-trigger%20accessibility%20gap%20in%20%60BibleVersionPicker.Trigger%60**%0A%0AWhen%20%60onContentClick%60%20is%20set%2C%20%60BibleVersionPicker.Trigger%60%20also%20renders%20a%20%60%3Cdiv%20onClick%3E%60%20wrapper%20without%20%60role%60%2C%20%60tabIndex%60%2C%20or%20keyboard%20handlers.%20The%20same%20%60%3Cbutton%20type%3D%22button%22%3E%60%20fix%20applies%20here.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-react&pr=222&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fui%2Fsrc%2Fcomponents%2Fbible-version-picker.tsx%0ALine%3A%201380-1395%0A%0AComment%3A%0A**Same%20div-trigger%20accessibility%20gap%20in%20%60BibleVersionPicker.Trigger%60**%0A%0AWhen%20%60onContentClick%60%20is%20set%2C%20%60BibleVersionPicker.Trigger%60%20also%20renders%20a%20%60%3Cdiv%20onClick%3E%60%20wrapper%20without%20%60role%60%2C%20%60tabIndex%60%2C%20or%20keyboard%20handlers.%20The%20same%20%60%3Cbutton%20type%3D%22button%22%3E%60%20fix%20applies%20here.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=222&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>


3. `packages/ui/src/components/bible-reader.tsx`, line 500-505 ([link](https://github.com/youversion/platform-sdk-react/blob/01777919905e2785f91005c44811d271b1417904/packages/ui/src/components/bible-reader.tsx#L500-L505)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`_currentFontSize` received but not rendered**

   `currentFontSize` is accepted in `BibleReaderSettingsContentProps` and destructured with an `_` prefix signalling intentional non-use, yet no current-size indicator is shown in the UI. If the native-sheet consumer passes this to synchronise the displayed size with the reader's state, the silent discard could leave the sheet UI out of sync. Either render the value (e.g., as a label between the two A buttons) or document that it is intentionally unused.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/ui/src/components/bible-reader.tsx
   Line: 500-505

   Comment:
   **`_currentFontSize` received but not rendered**

   `currentFontSize` is accepted in `BibleReaderSettingsContentProps` and destructured with an `_` prefix signalling intentional non-use, yet no current-size indicator is shown in the UI. If the native-sheet consumer passes this to synchronise the displayed size with the reader's state, the silent discard could leave the sheet UI out of sync. Either render the value (e.g., as a label between the two A buttons) or document that it is intentionally unused.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fui%2Fsrc%2Fcomponents%2Fbible-reader.tsx%0ALine%3A%20500-505%0A%0AComment%3A%0A**%60_currentFontSize%60%20received%20but%20not%20rendered**%0A%0A%60currentFontSize%60%20is%20accepted%20in%20%60BibleReaderSettingsContentProps%60%20and%20destructured%20with%20an%20%60_%60%20prefix%20signalling%20intentional%20non-use%2C%20yet%20no%20current-size%20indicator%20is%20shown%20in%20the%20UI.%20If%20the%20native-sheet%20consumer%20passes%20this%20to%20synchronise%20the%20displayed%20size%20with%20the%20reader's%20state%2C%20the%20silent%20discard%20could%20leave%20the%20sheet%20UI%20out%20of%20sync.%20Either%20render%20the%20value%20%28e.g.%2C%20as%20a%20label%20between%20the%20two%20A%20buttons%29%20or%20document%20that%20it%20is%20intentionally%20unused.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-react&pr=222&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fui%2Fsrc%2Fcomponents%2Fbible-reader.tsx%0ALine%3A%20500-505%0A%0AComment%3A%0A**%60_currentFontSize%60%20received%20but%20not%20rendered**%0A%0A%60currentFontSize%60%20is%20accepted%20in%20%60BibleReaderSettingsContentProps%60%20and%20destructured%20with%20an%20%60_%60%20prefix%20signalling%20intentional%20non-use%2C%20yet%20no%20current-size%20indicator%20is%20shown%20in%20the%20UI.%20If%20the%20native-sheet%20consumer%20passes%20this%20to%20synchronise%20the%20displayed%20size%20with%20the%20reader's%20state%2C%20the%20silent%20discard%20could%20leave%20the%20sheet%20UI%20out%20of%20sync.%20Either%20render%20the%20value%20%28e.g.%2C%20as%20a%20label%20between%20the%20two%20A%20buttons%29%20or%20document%20that%20it%20is%20intentionally%20unused.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=222&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fbible-chapter-picker.tsx%3A41-45%0A**%60background%60%20prop%20declared%20but%20silently%20ignored**%0A%0A%60BibleChapterPickerContentProps%60%20exposes%20a%20%60background%60%20prop%2C%20but%20the%20component%20only%20destructures%20%60versionId%60%2C%20%60defaultBook%60%2C%20and%20%60onSelectChapter%60%20%E2%80%94%20%60background%60%20is%20never%20applied%20inside%20the%20JSX.%20The%20same%20issue%20exists%20in%20%60BibleVersionPickerContent%60%20%28only%20destructures%20%60versionId%60%20%2F%20%60onSelectVersion%60%29%20and%20%60BibleReaderSettingsContent%60%20%28only%20destructures%20font-size%2Ffamily%20state%29.%20When%20a%20consumer%20renders%20these%20in%20a%20native%20bottom%20sheet%20and%20passes%20%60background%3D%22dark%22%60%2C%20no%20theming%20takes%20effect%20%E2%80%94%20the%20component%20will%20always%20render%20without%20a%20theme%20attribute%20on%20its%20wrapper.%0A%0AConsider%20either%20adding%20a%20%60data-yv-theme%60%20wrapper%20div%20keyed%20to%20%60background%60%2C%20or%20removing%20the%20prop%20from%20the%20public%20type%20until%20it's%20implemented.%0A%0A%23%23%23%20Issue%202%20of%204%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fbible-chapter-picker.tsx%3A422-431%0A**Div%20trigger%20not%20keyboard-accessible**%0A%0AWhen%20%60onContentClick%60%20is%20provided%2C%20%60BibleChapterPicker.Trigger%60%20replaces%20%60%3CPopoverTrigger%3E%60%20with%20a%20plain%20%60%3Cdiv%20onClick%3E%60.%20A%20%60%3Cdiv%3E%60%20is%20not%20in%20the%20tab%20order%20by%20default%20and%20receives%20no%20%60Enter%60%2F%60Space%60%20key%20events%2C%20so%20keyboard-only%20users%20cannot%20open%20the%20picker.%20Switch%20to%20%60%3Cbutton%20type%3D%22button%22%3E%60%20or%20add%20%60role%3D%22button%22%60%2C%20%60tabIndex%3D%7B0%7D%60%2C%20and%20an%20%60onKeyDown%60%20handler%20to%20restore%20keyboard%20accessibility.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%3Cbutton%0A%20%20%20%20%20%20%20%20type%3D%22button%22%0A%20%20%20%20%20%20%20%20data-yv-sdk%0A%20%20%20%20%20%20%20%20data-yv-theme%3D%7Btheme%7D%0A%20%20%20%20%20%20%20%20onClick%3D%7B%28%29%20%3D%3E%20onContentClick%28contentProps%29%7D%0A%20%20%20%20%20%20%20%20className%3D%22yv%3Ainline-flex%20yv%3Acursor-pointer%22%0A%20%20%20%20%20%20%3E%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fbible-version-picker.tsx%3A1380-1395%0A**Same%20div-trigger%20accessibility%20gap%20in%20%60BibleVersionPicker.Trigger%60**%0A%0AWhen%20%60onContentClick%60%20is%20set%2C%20%60BibleVersionPicker.Trigger%60%20also%20renders%20a%20%60%3Cdiv%20onClick%3E%60%20wrapper%20without%20%60role%60%2C%20%60tabIndex%60%2C%20or%20keyboard%20handlers.%20The%20same%20%60%3Cbutton%20type%3D%22button%22%3E%60%20fix%20applies%20here.%0A%0A%23%23%23%20Issue%204%20of%204%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fbible-reader.tsx%3A500-505%0A**%60_currentFontSize%60%20received%20but%20not%20rendered**%0A%0A%60currentFontSize%60%20is%20accepted%20in%20%60BibleReaderSettingsContentProps%60%20and%20destructured%20with%20an%20%60_%60%20prefix%20signalling%20intentional%20non-use%2C%20yet%20no%20current-size%20indicator%20is%20shown%20in%20the%20UI.%20If%20the%20native-sheet%20consumer%20passes%20this%20to%20synchronise%20the%20displayed%20size%20with%20the%20reader's%20state%2C%20the%20silent%20discard%20could%20leave%20the%20sheet%20UI%20out%20of%20sync.%20Either%20render%20the%20value%20%28e.g.%2C%20as%20a%20label%20between%20the%20two%20A%20buttons%29%20or%20document%20that%20it%20is%20intentionally%20unused.%0A%0A&repo=youversion%2Fplatform-sdk-react&pr=222&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fbible-chapter-picker.tsx%3A41-45%0A**%60background%60%20prop%20declared%20but%20silently%20ignored**%0A%0A%60BibleChapterPickerContentProps%60%20exposes%20a%20%60background%60%20prop%2C%20but%20the%20component%20only%20destructures%20%60versionId%60%2C%20%60defaultBook%60%2C%20and%20%60onSelectChapter%60%20%E2%80%94%20%60background%60%20is%20never%20applied%20inside%20the%20JSX.%20The%20same%20issue%20exists%20in%20%60BibleVersionPickerContent%60%20%28only%20destructures%20%60versionId%60%20%2F%20%60onSelectVersion%60%29%20and%20%60BibleReaderSettingsContent%60%20%28only%20destructures%20font-size%2Ffamily%20state%29.%20When%20a%20consumer%20renders%20these%20in%20a%20native%20bottom%20sheet%20and%20passes%20%60background%3D%22dark%22%60%2C%20no%20theming%20takes%20effect%20%E2%80%94%20the%20component%20will%20always%20render%20without%20a%20theme%20attribute%20on%20its%20wrapper.%0A%0AConsider%20either%20adding%20a%20%60data-yv-theme%60%20wrapper%20div%20keyed%20to%20%60background%60%2C%20or%20removing%20the%20prop%20from%20the%20public%20type%20until%20it's%20implemented.%0A%0A%23%23%23%20Issue%202%20of%204%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fbible-chapter-picker.tsx%3A422-431%0A**Div%20trigger%20not%20keyboard-accessible**%0A%0AWhen%20%60onContentClick%60%20is%20provided%2C%20%60BibleChapterPicker.Trigger%60%20replaces%20%60%3CPopoverTrigger%3E%60%20with%20a%20plain%20%60%3Cdiv%20onClick%3E%60.%20A%20%60%3Cdiv%3E%60%20is%20not%20in%20the%20tab%20order%20by%20default%20and%20receives%20no%20%60Enter%60%2F%60Space%60%20key%20events%2C%20so%20keyboard-only%20users%20cannot%20open%20the%20picker.%20Switch%20to%20%60%3Cbutton%20type%3D%22button%22%3E%60%20or%20add%20%60role%3D%22button%22%60%2C%20%60tabIndex%3D%7B0%7D%60%2C%20and%20an%20%60onKeyDown%60%20handler%20to%20restore%20keyboard%20accessibility.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%3Cbutton%0A%20%20%20%20%20%20%20%20type%3D%22button%22%0A%20%20%20%20%20%20%20%20data-yv-sdk%0A%20%20%20%20%20%20%20%20data-yv-theme%3D%7Btheme%7D%0A%20%20%20%20%20%20%20%20onClick%3D%7B%28%29%20%3D%3E%20onContentClick%28contentProps%29%7D%0A%20%20%20%20%20%20%20%20className%3D%22yv%3Ainline-flex%20yv%3Acursor-pointer%22%0A%20%20%20%20%20%20%3E%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fbible-version-picker.tsx%3A1380-1395%0A**Same%20div-trigger%20accessibility%20gap%20in%20%60BibleVersionPicker.Trigger%60**%0A%0AWhen%20%60onContentClick%60%20is%20set%2C%20%60BibleVersionPicker.Trigger%60%20also%20renders%20a%20%60%3Cdiv%20onClick%3E%60%20wrapper%20without%20%60role%60%2C%20%60tabIndex%60%2C%20or%20keyboard%20handlers.%20The%20same%20%60%3Cbutton%20type%3D%22button%22%3E%60%20fix%20applies%20here.%0A%0A%23%23%23%20Issue%204%20of%204%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fbible-reader.tsx%3A500-505%0A**%60_currentFontSize%60%20received%20but%20not%20rendered**%0A%0A%60currentFontSize%60%20is%20accepted%20in%20%60BibleReaderSettingsContentProps%60%20and%20destructured%20with%20an%20%60_%60%20prefix%20signalling%20intentional%20non-use%2C%20yet%20no%20current-size%20indicator%20is%20shown%20in%20the%20UI.%20If%20the%20native-sheet%20consumer%20passes%20this%20to%20synchronise%20the%20displayed%20size%20with%20the%20reader's%20state%2C%20the%20silent%20discard%20could%20leave%20the%20sheet%20UI%20out%20of%20sync.%20Either%20render%20the%20value%20%28e.g.%2C%20as%20a%20label%20between%20the%20two%20A%20buttons%29%20or%20document%20that%20it%20is%20intentionally%20unused.%0A%0A&pr=222&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
packages/ui/src/components/bible-chapter-picker.tsx:41-45
**`background` prop declared but silently ignored**

`BibleChapterPickerContentProps` exposes a `background` prop, but the component only destructures `versionId`, `defaultBook`, and `onSelectChapter` — `background` is never applied inside the JSX. The same issue exists in `BibleVersionPickerContent` (only destructures `versionId` / `onSelectVersion`) and `BibleReaderSettingsContent` (only destructures font-size/family state). When a consumer renders these in a native bottom sheet and passes `background="dark"`, no theming takes effect — the component will always render without a theme attribute on its wrapper.

Consider either adding a `data-yv-theme` wrapper div keyed to `background`, or removing the prop from the public type until it's implemented.

### Issue 2 of 4
packages/ui/src/components/bible-chapter-picker.tsx:422-431
**Div trigger not keyboard-accessible**

When `onContentClick` is provided, `BibleChapterPicker.Trigger` replaces `<PopoverTrigger>` with a plain `<div onClick>`. A `<div>` is not in the tab order by default and receives no `Enter`/`Space` key events, so keyboard-only users cannot open the picker. Switch to `<button type="button">` or add `role="button"`, `tabIndex={0}`, and an `onKeyDown` handler to restore keyboard accessibility.

```suggestion
      <button
        type="button"
        data-yv-sdk
        data-yv-theme={theme}
        onClick={() => onContentClick(contentProps)}
        className="yv:inline-flex yv:cursor-pointer"
      >
```

### Issue 3 of 4
packages/ui/src/components/bible-version-picker.tsx:1380-1395
**Same div-trigger accessibility gap in `BibleVersionPicker.Trigger`**

When `onContentClick` is set, `BibleVersionPicker.Trigger` also renders a `<div onClick>` wrapper without `role`, `tabIndex`, or keyboard handlers. The same `<button type="button">` fix applies here.

### Issue 4 of 4
packages/ui/src/components/bible-reader.tsx:500-505
**`_currentFontSize` received but not rendered**

`currentFontSize` is accepted in `BibleReaderSettingsContentProps` and destructured with an `_` prefix signalling intentional non-use, yet no current-size indicator is shown in the UI. If the native-sheet consumer passes this to synchronise the displayed size with the reader's state, the silent discard could leave the sheet UI out of sync. Either render the value (e.g., as a label between the two A buttons) or document that it is intentionally unused.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ui): extract standalone popover con..."](https://github.com/youversion/platform-sdk-react/commit/01777919905e2785f91005c44811d271b1417904) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30499550)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->