### PR TITLE
YPE-2256: abstract BibleChapterPicker content + override

### DIFF
--- a/.changeset/quick-baboons-stare.md
+++ b/.changeset/quick-baboons-stare.md
@@ -1,0 +1,6 @@
+---
+"@youversion/platform-react-ui": minor
+---
+
+Export `BibleChapterPicker.Content` for standalone rendering and add `onChapterPickerPress` to intercept trigger presses (e.g. to render picker content in a native bottom sheet instead of a popover).
+

--- a/packages/hooks/vitest.config.ts
+++ b/packages/hooks/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     globals: true,
     mockReset: true,
     unstubGlobals: true,
+    exclude: ['**/dist/**', '**/node_modules/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json-summary'],

--- a/packages/ui/src/components/bible-chapter-picker.test.tsx
+++ b/packages/ui/src/components/bible-chapter-picker.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * @vitest-environment jsdom
+ */
+// We stub ResizeObserver for jsdom (used by Radix/@floating-ui). The stub methods are intentionally no-ops.
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// ResizeObserver is used by @floating-ui/dom (Radix Popover)
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+
+import { BibleChapterPicker } from './bible-chapter-picker';
+import { useBooks, useTheme } from '@youversion/platform-react-hooks';
+import type { BibleBook } from '@youversion/platform-core';
+
+vi.mock('@youversion/platform-react-hooks');
+
+const mockBooks: BibleBook[] = [
+  {
+    id: 'GEN',
+    title: 'Genesis',
+    full_title: 'The First Book of Moses, Commonly Called Genesis',
+    canon: 'old_testament',
+    abbreviation: 'Gen',
+    intro: { id: 'INTRO', passage_id: 'GEN.0.INTRO', title: 'Intro' },
+    chapters: [
+      { id: '1', title: '1', passage_id: 'GEN.1' },
+      { id: '2', title: '2', passage_id: 'GEN.2' },
+    ],
+  },
+];
+
+function setupDefaultMocks() {
+  vi.mocked(useTheme).mockReturnValue('light');
+  vi.mocked(useBooks).mockReturnValue({
+    books: { data: [...mockBooks], next_page_token: null },
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  });
+}
+
+describe('BibleChapterPicker - onChapterPickerPress override', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDefaultMocks();
+  });
+
+  it('calls onChapterPickerPress with { book, chapter, versionId } when Trigger is clicked', async () => {
+    const user = userEvent.setup();
+    const onChapterPickerPress = vi.fn();
+
+    render(
+      <BibleChapterPicker.Root
+        versionId={3034}
+        book="GEN"
+        chapter="1"
+        onChapterPickerPress={onChapterPickerPress}
+      >
+        <BibleChapterPicker.Trigger />
+      </BibleChapterPicker.Root>,
+    );
+
+    await user.click(screen.getByRole('button'));
+
+    expect(onChapterPickerPress).toHaveBeenCalledTimes(1);
+    expect(onChapterPickerPress).toHaveBeenCalledWith({
+      book: 'GEN',
+      chapter: '1',
+      versionId: 3034,
+    });
+  });
+
+  it('does NOT render popover content when onChapterPickerPress is provided', () => {
+    render(
+      <BibleChapterPicker.Root
+        versionId={3034}
+        book="GEN"
+        chapter="1"
+        onChapterPickerPress={vi.fn()}
+      >
+        <BibleChapterPicker.Trigger />
+      </BibleChapterPicker.Root>,
+    );
+
+    expect(screen.queryByText('Books')).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('Search')).not.toBeInTheDocument();
+  });
+});
+
+describe('BibleChapterPicker - default popover mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDefaultMocks();
+  });
+
+  it('renders popover content when Trigger is clicked and no override is provided', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <BibleChapterPicker.Root versionId={3034} book="GEN" chapter="1">
+        <BibleChapterPicker.Trigger />
+      </BibleChapterPicker.Root>,
+    );
+
+    await user.click(screen.getByRole('button'));
+
+    expect(await screen.findByText('Books')).toBeInTheDocument();
+    expect(await screen.findByPlaceholderText('Search')).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/bible-chapter-picker.tsx
+++ b/packages/ui/src/components/bible-chapter-picker.tsx
@@ -281,9 +281,7 @@ function Trigger({ asChild = true, children, ...props }: TriggerProps) {
 
 function Content({ onRequestClose }: BibleChapterPickerContentProps) {
   const {
-    book,
     background,
-    defaultBook,
     filteredBooks,
     expandedBook,
     setExpandedBook,
@@ -310,8 +308,7 @@ function Content({ onRequestClose }: BibleChapterPickerContentProps) {
         className="yv:relative yv:overflow-y-auto yv:bg-background yv:px-6"
         type="single"
         collapsible
-        defaultValue={defaultBook || book || 'GEN'}
-        value={expandedBook ?? undefined}
+        value={expandedBook ?? ''}
         onValueChange={(value) => setExpandedBook(value || null)}
       >
         {filteredBooks && filteredBooks.length > 0 ? (

--- a/packages/ui/src/components/bible-chapter-picker.tsx
+++ b/packages/ui/src/components/bible-chapter-picker.tsx
@@ -1,10 +1,14 @@
+'use client';
+
 import {
+  cloneElement,
   createContext,
+  isValidElement,
   useContext,
-  useState,
   useEffect,
   useMemo,
   useRef,
+  useState,
   type ReactNode,
 } from 'react';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
@@ -13,9 +17,19 @@ import { type BibleBook } from '@youversion/platform-core';
 import { InfoIcon } from './icons/info';
 import { SearchIcon } from './icons/search';
 import { Button } from './ui/button';
-import { Popover, PopoverTrigger, PopoverContent, PopoverClose } from './ui/popover';
+import { Popover, PopoverContent, PopoverTrigger } from './ui/popover';
 import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from './ui/accordion';
 import { InputGroup, InputGroupInput, InputGroupAddon } from './ui/input-group';
+
+export interface BibleChapterPickerPressData {
+  book: string;
+  chapter: string;
+  versionId: number;
+}
+
+export type BibleChapterPickerContentProps = {
+  onRequestClose?: () => void;
+};
 
 type BibleChapterPickerContextType = {
   book: string;
@@ -25,6 +39,14 @@ type BibleChapterPickerContextType = {
   versionId: number;
   background: 'light' | 'dark';
   scrollToCurrentBook: () => void;
+  defaultBook: string;
+  searchQuery: string;
+  setSearchQuery: (query: string) => void;
+  expandedBook: string | null;
+  setExpandedBook: (bookId: string | null) => void;
+  filteredBooks: BibleBook[] | null;
+  registerBookElement: (bookId: string, node: HTMLDivElement | null) => void;
+  onChapterPickerPress?: (data: BibleChapterPickerPressData) => void;
 };
 
 const BibleChapterPickerContext = createContext<BibleChapterPickerContextType | null>(null);
@@ -46,6 +68,7 @@ export type RootProps = {
   onChapterChange?: (chapter: string) => void;
   versionId: number;
   background?: 'light' | 'dark';
+  onChapterPickerPress?: (data: BibleChapterPickerPressData) => void;
   children?: ReactNode;
 };
 
@@ -60,6 +83,7 @@ function Root({
   onChapterChange,
   versionId,
   background,
+  onChapterPickerPress,
   children,
 }: RootProps) {
   const [book, setBook] = useControllableState({
@@ -77,6 +101,7 @@ function Root({
   const providerTheme = useTheme();
   const theme = background || providerTheme;
 
+  const [isPopoverOpen, setIsPopoverOpenRaw] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [expandedBook, setExpandedBook] = useState<string | null>(book || null);
 
@@ -91,6 +116,14 @@ function Root({
   }, [books?.data, searchQuery]);
 
   const bookElementsRef = useRef<Record<string, HTMLDivElement | null>>({});
+
+  const registerBookElement = (bookId: string, node: HTMLDivElement | null) => {
+    if (node) {
+      bookElementsRef.current[bookId] = node;
+    } else {
+      delete bookElementsRef.current[bookId];
+    }
+  };
 
   const scrollToCurrentBook = () => {
     if (book) {
@@ -124,122 +157,43 @@ function Root({
     };
   }, [expandedBook]);
 
-  const handleChapterButtonClick = (bookId: string, passageId: string) => {
-    const chapterId = passageId.split('.').pop() || '';
-    if (chapterId && bookId) {
-      setBook(bookId);
-      setChapter(chapterId);
+  const setIsPopoverOpen = (open: boolean) => {
+    setIsPopoverOpenRaw(open);
+    if (!open) {
       setSearchQuery('');
     }
   };
 
-  return (
-    <Popover>
-      <BibleChapterPickerContext.Provider
-        value={{
-          book,
-          chapter,
-          setBook,
-          setChapter,
-          versionId,
-          background: theme,
-          scrollToCurrentBook,
-        }}
-      >
+  const contextValue: BibleChapterPickerContextType = {
+    book,
+    chapter,
+    setBook,
+    setChapter,
+    versionId,
+    background: theme,
+    scrollToCurrentBook,
+    defaultBook,
+    searchQuery,
+    setSearchQuery,
+    expandedBook,
+    setExpandedBook,
+    filteredBooks,
+    registerBookElement,
+    onChapterPickerPress,
+  };
+
+  return onChapterPickerPress ? (
+    <BibleChapterPickerContext.Provider value={contextValue}>
+      {children}
+    </BibleChapterPickerContext.Provider>
+  ) : (
+    <Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
+      <BibleChapterPickerContext.Provider value={contextValue}>
         {children}
 
         {/* data-yv-sdk for styles is needed because the popover gets rendered outside of the providers scope **/}
         <PopoverContent sideOffset={16} heading="Books" theme={theme} side="top">
-          <Accordion
-            className="yv:relative yv:overflow-y-auto yv:bg-background yv:px-6"
-            type="single"
-            collapsible
-            defaultValue={defaultBook || book || 'GEN'}
-            onValueChange={setExpandedBook}
-          >
-            {filteredBooks && filteredBooks.length > 0 ? (
-              filteredBooks.map((bookItem) => (
-                <AccordionItem
-                  className="yv:border-b yv:border-border"
-                  key={bookItem.id}
-                  value={bookItem.id}
-                  id={bookItem.id}
-                  ref={(node) => {
-                    if (node) {
-                      bookElementsRef.current[bookItem.id] = node;
-                    } else {
-                      delete bookElementsRef.current[bookItem.id];
-                    }
-                  }}
-                >
-                  <AccordionTrigger className="yv:rounded-none">{bookItem.title}</AccordionTrigger>
-                  <AccordionContent>
-                    {bookItem.chapters && bookItem.chapters.length > 0 ? (
-                      <div className="yv:grid yv:grid-cols-5 yv:gap-2">
-                        {bookItem.intro?.id && bookItem.intro?.passage_id ? (
-                          <PopoverClose asChild key={`${bookItem.id}-${bookItem.intro.passage_id}`}>
-                            <Button
-                              variant="secondary"
-                              size="icon"
-                              className="yv:aspect-square yv:w-full yv:h-full yv:flex yv:items-center yv:justify-center yv:rounded-[4px]"
-                              onClick={() =>
-                                handleChapterButtonClick(
-                                  bookItem.id,
-                                  bookItem.intro?.passage_id || '',
-                                )
-                              }
-                            >
-                              <InfoIcon />
-                            </Button>
-                          </PopoverClose>
-                        ) : null}
-                        {bookItem.chapters.map((chapterRef) => {
-                          const chapterId = chapterRef.passage_id.split('.').pop() || '';
-                          return (
-                            <PopoverClose asChild key={`${bookItem.id}-${chapterRef.passage_id}`}>
-                              <Button
-                                variant="secondary"
-                                size="icon"
-                                className="yv:aspect-square yv:w-full yv:h-full yv:flex yv:items-center yv:justify-center yv:rounded-[4px]"
-                                onClick={() =>
-                                  handleChapterButtonClick(bookItem.id, chapterRef.passage_id)
-                                }
-                              >
-                                {chapterId}
-                              </Button>
-                            </PopoverClose>
-                          );
-                        })}
-                      </div>
-                    ) : (
-                      <div className="yv:w-full yv:flex yv:items-center yv:justify-center yv:py-4 yv:text-muted-foreground yv:text-sm">
-                        No chapters available
-                      </div>
-                    )}
-                  </AccordionContent>
-                </AccordionItem>
-              ))
-            ) : (
-              <div className="yv:w-full yv:h-full yv:flex yv:items-center yv:justify-center yv:py-4 yv:text-center yv:text-balance yv:text-muted-foreground yv:text-sm">
-                We're sorry, there are no Bible results for this search.
-              </div>
-            )}
-          </Accordion>
-
-          <section className="yv:bg-muted yv:border-s yv:border-muted yv:p-4 yv:w-full">
-            <InputGroup className="yv:rounded-3xl yv:bg-background yv:shadow-none yv:border-border">
-              <InputGroupInput
-                tabIndex={1}
-                type="text"
-                placeholder="Search"
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-              />
-              <InputGroupAddon align="inline-start">
-                <SearchIcon className="yv:size-5 yv:text-muted-foreground" />
-              </InputGroupAddon>
-            </InputGroup>
-          </section>
+          <Content onRequestClose={() => setIsPopoverOpen(false)} />
         </PopoverContent>
       </BibleChapterPickerContext.Provider>
     </Popover>
@@ -261,7 +215,7 @@ export type TriggerProps = Omit<React.ComponentProps<typeof PopoverTrigger>, 'ch
 };
 
 function Trigger({ asChild = true, children, ...props }: TriggerProps) {
-  const { book, chapter, background, versionId, scrollToCurrentBook } =
+  const { book, chapter, background, versionId, scrollToCurrentBook, onChapterPickerPress } =
     useBibleChapterPickerContext();
   const { books, loading } = useBooks(versionId);
   const providerTheme = useTheme();
@@ -282,17 +236,158 @@ function Trigger({ asChild = true, children, ...props }: TriggerProps) {
       ? children({ book, chapter, chapterLabel, currentBook, loading })
       : children || <Button variant="secondary">{buttonText}</Button>;
 
+  const handlePress = (event: React.MouseEvent<HTMLButtonElement>) => {
+    props.onClick?.(event);
+    scrollToCurrentBook();
+    if (onChapterPickerPress) {
+      onChapterPickerPress({ book, chapter, versionId });
+    }
+  };
+
+  if (onChapterPickerPress) {
+    if (asChild && isValidElement<Record<string, unknown>>(content)) {
+      return cloneElement(content, {
+        'data-yv-sdk': true,
+        'data-yv-theme': theme,
+        ...props,
+        onClick: handlePress,
+      });
+    }
+
+    return (
+      <button type="button" data-yv-sdk data-yv-theme={theme} {...props} onClick={handlePress}>
+        {content}
+      </button>
+    );
+  }
+
+  const handleOpenPopover = (event: React.MouseEvent<HTMLButtonElement>) => {
+    props.onClick?.(event);
+    scrollToCurrentBook();
+  };
+
   return (
     <PopoverTrigger
       data-yv-sdk
       data-yv-theme={theme}
       asChild={asChild}
-      onClick={scrollToCurrentBook}
       {...props}
+      onClick={handleOpenPopover}
     >
       {content}
     </PopoverTrigger>
   );
 }
 
-export const BibleChapterPicker = Object.assign({}, { Root, Trigger });
+function Content({ onRequestClose }: BibleChapterPickerContentProps) {
+  const {
+    book,
+    background,
+    defaultBook,
+    filteredBooks,
+    expandedBook,
+    setExpandedBook,
+    searchQuery,
+    setSearchQuery,
+    registerBookElement,
+    setBook,
+    setChapter,
+  } = useBibleChapterPickerContext();
+
+  const handleChapterButtonClick = (bookId: string, passageId: string) => {
+    const chapterId = passageId.split('.').pop() || '';
+    if (chapterId && bookId) {
+      setBook(bookId);
+      setChapter(chapterId);
+      setSearchQuery('');
+      onRequestClose?.();
+    }
+  };
+
+  return (
+    <div data-yv-sdk data-yv-theme={background}>
+      <Accordion
+        className="yv:relative yv:overflow-y-auto yv:bg-background yv:px-6"
+        type="single"
+        collapsible
+        defaultValue={defaultBook || book || 'GEN'}
+        value={expandedBook ?? undefined}
+        onValueChange={(value) => setExpandedBook(value || null)}
+      >
+        {filteredBooks && filteredBooks.length > 0 ? (
+          filteredBooks.map((bookItem) => (
+            <AccordionItem
+              className="yv:border-b yv:border-border"
+              key={bookItem.id}
+              value={bookItem.id}
+              id={bookItem.id}
+              ref={(node) => registerBookElement(bookItem.id, node)}
+            >
+              <AccordionTrigger className="yv:rounded-none">{bookItem.title}</AccordionTrigger>
+              <AccordionContent>
+                {bookItem.chapters && bookItem.chapters.length > 0 ? (
+                  <div className="yv:grid yv:grid-cols-5 yv:gap-2">
+                    {bookItem.intro?.id && bookItem.intro?.passage_id ? (
+                      <Button
+                        key={`${bookItem.id}-${bookItem.intro.passage_id}`}
+                        variant="secondary"
+                        size="icon"
+                        className="yv:aspect-square yv:w-full yv:h-full yv:flex yv:items-center yv:justify-center yv:rounded-[4px]"
+                        onClick={() =>
+                          handleChapterButtonClick(bookItem.id, bookItem.intro?.passage_id || '')
+                        }
+                      >
+                        <InfoIcon />
+                      </Button>
+                    ) : null}
+                    {bookItem.chapters.map((chapterRef) => {
+                      const chapterId = chapterRef.passage_id.split('.').pop() || '';
+                      return (
+                        <Button
+                          key={`${bookItem.id}-${chapterRef.passage_id}`}
+                          variant="secondary"
+                          size="icon"
+                          className="yv:aspect-square yv:w-full yv:h-full yv:flex yv:items-center yv:justify-center yv:rounded-[4px]"
+                          onClick={() =>
+                            handleChapterButtonClick(bookItem.id, chapterRef.passage_id)
+                          }
+                        >
+                          {chapterId}
+                        </Button>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <div className="yv:w-full yv:flex yv:items-center yv:justify-center yv:py-4 yv:text-muted-foreground yv:text-sm">
+                    No chapters available
+                  </div>
+                )}
+              </AccordionContent>
+            </AccordionItem>
+          ))
+        ) : (
+          <div className="yv:w-full yv:h-full yv:flex yv:items-center yv:justify-center yv:py-4 yv:text-center yv:text-balance yv:text-muted-foreground yv:text-sm">
+            We're sorry, there are no Bible results for this search.
+          </div>
+        )}
+      </Accordion>
+
+      <section className="yv:bg-muted yv:border-s yv:border-muted yv:p-4 yv:w-full">
+        <InputGroup className="yv:rounded-3xl yv:bg-background yv:shadow-none yv:border-border">
+          <InputGroupInput
+            tabIndex={1}
+            type="text"
+            placeholder="Search"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+          />
+          <InputGroupAddon align="inline-start">
+            <SearchIcon className="yv:size-5 yv:text-muted-foreground" />
+          </InputGroupAddon>
+        </InputGroup>
+      </section>
+    </div>
+  );
+}
+
+export const BibleChapterPicker = Object.assign({}, { Root, Trigger, Content });

--- a/packages/ui/src/components/bible-chapter-picker.tsx
+++ b/packages/ui/src/components/bible-chapter-picker.tsx
@@ -282,7 +282,6 @@ function Trigger({ asChild = true, children, ...props }: TriggerProps) {
 
 function Content({ onRequestClose }: BibleChapterPickerContentProps) {
   const {
-    background,
     filteredBooks,
     expandedBook,
     setExpandedBook,
@@ -304,7 +303,7 @@ function Content({ onRequestClose }: BibleChapterPickerContentProps) {
   };
 
   return (
-    <div data-yv-sdk data-yv-theme={background}>
+    <>
       <Accordion
         className="yv:relative yv:overflow-y-auto yv:bg-background yv:px-6"
         type="single"
@@ -384,7 +383,7 @@ function Content({ onRequestClose }: BibleChapterPickerContentProps) {
           </InputGroupAddon>
         </InputGroup>
       </section>
-    </div>
+    </>
   );
 }
 

--- a/packages/ui/src/components/bible-chapter-picker.tsx
+++ b/packages/ui/src/components/bible-chapter-picker.tsx
@@ -129,10 +129,13 @@ function Root({
     if (book) {
       setExpandedBook(book);
       setTimeout(() => {
-        bookElementsRef.current[book]?.scrollIntoView({
-          behavior: 'smooth',
-          block: 'start',
-        });
+        const element = bookElementsRef.current[book];
+        if (element && typeof element.scrollIntoView === 'function') {
+          element.scrollIntoView({
+            behavior: 'smooth',
+            block: 'start',
+          });
+        }
       }, 200);
     }
   };
@@ -144,10 +147,13 @@ function Root({
     const controller = new AbortController();
     const timeoutId = setTimeout(() => {
       if (!controller.signal.aborted) {
-        bookElementsRef.current[expandedBook]?.scrollIntoView({
-          behavior: 'smooth',
-          block: 'start',
-        });
+        const element = bookElementsRef.current[expandedBook];
+        if (element && typeof element.scrollIntoView === 'function') {
+          element.scrollIntoView({
+            behavior: 'smooth',
+            block: 'start',
+          });
+        }
       }
     }, 200);
 
@@ -238,10 +244,9 @@ function Trigger({ asChild = true, children, ...props }: TriggerProps) {
 
   const handlePress = (event: React.MouseEvent<HTMLButtonElement>) => {
     props.onClick?.(event);
+    scrollToCurrentBook();
     if (onChapterPickerPress) {
       onChapterPickerPress({ book, chapter, versionId });
-    } else {
-      scrollToCurrentBook();
     }
   };
 
@@ -282,6 +287,8 @@ function Trigger({ asChild = true, children, ...props }: TriggerProps) {
 
 function Content({ onRequestClose }: BibleChapterPickerContentProps) {
   const {
+    book,
+    defaultBook,
     filteredBooks,
     expandedBook,
     setExpandedBook,
@@ -308,7 +315,8 @@ function Content({ onRequestClose }: BibleChapterPickerContentProps) {
         className="yv:relative yv:overflow-y-auto yv:bg-background yv:px-6"
         type="single"
         collapsible
-        value={expandedBook ?? ''}
+        defaultValue={defaultBook || book || 'GEN'}
+        value={expandedBook ?? undefined}
         onValueChange={(value) => setExpandedBook(value || null)}
       >
         {filteredBooks && filteredBooks.length > 0 ? (

--- a/packages/ui/src/components/bible-chapter-picker.tsx
+++ b/packages/ui/src/components/bible-chapter-picker.tsx
@@ -238,9 +238,10 @@ function Trigger({ asChild = true, children, ...props }: TriggerProps) {
 
   const handlePress = (event: React.MouseEvent<HTMLButtonElement>) => {
     props.onClick?.(event);
-    scrollToCurrentBook();
     if (onChapterPickerPress) {
       onChapterPickerPress({ book, chapter, versionId });
+    } else {
+      scrollToCurrentBook();
     }
   };
 

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -3,6 +3,8 @@ export {
   type RootProps,
   type BibleChapterPickerRootProps,
   type TriggerProps,
+  type BibleChapterPickerContentProps,
+  type BibleChapterPickerPressData,
 } from './bible-chapter-picker';
 export { BibleReader, type BibleReaderRootProps } from './bible-reader';
 export {


### PR DESCRIPTION
## Summary
- Export `BibleChapterPicker.Content` for standalone rendering (Expo DOM / native sheet).
- Add `onChapterPickerPress` to intercept trigger presses and suppress popover.
- Add unit tests and a changeset for `@youversion/platform-react-ui`.

## Test plan
- `pnpm --filter @youversion/platform-react-ui test`

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts the book-list and search UI into a standalone `BibleChapterPicker.Content` component and adds an `onChapterPickerPress` prop to `Root` that intercepts trigger presses and suppresses the built-in Popover, enabling consumers to render the picker inside a native bottom sheet or Expo DOM component.

- **`Content` extraction**: book accordion, chapter buttons, and search input are moved from an inline `PopoverContent` render into a reusable `Content` component that accepts an optional `onRequestClose` callback; popover mode passes `() => setIsPopoverOpen(false)`, standalone mode omits it.
- **`onChapterPickerPress` override**: when set on `Root`, the `Trigger` renders a plain `button` (or `cloneElement` for `asChild`) and calls the callback with `{ book, chapter, versionId }` instead of opening the Popover.
- **New exports**: `BibleChapterPicker.Content`, `BibleChapterPickerContentProps`, and `BibleChapterPickerPressData` are exported from the package index; a minor changeset is included.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the refactor is well-scoped, the existing popover path is preserved faithfully, and the new standalone path is exercised by the added tests.

The core popover flow is unchanged in behavior; `Content` is a mechanical extraction of the same JSX that was previously inlined. The override path is additive and guarded by a simple conditional. No data-loss or broken-contract scenarios were found in the changed code paths.

packages/ui/src/components/bible-chapter-picker.tsx — the untracked `setTimeout` in `scrollToCurrentBook` is worth addressing before this becomes a source of multiple simultaneous scroll attempts.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/bible-chapter-picker.tsx | Major refactor: extracts book-list/search UI into a standalone `Content` component, adds `onChapterPickerPress` override path that bypasses the Popover, and exposes `Content` on the `BibleChapterPicker` namespace. One new finding: untracked timer in `scrollToCurrentBook`. |
| packages/ui/src/components/bible-chapter-picker.test.tsx | New test file covering `onChapterPickerPress` callback args, popover suppression when override is set, and default popover-open behaviour; ResizeObserver is correctly stubbed for jsdom. |
| packages/ui/src/components/index.ts | Exports the two new public types (`BibleChapterPickerContentProps`, `BibleChapterPickerPressData`) alongside existing exports. |
| .changeset/quick-baboons-stare.md | Minor-version changeset for `@youversion/platform-react-ui` describing the new `Content` export and `onChapterPickerPress` addition. |
| packages/hooks/vitest.config.ts | Adds `exclude` for `dist` and `node_modules` to the hooks package vitest config to prevent built artifacts from being picked up by the test runner. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User clicks Trigger] --> B{onChapterPickerPress set on Root?}
    B -- Yes --> C[handlePress called]
    C --> D[props.onClick fired]
    D --> E[scrollToCurrentBook called]
    E --> F[onChapterPickerPress callback called with book/chapter/versionId]
    F --> G[Consumer renders native sheet / Expo DOM]
    G --> H[BibleChapterPicker.Content rendered standalone]
    H --> I{User selects chapter}
    I --> J[setBook + setChapter, setSearchQuery cleared, onRequestClose called]
    B -- No --> K[handleOpenPopover called]
    K --> L[props.onClick fired]
    L --> M[scrollToCurrentBook called]
    M --> N[Popover opens, Content rendered inside PopoverContent]
    N --> O{User selects chapter}
    O --> P[setBook + setChapter, setSearchQuery cleared, setIsPopoverOpen false]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fbible-chapter-picker.tsx%3A128-141%0AThe%20timer%20returned%20by%20%60setTimeout%60%20inside%20%60scrollToCurrentBook%60%20is%20never%20stored%2C%20so%20it%20cannot%20be%20cancelled%20before%20the%20next%20call.%20If%20the%20user%20clicks%20the%20trigger%20in%20quick%20succession%2C%20multiple%20200%20ms%20timers%20accumulate%20and%20all%20fire%2C%20each%20calling%20%60scrollIntoView%60.%20The%20%60useEffect%60%20block%20just%20below%20this%20function%20correctly%20uses%20%60clearTimeout%60%20to%20cancel%20the%20previous%20timer%20%E2%80%94%20the%20same%20pattern%20should%20be%20applied%20here%20using%20a%20ref.%0A%0A%60%60%60suggestion%0A%20%20const%20scrollToCurrentBookTimerRef%20%3D%20useRef%3CReturnType%3Ctypeof%20setTimeout%3E%20%7C%20null%3E%28null%29%3B%0A%0A%20%20const%20scrollToCurrentBook%20%3D%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20if%20%28book%29%20%7B%0A%20%20%20%20%20%20setExpandedBook%28book%29%3B%0A%20%20%20%20%20%20if%20%28scrollToCurrentBookTimerRef.current%20!%3D%3D%20null%29%20%7B%0A%20%20%20%20%20%20%20%20clearTimeout%28scrollToCurrentBookTimerRef.current%29%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20scrollToCurrentBookTimerRef.current%20%3D%20setTimeout%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20scrollToCurrentBookTimerRef.current%20%3D%20null%3B%0A%20%20%20%20%20%20%20%20const%20element%20%3D%20bookElementsRef.current%5Bbook%5D%3B%0A%20%20%20%20%20%20%20%20if%20%28element%20%26%26%20typeof%20element.scrollIntoView%20%3D%3D%3D%20'function'%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20element.scrollIntoView%28%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20behavior%3A%20'smooth'%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20block%3A%20'start'%2C%0A%20%20%20%20%20%20%20%20%20%20%7D%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%2C%20200%29%3B%0A%20%20%20%20%7D%0A%20%20%7D%3B%0A%60%60%60%0A%0A&repo=youversion%2Fplatform-sdk-react&pr=225&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fbible-chapter-picker.tsx%3A128-141%0AThe%20timer%20returned%20by%20%60setTimeout%60%20inside%20%60scrollToCurrentBook%60%20is%20never%20stored%2C%20so%20it%20cannot%20be%20cancelled%20before%20the%20next%20call.%20If%20the%20user%20clicks%20the%20trigger%20in%20quick%20succession%2C%20multiple%20200%20ms%20timers%20accumulate%20and%20all%20fire%2C%20each%20calling%20%60scrollIntoView%60.%20The%20%60useEffect%60%20block%20just%20below%20this%20function%20correctly%20uses%20%60clearTimeout%60%20to%20cancel%20the%20previous%20timer%20%E2%80%94%20the%20same%20pattern%20should%20be%20applied%20here%20using%20a%20ref.%0A%0A%60%60%60suggestion%0A%20%20const%20scrollToCurrentBookTimerRef%20%3D%20useRef%3CReturnType%3Ctypeof%20setTimeout%3E%20%7C%20null%3E%28null%29%3B%0A%0A%20%20const%20scrollToCurrentBook%20%3D%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20if%20%28book%29%20%7B%0A%20%20%20%20%20%20setExpandedBook%28book%29%3B%0A%20%20%20%20%20%20if%20%28scrollToCurrentBookTimerRef.current%20!%3D%3D%20null%29%20%7B%0A%20%20%20%20%20%20%20%20clearTimeout%28scrollToCurrentBookTimerRef.current%29%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20scrollToCurrentBookTimerRef.current%20%3D%20setTimeout%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20scrollToCurrentBookTimerRef.current%20%3D%20null%3B%0A%20%20%20%20%20%20%20%20const%20element%20%3D%20bookElementsRef.current%5Bbook%5D%3B%0A%20%20%20%20%20%20%20%20if%20%28element%20%26%26%20typeof%20element.scrollIntoView%20%3D%3D%3D%20'function'%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20element.scrollIntoView%28%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20behavior%3A%20'smooth'%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20block%3A%20'start'%2C%0A%20%20%20%20%20%20%20%20%20%20%7D%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%2C%20200%29%3B%0A%20%20%20%20%7D%0A%20%20%7D%3B%0A%60%60%60%0A%0A&pr=225&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/ui/src/components/bible-chapter-picker.tsx:128-141
The timer returned by `setTimeout` inside `scrollToCurrentBook` is never stored, so it cannot be cancelled before the next call. If the user clicks the trigger in quick succession, multiple 200 ms timers accumulate and all fire, each calling `scrollIntoView`. The `useEffect` block just below this function correctly uses `clearTimeout` to cancel the previous timer — the same pattern should be applied here using a ref.

```suggestion
  const scrollToCurrentBookTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);

  const scrollToCurrentBook = () => {
    if (book) {
      setExpandedBook(book);
      if (scrollToCurrentBookTimerRef.current !== null) {
        clearTimeout(scrollToCurrentBookTimerRef.current);
      }
      scrollToCurrentBookTimerRef.current = setTimeout(() => {
        scrollToCurrentBookTimerRef.current = null;
        const element = bookElementsRef.current[book];
        if (element && typeof element.scrollIntoView === 'function') {
          element.scrollIntoView({
            behavior: 'smooth',
            block: 'start',
          });
        }
      }, 200);
    }
  };
```

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["Fix scrolling and default book in Bible ..."](https://github.com/youversion/platform-sdk-react/commit/de4d87f2d90b8ddbd8fad3a2b003dde23c3db627) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30877414)</sub>

**Context used:**

- Rule used - Always invalidate existing timers before creating ... ([source](https://app.greptile.com/review/custom-context?memory=fa2b0c84-c84e-482b-a0c8-aa52b576f3cc))

**Learned From**
[lifechurch/youversion/user-applications/mobile/bible-ios#4801](https://gitlab.com/lifechurch/youversion/user-applications/mobile/bible-ios/-/merge_requests/4801)

<!-- /greptile_comment -->