### PR TITLE
YPE-2255 - Abstract Footnote Content for React Native Expo SDK

### DIFF
--- a/.changeset/footnote-callback.md
+++ b/.changeset/footnote-callback.md
@@ -2,4 +2,4 @@
 "@youversion/platform-react-ui": minor
 ---
 
-Add `onFootnotePress` callback prop to `BibleTextView`, `Verse.Html`, and `BibleReader.Root`. When provided, suppresses the Radix popover and calls the callback with a serializable `FootnoteData` payload. Exports new `FootnoteData` type.
+Add `onFootnotePress` callback prop to `BibleTextView`, `Verse.Html`, and `BibleReader.Root`. When provided, suppresses the Radix popover and calls the callback with a serializable `FootnoteData` payload. Export `FootnoteContent` component for rendering footnote data standalone (e.g. inside an Expo DOM component). Exports new `FootnoteData` and `FootnoteContentProps` types.

--- a/.changeset/footnote-callback.md
+++ b/.changeset/footnote-callback.md
@@ -1,0 +1,5 @@
+---
+"@youversion/platform-react-ui": minor
+---
+
+Add `onFootnotePress` callback prop to `BibleTextView`, `Verse.Html`, and `BibleReader.Root`. When provided, suppresses the Radix popover and calls the callback with a serializable `FootnoteData` payload. Exports new `FootnoteData` type.

--- a/greptile.json
+++ b/greptile.json
@@ -17,7 +17,7 @@
       },
       {
         "scope": ["packages/**", ".changeset/**"],
-        "rule": "Unified versioning: All packages must maintain exact same version - never version packages independently. This change will happen automatically any time a single package is updated via changeset."
+        "rule": "Unified versioning: All packages must maintain exact same version. This change will happen automatically any time a single package is updated via changeset."
       },
       {
         "scope": ["packages/core/src/**"],

--- a/greptile.json
+++ b/greptile.json
@@ -17,7 +17,7 @@
       },
       {
         "scope": ["packages/**", ".changeset/**"],
-        "rule": "Unified versioning: All packages must maintain exact same version - never version packages independently"
+        "rule": "Unified versioning: All packages must maintain exact same version - never version packages independently. This change will happen automatically any time a single package is updated via changeset."
       },
       {
         "scope": ["packages/core/src/**"],

--- a/packages/ui/src/components/bible-reader.tsx
+++ b/packages/ui/src/components/bible-reader.tsx
@@ -28,7 +28,7 @@ import { LoaderIcon } from './icons/loader';
 import { PersonIcon } from './icons/person';
 import { Button } from './ui/button';
 import { Popover, PopoverContent, PopoverTrigger, PopoverClose } from './ui/popover';
-import { BibleTextView } from './verse';
+import { BibleTextView, type FootnoteData } from './verse';
 import { INTER_FONT, SOURCE_SERIF_FONT, type FontFamily } from '@/lib/verse-html-utils';
 import { ChevronLeftIcon } from './icons/chevron-left';
 import { ChevronRightIcon } from './icons/chevron-right';
@@ -49,6 +49,7 @@ type BibleReaderContextType = {
   lineHeight?: number;
   showVerseNumbers: boolean;
   background: 'light' | 'dark';
+  onFootnotePress?: (data: FootnoteData) => void;
 };
 
 const BibleReaderContext = createContext<BibleReaderContextType | null>(null);
@@ -76,6 +77,7 @@ export type RootProps = {
   lineHeight?: number;
   showVerseNumbers?: boolean;
   background?: 'light' | 'dark';
+  onFootnotePress?: (data: FootnoteData) => void;
   children?: ReactNode;
 };
 
@@ -98,6 +100,7 @@ function Root({
   lineHeight,
   showVerseNumbers = true,
   background,
+  onFootnotePress,
   children,
 }: RootProps) {
   const [book, setBook] = useControllableState({
@@ -171,6 +174,7 @@ function Root({
     lineHeight,
     showVerseNumbers,
     background: theme,
+    onFootnotePress,
   };
 
   return (
@@ -197,6 +201,7 @@ function Content() {
     currentFontFamily,
     lineHeight,
     showVerseNumbers,
+    onFootnotePress,
   } = useBibleReaderContext();
   const { version } = useVersion(versionId);
 
@@ -251,6 +256,7 @@ function Content() {
           lineHeight={lineHeight}
           showVerseNumbers={showVerseNumbers}
           theme={background}
+          onFootnotePress={onFootnotePress}
         />
       )}
 

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -12,7 +12,7 @@ export {
 } from './bible-version-picker';
 export { YouVersionAuthButton, type YouVersionAuthButtonProps } from './YouVersionAuthButton';
 export { VerseOfTheDay, type VerseOfTheDayProps } from './verse-of-the-day';
-export { BibleTextView, type BibleTextViewProps } from './verse';
+export { BibleTextView, type BibleTextViewProps, type FootnoteData } from './verse';
 export { BibleCard, type BibleCardProps } from './bible-card';
 export { BibleWidgetView, type BibleWidgetViewProps } from './bible-widget-view';
 export { Separator } from './ui/separator';

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -12,7 +12,13 @@ export {
 } from './bible-version-picker';
 export { YouVersionAuthButton, type YouVersionAuthButtonProps } from './YouVersionAuthButton';
 export { VerseOfTheDay, type VerseOfTheDayProps } from './verse-of-the-day';
-export { BibleTextView, type BibleTextViewProps, type FootnoteData } from './verse';
+export {
+  BibleTextView,
+  type BibleTextViewProps,
+  type FootnoteData,
+  FootnoteContent,
+  type FootnoteContentProps,
+} from './verse';
 export { BibleCard, type BibleCardProps } from './bible-card';
 export { BibleWidgetView, type BibleWidgetViewProps } from './bible-widget-view';
 export { Separator } from './ui/separator';

--- a/packages/ui/src/components/verse.test.tsx
+++ b/packages/ui/src/components/verse.test.tsx
@@ -911,7 +911,7 @@ describe('Verse.Html - onFootnotePress callback', () => {
     expect(data.notes).toHaveLength(1);
     expect(data.notes[0]).toContain('Or understood');
     expect(data.reference).toBe('JHN.1');
-    expect(typeof data.verseHtml).toBe('string');
+    expect(data.verseHtml).toContain('The light shines');
   });
 
   it('should NOT render a Popover when onFootnotePress is provided', async () => {

--- a/packages/ui/src/components/verse.test.tsx
+++ b/packages/ui/src/components/verse.test.tsx
@@ -4,7 +4,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Verse, BibleTextView, type BibleTextViewPassageState } from './verse';
+import { Verse, BibleTextView, type BibleTextViewPassageState, type FootnoteData } from './verse';
 
 // BibleTextView always calls usePassage/useTheme internally (even when passageState
 // is provided), so we must mock the hooks to avoid requiring YouVersionProvider.
@@ -875,5 +875,120 @@ describe('BibleTextView - Error messaging', () => {
         'The Bible service is having trouble right now. Please try again in a moment.',
       );
     });
+  });
+});
+
+describe('Verse.Html - onFootnotePress callback', () => {
+  const htmlWithFootnote = `
+    <div class="p">
+      <span class="yv-v" v="5"></span><span class="yv-vlbl">5</span>The light shines in the darkness<span class="yv-n f"><span class="fr">1:5 </span><span class="ft">Or understood</span></span>.
+    </div>
+  `;
+
+  it('should call onFootnotePress with correct FootnoteData when clicked', async () => {
+    const onFootnotePress = vi.fn();
+
+    const { container } = render(
+      <Verse.Html
+        html={htmlWithFootnote}
+        renderNotes={true}
+        reference="JHN.1"
+        onFootnotePress={onFootnotePress}
+      />,
+    );
+
+    const button = await waitFor(() => {
+      const btn = container.querySelector('[data-verse-footnote="5"] button');
+      expect(btn).not.toBeNull();
+      return btn as HTMLButtonElement;
+    });
+
+    await userEvent.click(button);
+
+    expect(onFootnotePress).toHaveBeenCalledTimes(1);
+    const data = onFootnotePress.mock.calls[0]![0] as FootnoteData;
+    expect(data.verseNum).toBe('5');
+    expect(data.notes).toHaveLength(1);
+    expect(data.notes[0]).toContain('Or understood');
+    expect(data.reference).toBe('JHN.1');
+    expect(typeof data.verseHtml).toBe('string');
+  });
+
+  it('should NOT render a Popover when onFootnotePress is provided', async () => {
+    const onFootnotePress = vi.fn();
+
+    const { container } = render(
+      <Verse.Html
+        html={htmlWithFootnote}
+        renderNotes={true}
+        reference="JHN.1"
+        onFootnotePress={onFootnotePress}
+      />,
+    );
+
+    const button = await waitFor(() => {
+      const btn = container.querySelector('[data-verse-footnote="5"] button');
+      expect(btn).not.toBeNull();
+      return btn as HTMLButtonElement;
+    });
+
+    await userEvent.click(button);
+
+    // No popover should appear
+    const popover = document.body.querySelector('[role="dialog"]');
+    expect(popover).toBeNull();
+  });
+
+  it('should still render Popover when onFootnotePress is NOT provided', async () => {
+    const { container } = render(
+      <Verse.Html html={htmlWithFootnote} renderNotes={true} reference="JHN.1" />,
+    );
+
+    const button = await waitFor(() => {
+      const btn = container.querySelector('[data-verse-footnote="5"] button');
+      expect(btn).not.toBeNull();
+      return btn as HTMLButtonElement;
+    });
+
+    await userEvent.click(button);
+
+    await waitFor(() => {
+      const popover = document.body.querySelector('[role="dialog"]');
+      expect(popover).not.toBeNull();
+    });
+  });
+});
+
+describe('BibleTextView - onFootnotePress callback', () => {
+  const mockPassage: BibleTextViewPassageState['passage'] = {
+    id: 'JHN.1',
+    content: `<div class="p"><span class="yv-v" v="5"></span><span class="yv-vlbl">5</span>The light shines<span class="yv-n f"><span class="fr">1:5 </span><span class="ft">Or understood</span></span>.</div>`,
+    reference: 'JHN.1',
+  };
+
+  it('should call onFootnotePress when provided via BibleTextView', async () => {
+    const onFootnotePress = vi.fn();
+
+    const { container } = render(
+      <BibleTextView
+        reference="JHN.1"
+        versionId={3034}
+        passageState={{ passage: mockPassage, loading: false, error: null }}
+        onFootnotePress={onFootnotePress}
+      />,
+    );
+
+    const button = await waitFor(() => {
+      const btn = container.querySelector('[data-verse-footnote="5"] button');
+      expect(btn).not.toBeNull();
+      return btn as HTMLButtonElement;
+    });
+
+    await userEvent.click(button);
+
+    expect(onFootnotePress).toHaveBeenCalledTimes(1);
+    const data = onFootnotePress.mock.calls[0]![0] as FootnoteData;
+    expect(data.verseNum).toBe('5');
+    expect(data.reference).toBe('JHN.1');
   });
 });

--- a/packages/ui/src/components/verse.tsx
+++ b/packages/ui/src/components/verse.tsx
@@ -41,6 +41,56 @@ export type FootnoteData = {
   reference?: string;
 };
 
+export type FootnoteContentProps = FootnoteData & {
+  fontSize?: number;
+  theme?: 'light' | 'dark';
+};
+
+export function FootnoteContent({
+  verseNum,
+  notes,
+  verseHtml,
+  reference,
+  fontSize,
+  theme,
+}: FootnoteContentProps): React.ReactElement {
+  const verseReference = reference ? `${reference}:${verseNum}` : `Verse ${verseNum}`;
+  const hasVerseContext = verseHtml.length > 0;
+
+  return (
+    <div data-yv-sdk data-yv-theme={theme}>
+      <div className="yv:p-3 yv:overflow-y-auto yv:bg-background yv:text-foreground">
+        {hasVerseContext && (
+          <>
+            <div className="yv:font-bold yv:mb-2">{verseReference}</div>
+            <div
+              className="yv:mb-3 yv:font-serif yv:*:font-serif"
+              style={{ fontSize: fontSize ? `${fontSize}px` : '1.25rem' }}
+              // biome-ignore lint/security/noDangerouslySetInnerHtml: Bible footnote HTML comes from our YouVersion APIs and is safe
+              dangerouslySetInnerHTML={{ __html: verseHtml }}
+            />
+          </>
+        )}
+        <ul className="yv:list-none yv:p-0 yv:m-0 yv:space-y-1">
+          {notes.map((note, index) => {
+            const marker = getFootnoteMarker(index);
+            return (
+              <li
+                key={marker}
+                className="yv:flex yv:gap-2 yv:text-xs yv:border-b yv:border-border yv:py-2"
+              >
+                <span>{marker}.</span>
+                {/** biome-ignore lint/security/noDangerouslySetInnerHtml: Bible footnote HTML comes from our YouVersion APIs and is safe */}
+                <span dangerouslySetInnerHTML={{ __html: note }} />
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
 type VerseFootnoteData = {
   verseNum: string;
   el: Element;

--- a/packages/ui/src/components/verse.tsx
+++ b/packages/ui/src/components/verse.tsx
@@ -156,6 +156,7 @@ const VerseFootnoteButton = memo(function VerseFootnoteButton({
   if (onFootnotePress) {
     return (
       <button
+        aria-label="Footnote"
         type="button"
         className="yv:inline-flex yv:align-middle yv:cursor-pointer yv:ml-1! yv:text-(--yv-gray-20)"
         onClick={() => onFootnotePress({ verseNum, notes, verseHtml, reference })}
@@ -170,6 +171,7 @@ const VerseFootnoteButton = memo(function VerseFootnoteButton({
     <Popover>
       <PopoverTrigger data-yv-sdk data-yv-theme={theme} asChild>
         <button
+          aria-label="Footnote"
           type="button"
           className="yv:inline-flex yv:align-middle yv:cursor-pointer yv:ml-1! yv:text-(--yv-gray-20)"
         >

--- a/packages/ui/src/components/verse.tsx
+++ b/packages/ui/src/components/verse.tsx
@@ -44,6 +44,7 @@ export type FootnoteData = {
 export type FootnoteContentProps = FootnoteData & {
   fontSize?: number;
   theme?: 'light' | 'dark';
+  hasVerseContext?: boolean;
 };
 
 export function FootnoteContent({
@@ -53,14 +54,15 @@ export function FootnoteContent({
   reference,
   fontSize,
   theme,
+  hasVerseContext,
 }: FootnoteContentProps): React.ReactElement {
   const verseReference = reference ? `${reference}:${verseNum}` : `Verse ${verseNum}`;
-  const hasVerseContext = verseHtml.length > 0;
+  const showVerseContext = hasVerseContext ?? verseHtml.length > 0;
 
   return (
     <div data-yv-sdk data-yv-theme={theme}>
       <div className="yv:p-3 yv:overflow-y-auto yv:bg-background yv:text-foreground">
-        {hasVerseContext && (
+        {showVerseContext && (
           <>
             <div className="yv:font-bold yv:mb-2">{verseReference}</div>
             <div
@@ -166,7 +168,6 @@ const VerseFootnoteButton = memo(function VerseFootnoteButton({
     );
   }
 
-  const verseReference = reference ? `${reference}:${verseNum}` : `Verse ${verseNum}`;
   return (
     <Popover>
       <PopoverTrigger data-yv-sdk data-yv-theme={theme} asChild>
@@ -183,33 +184,16 @@ const VerseFootnoteButton = memo(function VerseFootnoteButton({
         heading="Footnotes"
         theme={theme}
       >
-        <div className="yv:p-3 yv:overflow-y-auto yv:max-h-[33svh]">
-          {hasVerseContext && (
-            <>
-              <div className="yv:font-bold yv:mb-2">{verseReference}</div>
-              <div
-                className="yv:mb-3 yv:font-serif yv:*:font-serif"
-                style={{ fontSize: fontSize ? `${fontSize}px` : '1.25rem' }}
-                // biome-ignore lint/security/noDangerouslySetInnerHtml: Bible footnote HTML comes from our YouVersion APIs and is safe
-                dangerouslySetInnerHTML={{ __html: verseHtml }}
-              />
-            </>
-          )}
-          <ul className="yv:list-none yv:p-0 yv:m-0 yv:space-y-1">
-            {notes.map((note, index) => {
-              const marker = getFootnoteMarker(index);
-              return (
-                <li
-                  key={marker}
-                  className="yv:flex yv:gap-2 yv:text-xs yv:border-b yv:border-border yv:py-2"
-                >
-                  <span className="">{marker}.</span>
-                  {/** biome-ignore lint/security/noDangerouslySetInnerHtml: Bible footnote HTML comes from our YouVersion APIs and is safe */}
-                  <span dangerouslySetInnerHTML={{ __html: note }} />
-                </li>
-              );
-            })}
-          </ul>
+        <div className="yv:max-h-[33svh] yv:overflow-y-auto">
+          <FootnoteContent
+            verseNum={verseNum}
+            notes={notes}
+            verseHtml={verseHtml}
+            hasVerseContext={hasVerseContext}
+            reference={reference}
+            fontSize={fontSize}
+            theme={theme}
+          />
         </div>
       </PopoverContent>
     </Popover>

--- a/packages/ui/src/components/verse.tsx
+++ b/packages/ui/src/components/verse.tsx
@@ -34,6 +34,13 @@ function getFootnoteMarker(index: number): string {
   return marker;
 }
 
+export type FootnoteData = {
+  verseNum: string;
+  notes: string[];
+  verseHtml: string;
+  reference?: string;
+};
+
 type VerseFootnoteData = {
   verseNum: string;
   el: Element;
@@ -85,6 +92,7 @@ const VerseFootnoteButton = memo(function VerseFootnoteButton({
   reference,
   fontSize,
   theme,
+  onFootnotePress,
 }: {
   verseNum: string;
   notes: string[];
@@ -93,7 +101,20 @@ const VerseFootnoteButton = memo(function VerseFootnoteButton({
   reference?: string;
   fontSize?: number;
   theme: 'light' | 'dark';
+  onFootnotePress?: (data: FootnoteData) => void;
 }) {
+  if (onFootnotePress) {
+    return (
+      <button
+        type="button"
+        className="yv:inline-flex yv:align-middle yv:cursor-pointer yv:ml-1! yv:text-(--yv-gray-20)"
+        onClick={() => onFootnotePress({ verseNum, notes, verseHtml, reference })}
+      >
+        <Footnote className="yv:size-[1.5em]" />
+      </button>
+    );
+  }
+
   const verseReference = reference ? `${reference}:${verseNum}` : `Verse ${verseNum}`;
   return (
     <Popover>
@@ -168,6 +189,7 @@ function BibleTextHtml({
   selectedVerses = [],
   onVerseSelect,
   highlightedVerses = {},
+  onFootnotePress,
 }: {
   html: string;
   reference?: string;
@@ -176,6 +198,7 @@ function BibleTextHtml({
   selectedVerses?: number[];
   onVerseSelect?: (verses: number[]) => void;
   highlightedVerses?: Record<number, boolean>;
+  onFootnotePress?: (data: FootnoteData) => void;
 }) {
   const contentRef = useRef<HTMLDivElement>(null);
   const [footnoteData, setFootnoteData] = useState<VerseFootnoteData[]>([]);
@@ -252,6 +275,7 @@ function BibleTextHtml({
             reference={reference}
             fontSize={fontSize}
             theme={currentTheme}
+            onFootnotePress={onFootnotePress}
           />,
           el,
           `${verseNum}-${index}`,
@@ -291,6 +315,7 @@ type VerseHtmlProps = {
   selectedVerses?: number[];
   onVerseSelect?: (verses: number[]) => void;
   highlightedVerses?: Record<number, boolean>;
+  onFootnotePress?: (data: FootnoteData) => void;
 };
 
 /**
@@ -342,6 +367,7 @@ export const Verse = {
         selectedVerses,
         onVerseSelect,
         highlightedVerses,
+        onFootnotePress,
       }: VerseHtmlProps,
       ref,
     ): ReactNode => {
@@ -378,6 +404,7 @@ export const Verse = {
             selectedVerses={selectedVerses}
             onVerseSelect={onVerseSelect}
             highlightedVerses={highlightedVerses}
+            onFootnotePress={onFootnotePress}
           />
         </section>
       );
@@ -398,6 +425,7 @@ export type BibleTextViewProps = {
   onVerseSelect?: (verses: number[]) => void;
   highlightedVerses?: Record<number, boolean>;
   passageState?: Partial<BibleTextViewPassageState>;
+  onFootnotePress?: (data: FootnoteData) => void;
 };
 
 /**
@@ -418,6 +446,7 @@ export const BibleTextView = forwardRef<HTMLDivElement, BibleTextViewProps>(
       onVerseSelect,
       highlightedVerses,
       passageState,
+      onFootnotePress,
     },
     ref,
   ): React.ReactElement => {
@@ -493,6 +522,7 @@ export const BibleTextView = forwardRef<HTMLDivElement, BibleTextViewProps>(
           selectedVerses={selectedVerses}
           onVerseSelect={onVerseSelect}
           highlightedVerses={highlightedVerses}
+          onFootnotePress={onFootnotePress}
         />
       </div>
     );


### PR DESCRIPTION
https://lifechurch.atlassian.net/browse/YPE-2255

## Summary
- Adds `onFootnotePress` optional callback prop to `BibleTextView`, `Verse.Html`, and `BibleReader.Root`
- When provided, suppresses the Radix `<Popover>` and calls the callback with a serializable `FootnoteData` payload (`verseNum`, `notes`, `verseHtml`, `reference`)
- When omitted, existing popover behavior is unchanged (non-breaking)
- Exports new `FootnoteData` type from `@youversion/platform-react-ui`

This establishes the interception pattern needed for the Expo SDK to replace in-DOM popovers with native bottom sheets.

## Test plan
- [x] Existing footnote tests pass (popover unchanged when `onFootnotePress` omitted)
- [x] New test: callback fires with correct `FootnoteData` on click
- [x] New test: Popover does NOT render when `onFootnotePress` provided
- [x] New test: works through `BibleTextView` passthrough
- [x] Full monorepo test suite passes (67 UI tests, all packages green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an `onFootnotePress` optional callback to `BibleTextView`, `Verse.Html`, and `BibleReader.Root`, allowing the Expo SDK to intercept footnote taps and display them in native bottom sheets instead of Radix popovers. The existing popover path is preserved unchanged when the callback is omitted. `FootnoteContent` is extracted from the popover internals and exported as a standalone component for reuse in Expo DOM components, along with the new `FootnoteData` and `FootnoteContentProps` types.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 style suggestions with no functional regressions.

No P0 or P1 issues found. The two P2 findings (redundant overflow class inside FootnoteContent and undocumented HTML content type on `notes`) do not affect correctness or existing behavior. The change is non-breaking, well-tested (4 new tests covering all three toggled behaviors), and the prop threading through BibleReaderContext is clean.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/ui/src/components/verse.tsx | Adds `onFootnotePress` prop through `VerseFootnoteButton`, `BibleTextHtml`, `Verse.Html`, and `BibleTextView`; extracts `FootnoteContent` from the inline popover body into a standalone exported component. Two minor style findings: redundant `overflow-y-auto` inside `FootnoteContent`, and undocumented HTML type of `notes`. |
| packages/ui/src/components/bible-reader.tsx | Threads `onFootnotePress` through `BibleReaderContext` and `RootProps` into `Content`→`BibleTextView`. Clean pass-through with no issues. |
| packages/ui/src/components/index.ts | Exports `FootnoteData`, `FootnoteContent`, and `FootnoteContentProps` from `./verse`. Correct and complete. |
| packages/ui/src/components/verse.test.tsx | Adds four new tests covering callback invocation, correct `FootnoteData` payload, popover suppression, and pass-through via `BibleTextView`. First test's `verseHtml` assertion (`toContain('The light shines')`) depends on `transformBibleHtml` restructuring the fixture HTML to place footnotes inside `.yv-v` wrappers — worth noting as a pre-existing structural concern flagged in earlier review rounds. |
| .changeset/footnote-callback.md | Correctly versioned as `minor` for `@youversion/platform-react-ui`. Accurately describes all three exported symbols and the interception pattern. |
| greptile.json | Minor prose fix to the unified-versioning rule description. No functional change. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant VerseFootnoteButton
    participant Consumer

    alt onFootnotePress provided
        User->>VerseFootnoteButton: click footnote icon
        VerseFootnoteButton->>Consumer: onFootnotePress(FootnoteData)
        Note over Consumer: { verseNum, notes, verseHtml, reference }
        Consumer-->>User: show native bottom sheet (Expo SDK)
    else onFootnotePress omitted
        User->>VerseFootnoteButton: click footnote icon
        VerseFootnoteButton->>VerseFootnoteButton: open Radix Popover
        VerseFootnoteButton-->>User: show FootnoteContent in popover
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/ui/src/components/verse.tsx`, line 97-104 ([link](https://github.com/youversion/platform-sdk-react/blob/9b413cb418409736419f0ba6fd0b57bed9b0faba/packages/ui/src/components/verse.tsx#L97-L104)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`verseHtml` will be empty for nearly all real Bible content**

   `FootnoteData.verseHtml` is populated by `getVerseHtmlFromDom`, which only runs when `el.closest('.yv-v[v]') !== null` — i.e., when the footnote element is a **descendant** of a `.yv-v[v]` wrapper. In the standard YouVersion Bible HTML structure (confirmed by every test fixture in this file), `.yv-n` footnote spans are **siblings** of `.yv-v` spans, not children, so `hasVerseContext` is always `false` and `verseHtml` is always `''`.

   This means consumers using `FootnoteContent` with the payload from `onFootnotePress` will never see the verse preview block — the primary differentiator between `FootnoteContent` and a bare notes list. Consider either documenting this limitation on the `FootnoteData` type or adjusting `getVerseHtmlFromDom` to find the verse text by walking siblings of the `.yv-v` marker rather than its descendants.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/ui/src/components/verse.tsx
   Line: 97-104

   Comment:
   **`verseHtml` will be empty for nearly all real Bible content**

   `FootnoteData.verseHtml` is populated by `getVerseHtmlFromDom`, which only runs when `el.closest('.yv-v[v]') !== null` — i.e., when the footnote element is a **descendant** of a `.yv-v[v]` wrapper. In the standard YouVersion Bible HTML structure (confirmed by every test fixture in this file), `.yv-n` footnote spans are **siblings** of `.yv-v` spans, not children, so `hasVerseContext` is always `false` and `verseHtml` is always `''`.

   This means consumers using `FootnoteContent` with the payload from `onFootnotePress` will never see the verse preview block — the primary differentiator between `FootnoteContent` and a bare notes list. Consider either documenting this limitation on the `FootnoteData` type or adjusting `getVerseHtmlFromDom` to find the verse text by walking siblings of the `.yv-v` marker rather than its descendants.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fui%2Fsrc%2Fcomponents%2Fverse.tsx%0ALine%3A%2097-104%0A%0AComment%3A%0A**%60verseHtml%60%20will%20be%20empty%20for%20nearly%20all%20real%20Bible%20content**%0A%0A%60FootnoteData.verseHtml%60%20is%20populated%20by%20%60getVerseHtmlFromDom%60%2C%20which%20only%20runs%20when%20%60el.closest%28'.yv-v%5Bv%5D'%29%20!%3D%3D%20null%60%20%E2%80%94%20i.e.%2C%20when%20the%20footnote%20element%20is%20a%20**descendant**%20of%20a%20%60.yv-v%5Bv%5D%60%20wrapper.%20In%20the%20standard%20YouVersion%20Bible%20HTML%20structure%20%28confirmed%20by%20every%20test%20fixture%20in%20this%20file%29%2C%20%60.yv-n%60%20footnote%20spans%20are%20**siblings**%20of%20%60.yv-v%60%20spans%2C%20not%20children%2C%20so%20%60hasVerseContext%60%20is%20always%20%60false%60%20and%20%60verseHtml%60%20is%20always%20%60''%60.%0A%0AThis%20means%20consumers%20using%20%60FootnoteContent%60%20with%20the%20payload%20from%20%60onFootnotePress%60%20will%20never%20see%20the%20verse%20preview%20block%20%E2%80%94%20the%20primary%20differentiator%20between%20%60FootnoteContent%60%20and%20a%20bare%20notes%20list.%20Consider%20either%20documenting%20this%20limitation%20on%20the%20%60FootnoteData%60%20type%20or%20adjusting%20%60getVerseHtmlFromDom%60%20to%20find%20the%20verse%20text%20by%20walking%20siblings%20of%20the%20%60.yv-v%60%20marker%20rather%20than%20its%20descendants.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-react&pr=223&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fui%2Fsrc%2Fcomponents%2Fverse.tsx%0ALine%3A%2097-104%0A%0AComment%3A%0A**%60verseHtml%60%20will%20be%20empty%20for%20nearly%20all%20real%20Bible%20content**%0A%0A%60FootnoteData.verseHtml%60%20is%20populated%20by%20%60getVerseHtmlFromDom%60%2C%20which%20only%20runs%20when%20%60el.closest%28'.yv-v%5Bv%5D'%29%20!%3D%3D%20null%60%20%E2%80%94%20i.e.%2C%20when%20the%20footnote%20element%20is%20a%20**descendant**%20of%20a%20%60.yv-v%5Bv%5D%60%20wrapper.%20In%20the%20standard%20YouVersion%20Bible%20HTML%20structure%20%28confirmed%20by%20every%20test%20fixture%20in%20this%20file%29%2C%20%60.yv-n%60%20footnote%20spans%20are%20**siblings**%20of%20%60.yv-v%60%20spans%2C%20not%20children%2C%20so%20%60hasVerseContext%60%20is%20always%20%60false%60%20and%20%60verseHtml%60%20is%20always%20%60''%60.%0A%0AThis%20means%20consumers%20using%20%60FootnoteContent%60%20with%20the%20payload%20from%20%60onFootnotePress%60%20will%20never%20see%20the%20verse%20preview%20block%20%E2%80%94%20the%20primary%20differentiator%20between%20%60FootnoteContent%60%20and%20a%20bare%20notes%20list.%20Consider%20either%20documenting%20this%20limitation%20on%20the%20%60FootnoteData%60%20type%20or%20adjusting%20%60getVerseHtmlFromDom%60%20to%20find%20the%20verse%20text%20by%20walking%20siblings%20of%20the%20%60.yv-v%60%20marker%20rather%20than%20its%20descendants.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=223&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fverse.tsx%3A64%0A**Redundant%20%60overflow-y-auto%60%20without%20height%20constraint**%0A%0A%60FootnoteContent%60%20sets%20%60yv%3Aoverflow-y-auto%60%20on%20its%20inner%20div%2C%20but%20there%20is%20no%20%60max-h%60%20or%20fixed%20height%20on%20the%20component%20itself.%20When%20rendered%20inside%20the%20popover%2C%20the%20outer%20%60yv%3Amax-h-%5B33svh%5D%60%20wrapper%20correctly%20provides%20the%20scroll%20boundary%20%E2%80%94%20the%20inner%20%60overflow-y-auto%60%20is%20a%20no-op%20in%20that%20context.%20When%20used%20standalone%20by%20the%20Expo%20SDK%2C%20the%20consumer%20**must**%20wrap%20%60FootnoteContent%60%20in%20a%20height-constrained%20container%20for%20scroll%20to%20engage%3B%20the%20inner%20class%20alone%20won't%20provide%20it.%20Consider%20removing%20%60yv%3Aoverflow-y-auto%60%20from%20%60FootnoteContent%60%20and%20letting%20callers%20own%20scroll%2C%20or%20document%20that%20a%20height-constrained%20wrapper%20is%20required.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fverse.tsx%3A37-42%0A**%60notes%60%20contains%20HTML%20strings%20%E2%80%94%20type%20doesn't%20communicate%20this**%0A%0AThe%20%60notes%3A%20string%5B%5D%60%20in%20%60FootnoteData%60%20holds%20HTML%20fragments%20sourced%20from%20%60data-verse-footnote-content%60%20attributes%20%28set%20by%20%60transformBibleHtml%60%29.%20%60FootnoteContent%60%20renders%20them%20via%20%60dangerouslySetInnerHTML%60%2C%20which%20is%20correct%20for%20web.%20However%2C%20Expo%20SDK%20consumers%20who%20use%20the%20raw%20%60FootnoteData%60%20payload%20%28e.g.%2C%20to%20render%20in%20a%20native%20bottom%20sheet%20with%20%60Text%60%20components%29%20would%20receive%20HTML-tagged%20strings%20like%20%60%3Cspan%20class%3D%22fr%22%3E1%3A5%20%3C%2Fspan%3EOr%20understood%60%2C%20and%20would%20see%20raw%20markup%20if%20rendered%20as%20plain%20text.%20Adding%20a%20JSDoc%20note%20on%20the%20field%20%E2%80%94%20e.g.%2C%20%60%2F**%20HTML-formatted%20string%20from%20YouVersion%20API%3B%20render%20via%20dangerouslySetInnerHTML%20or%20strip%20tags%20before%20displaying%20as%20plain%20text%20*%2F%60%20%E2%80%94%20would%20prevent%20silent%20bugs%20in%20native%20consumers.%0A%0A&repo=youversion%2Fplatform-sdk-react&pr=223&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fverse.tsx%3A64%0A**Redundant%20%60overflow-y-auto%60%20without%20height%20constraint**%0A%0A%60FootnoteContent%60%20sets%20%60yv%3Aoverflow-y-auto%60%20on%20its%20inner%20div%2C%20but%20there%20is%20no%20%60max-h%60%20or%20fixed%20height%20on%20the%20component%20itself.%20When%20rendered%20inside%20the%20popover%2C%20the%20outer%20%60yv%3Amax-h-%5B33svh%5D%60%20wrapper%20correctly%20provides%20the%20scroll%20boundary%20%E2%80%94%20the%20inner%20%60overflow-y-auto%60%20is%20a%20no-op%20in%20that%20context.%20When%20used%20standalone%20by%20the%20Expo%20SDK%2C%20the%20consumer%20**must**%20wrap%20%60FootnoteContent%60%20in%20a%20height-constrained%20container%20for%20scroll%20to%20engage%3B%20the%20inner%20class%20alone%20won't%20provide%20it.%20Consider%20removing%20%60yv%3Aoverflow-y-auto%60%20from%20%60FootnoteContent%60%20and%20letting%20callers%20own%20scroll%2C%20or%20document%20that%20a%20height-constrained%20wrapper%20is%20required.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fverse.tsx%3A37-42%0A**%60notes%60%20contains%20HTML%20strings%20%E2%80%94%20type%20doesn't%20communicate%20this**%0A%0AThe%20%60notes%3A%20string%5B%5D%60%20in%20%60FootnoteData%60%20holds%20HTML%20fragments%20sourced%20from%20%60data-verse-footnote-content%60%20attributes%20%28set%20by%20%60transformBibleHtml%60%29.%20%60FootnoteContent%60%20renders%20them%20via%20%60dangerouslySetInnerHTML%60%2C%20which%20is%20correct%20for%20web.%20However%2C%20Expo%20SDK%20consumers%20who%20use%20the%20raw%20%60FootnoteData%60%20payload%20%28e.g.%2C%20to%20render%20in%20a%20native%20bottom%20sheet%20with%20%60Text%60%20components%29%20would%20receive%20HTML-tagged%20strings%20like%20%60%3Cspan%20class%3D%22fr%22%3E1%3A5%20%3C%2Fspan%3EOr%20understood%60%2C%20and%20would%20see%20raw%20markup%20if%20rendered%20as%20plain%20text.%20Adding%20a%20JSDoc%20note%20on%20the%20field%20%E2%80%94%20e.g.%2C%20%60%2F**%20HTML-formatted%20string%20from%20YouVersion%20API%3B%20render%20via%20dangerouslySetInnerHTML%20or%20strip%20tags%20before%20displaying%20as%20plain%20text%20*%2F%60%20%E2%80%94%20would%20prevent%20silent%20bugs%20in%20native%20consumers.%0A%0A&pr=223&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/ui/src/components/verse.tsx:64
**Redundant `overflow-y-auto` without height constraint**

`FootnoteContent` sets `yv:overflow-y-auto` on its inner div, but there is no `max-h` or fixed height on the component itself. When rendered inside the popover, the outer `yv:max-h-[33svh]` wrapper correctly provides the scroll boundary — the inner `overflow-y-auto` is a no-op in that context. When used standalone by the Expo SDK, the consumer **must** wrap `FootnoteContent` in a height-constrained container for scroll to engage; the inner class alone won't provide it. Consider removing `yv:overflow-y-auto` from `FootnoteContent` and letting callers own scroll, or document that a height-constrained wrapper is required.

### Issue 2 of 2
packages/ui/src/components/verse.tsx:37-42
**`notes` contains HTML strings — type doesn't communicate this**

The `notes: string[]` in `FootnoteData` holds HTML fragments sourced from `data-verse-footnote-content` attributes (set by `transformBibleHtml`). `FootnoteContent` renders them via `dangerouslySetInnerHTML`, which is correct for web. However, Expo SDK consumers who use the raw `FootnoteData` payload (e.g., to render in a native bottom sheet with `Text` components) would receive HTML-tagged strings like `<span class="fr">1:5 </span>Or understood`, and would see raw markup if rendered as plain text. Adding a JSDoc note on the field — e.g., `/** HTML-formatted string from YouVersion API; render via dangerouslySetInnerHTML or strip tags before displaying as plain text */` — would prevent silent bugs in native consumers.


`````

</details>

<sub>Reviews (7): Last reviewed commit: ["refactor(ui): use FootnoteContent in Ver..."](https://github.com/youversion/platform-sdk-react/commit/311214b9f61e1335197ada779908dc7ed48da6c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30511860)</sub>

<!-- /greptile_comment -->