### PR TITLE
feat(ui): abstract Bible reader theme settings for RN

### DIFF
--- a/.changeset/reader-theme-settings-rn.md
+++ b/.changeset/reader-theme-settings-rn.md
@@ -2,4 +2,4 @@
 '@youversion/platform-react-ui': minor
 ---
 
-Expose `BibleThemeSettingsContent` and add optional `onOpenBibleThemeSettings` on `BibleReader.Toolbar` so hosts (e.g. React Native) can open native settings UI while applying font changes through the same semantic actions as the web reader.
+Expose `BibleThemeSettingsContent` and add optional `onOpenBibleThemeSettings` on `BibleReader.Toolbar` with a **serializable** `BibleThemeSettingsSnapshot` payload for Expo DOM hosts. Export `BIBLE_READER_FONT`, `clampBibleReaderFontSize`, `nextBibleReaderFontSizeUp`, and `nextBibleReaderFontSizeDown` so native can apply edits without closure payloads. Add optional controlled typography on `BibleReader.Root` via `fontSize`/`fontFamily` with `onFontSizeChange`/`onFontFamilyChange` (and `defaultFontSize` / `defaultFontFamily` for defaults).

--- a/.changeset/reader-theme-settings-rn.md
+++ b/.changeset/reader-theme-settings-rn.md
@@ -1,0 +1,5 @@
+---
+'@youversion/platform-react-ui': minor
+---
+
+Expose `BibleThemeSettingsContent` and add optional `onOpenBibleThemeSettings` on `BibleReader.Toolbar` so hosts (e.g. React Native) can open native settings UI while applying font changes through the same semantic actions as the web reader.

--- a/packages/ui/src/components/bible-reader.stories.tsx
+++ b/packages/ui/src/components/bible-reader.stories.tsx
@@ -114,16 +114,16 @@ export const Default: Story = {
     await userEvent.click(increaseFontButton);
     await expect(localStorage.getItem('youversion-platform:reader:font-size')).toBe('18');
     await userEvent.click(increaseFontButton);
-    await userEvent.click(increaseFontButton);
     await expect(localStorage.getItem('youversion-platform:reader:font-size')).toBe('20');
+    await expect(increaseFontButton).toBeDisabled();
 
     await userEvent.click(decreaseFontButton);
     await userEvent.click(decreaseFontButton);
     await expect(localStorage.getItem('youversion-platform:reader:font-size')).toBe('16');
     await userEvent.click(decreaseFontButton);
     await userEvent.click(decreaseFontButton);
-    await userEvent.click(decreaseFontButton);
     await expect(localStorage.getItem('youversion-platform:reader:font-size')).toBe('12');
+    await expect(decreaseFontButton).toBeDisabled();
 
     const interButton = screen.getByRole('button', { name: /inter/i });
     const sourceSerifButton = screen.getByRole('button', { name: /source serif/i });

--- a/packages/ui/src/components/bible-reader.test.tsx
+++ b/packages/ui/src/components/bible-reader.test.tsx
@@ -141,6 +141,9 @@ describe('createBibleThemeSettingsContentHandlers', () => {
     handlers.onFontIncreased();
     expect(setFontSize).toHaveBeenCalledWith(18);
 
+    handlers.onFontDecreased();
+    expect(setFontSize).toHaveBeenLastCalledWith(16);
+
     handlers.onFontSelected(INTER_FONT);
     expect(setFontFamily).toHaveBeenCalledWith(INTER_FONT);
   });

--- a/packages/ui/src/components/bible-reader.test.tsx
+++ b/packages/ui/src/components/bible-reader.test.tsx
@@ -6,6 +6,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
 import type { BibleBook, BibleVersion, Language } from '@youversion/platform-core';
 import {
   useBooks,
@@ -16,8 +17,15 @@ import {
   useVersion,
   useVersions,
 } from '@youversion/platform-react-hooks';
-import { BibleReader, type BibleThemeSettingsData } from './bible-reader';
-import { INTER_FONT, SOURCE_SERIF_FONT } from '@/lib/verse-html-utils';
+import {
+  BibleReader,
+  clampBibleReaderFontSize,
+  createBibleThemeSettingsContentHandlers,
+  nextBibleReaderFontSizeDown,
+  nextBibleReaderFontSizeUp,
+  type BibleThemeSettingsSnapshot,
+} from './bible-reader';
+import { INTER_FONT, SOURCE_SERIF_FONT, type FontFamily } from '@/lib/verse-html-utils';
 
 class ResizeObserverMock {
   observe() {}
@@ -97,6 +105,47 @@ function setupDefaultMocks() {
   vi.mocked(useFilteredVersions).mockReturnValue([]);
 }
 
+describe('BibleReader font helpers', () => {
+  it('clamps font size to reader bounds', () => {
+    expect(clampBibleReaderFontSize(8)).toBe(12);
+    expect(clampBibleReaderFontSize(30)).toBe(20);
+    expect(clampBibleReaderFontSize(16)).toBe(16);
+  });
+
+  it('steps up and down with clamping at bounds', () => {
+    expect(nextBibleReaderFontSizeUp(16)).toBe(18);
+    expect(nextBibleReaderFontSizeUp(20)).toBe(20);
+    expect(nextBibleReaderFontSizeDown(18)).toBe(16);
+    expect(nextBibleReaderFontSizeDown(12)).toBe(12);
+  });
+});
+
+describe('createBibleThemeSettingsContentHandlers', () => {
+  it('updates font size and family via host-owned setters', () => {
+    let fontSize = 16;
+    let fontFamily: FontFamily = SOURCE_SERIF_FONT;
+    const setFontSize = vi.fn((n: number) => {
+      fontSize = n;
+    });
+    const setFontFamily = vi.fn((f: FontFamily) => {
+      fontFamily = f;
+    });
+
+    const handlers = createBibleThemeSettingsContentHandlers({
+      getFontSize: () => fontSize,
+      getFontFamily: () => fontFamily,
+      setFontSize,
+      setFontFamily,
+    });
+
+    handlers.onFontIncreased();
+    expect(setFontSize).toHaveBeenCalledWith(18);
+
+    handlers.onFontSelected(INTER_FONT);
+    expect(setFontFamily).toHaveBeenCalledWith(INTER_FONT);
+  });
+});
+
 describe('BibleReader theme settings', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -128,7 +177,7 @@ describe('BibleReader theme settings', () => {
     });
   });
 
-  it('calls onOpenBibleThemeSettings with current settings/actions and skips popover content', async () => {
+  it('calls onOpenBibleThemeSettings with a serializable snapshot and skips popover content', async () => {
     const user = userEvent.setup();
     const onOpenBibleThemeSettings = vi.fn();
 
@@ -149,56 +198,66 @@ describe('BibleReader theme settings', () => {
     expect(onOpenBibleThemeSettings).toHaveBeenCalledTimes(1);
     expect(screen.queryByText('Reader Settings')).not.toBeInTheDocument();
 
-    const data = onOpenBibleThemeSettings.mock.calls[0]![0] as BibleThemeSettingsData;
-    expect(data).toMatchObject({
+    const snapshot = onOpenBibleThemeSettings.mock.calls[0]![0] as BibleThemeSettingsSnapshot;
+    expect(snapshot).toEqual({
       fontSize: 18,
       fontFamily: INTER_FONT,
       minFontSize: 12,
       maxFontSize: 20,
     });
-    expect(data.onFontIncreased).toEqual(expect.any(Function));
-    expect(data.onFontDecreased).toEqual(expect.any(Function));
-    expect(data.onFontSelected).toEqual(expect.any(Function));
   });
 
-  it('returns next settings when override actions update SDK-owned state', async () => {
+  it('applies font updates via controlled props using snapshot and exported font math', async () => {
     const user = userEvent.setup();
-    const onOpenBibleThemeSettings = vi.fn();
+    const onOpen = vi.fn();
 
-    render(
-      <BibleReader.Root defaultVersionId={3034} defaultBook="JHN" defaultChapter="1">
-        <BibleReader.Toolbar onOpenBibleThemeSettings={onOpenBibleThemeSettings} />
-      </BibleReader.Root>,
-    );
+    function ControlledHost() {
+      const [fontSize, setFontSize] = useState(16);
+      const [fontFamily, setFontFamily] = useState<FontFamily>(SOURCE_SERIF_FONT);
+
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() => {
+              const snap = onOpen.mock.calls[0]?.[0] as BibleThemeSettingsSnapshot | undefined;
+              if (snap) {
+                setFontSize(nextBibleReaderFontSizeDown(snap.fontSize));
+                setFontFamily(INTER_FONT);
+              }
+            }}
+          >
+            simulate-native-apply
+          </button>
+          <BibleReader.Root
+            defaultVersionId={3034}
+            defaultBook="JHN"
+            defaultChapter="1"
+            fontSize={fontSize}
+            fontFamily={fontFamily}
+            onFontSizeChange={setFontSize}
+            onFontFamilyChange={setFontFamily}
+          >
+            <BibleReader.Toolbar onOpenBibleThemeSettings={onOpen} />
+          </BibleReader.Root>
+        </>
+      );
+    }
+
+    render(<ControlledHost />);
 
     await user.click(screen.getByRole('button', { name: 'Settings' }));
+    expect(onOpen).toHaveBeenCalledTimes(1);
 
-    const data = onOpenBibleThemeSettings.mock.calls[0]![0] as BibleThemeSettingsData;
-
-    expect(data.onFontIncreased()).toEqual({
-      fontSize: 18,
-      fontFamily: SOURCE_SERIF_FONT,
-    });
-    expect(data.onFontIncreased()).toEqual({
-      fontSize: 20,
-      fontFamily: SOURCE_SERIF_FONT,
-    });
-    expect(data.onFontIncreased()).toEqual({
-      fontSize: 20,
-      fontFamily: SOURCE_SERIF_FONT,
-    });
-    expect(data.onFontDecreased()).toEqual({
-      fontSize: 18,
-      fontFamily: SOURCE_SERIF_FONT,
-    });
-    expect(data.onFontSelected(INTER_FONT)).toEqual({
-      fontSize: 18,
-      fontFamily: INTER_FONT,
-    });
-
+    await user.click(screen.getByRole('button', { name: 'simulate-native-apply' }));
     await waitFor(() => {
-      expect(localStorage.getItem('youversion-platform:reader:font-size')).toBe('18');
-      expect(localStorage.getItem('youversion-platform:reader:font-family')).toBe(INTER_FONT);
+      expect(localStorage.getItem('youversion-platform:reader:font-size')).toBeNull();
+      expect(localStorage.getItem('youversion-platform:reader:font-family')).toBeNull();
     });
+
+    await user.click(screen.getByRole('button', { name: 'Settings' }));
+    const nextSnap = onOpen.mock.calls[1]![0] as BibleThemeSettingsSnapshot;
+    expect(nextSnap.fontSize).toBe(14);
+    expect(nextSnap.fontFamily).toBe(INTER_FONT);
   });
 });

--- a/packages/ui/src/components/bible-reader.test.tsx
+++ b/packages/ui/src/components/bible-reader.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * @vitest-environment jsdom
+ */
+// We stub ResizeObserver for jsdom (used by Radix/@floating-ui). The stub methods are intentionally no-ops.
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { BibleBook, BibleVersion, Language } from '@youversion/platform-core';
+import {
+  useBooks,
+  useFilteredVersions,
+  useLanguage,
+  useLanguages,
+  useTheme,
+  useVersion,
+  useVersions,
+} from '@youversion/platform-react-hooks';
+import { BibleReader, type BibleThemeSettingsData } from './bible-reader';
+import { INTER_FONT, SOURCE_SERIF_FONT } from '@/lib/verse-html-utils';
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+
+vi.mock('@youversion/platform-react-hooks', async () => {
+  const actual = await vi.importActual('@youversion/platform-react-hooks');
+  return {
+    ...actual,
+    useBooks: vi.fn(),
+    useFilteredVersions: vi.fn(),
+    useLanguage: vi.fn(),
+    useLanguages: vi.fn(),
+    useTheme: vi.fn(),
+    useVersion: vi.fn(),
+    useVersions: vi.fn(),
+  };
+});
+
+const mockBooks: BibleBook[] = [
+  {
+    id: 'JHN',
+    title: 'John',
+    full_title: 'The Gospel According to John',
+    canon: 'new_testament',
+    abbreviation: 'John',
+    chapters: [
+      { id: '1', title: '1', passage_id: 'JHN.1' },
+      { id: '2', title: '2', passage_id: 'JHN.2' },
+    ],
+  },
+];
+
+const mockVersion = {
+  id: 3034,
+  localized_abbreviation: 'BSB',
+  abbreviation: 'BSB',
+  title: 'Berean Standard Bible',
+  language_tag: 'en',
+} as BibleVersion;
+
+function setupDefaultMocks() {
+  vi.mocked(useTheme).mockReturnValue('light');
+  vi.mocked(useBooks).mockReturnValue({
+    books: { data: [...mockBooks], next_page_token: null },
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  });
+  vi.mocked(useVersion).mockReturnValue({
+    version: mockVersion,
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  });
+  vi.mocked(useLanguages).mockReturnValue({
+    languages: { data: [] as Language[], next_page_token: null },
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  });
+  vi.mocked(useLanguage).mockReturnValue({
+    language: { id: 'en', language: 'English', display_names: { en: 'English' } } as Language,
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  });
+  vi.mocked(useVersions).mockReturnValue({
+    versions: { data: [], next_page_token: null },
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  });
+  vi.mocked(useFilteredVersions).mockReturnValue([]);
+}
+
+describe('BibleReader theme settings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    setupDefaultMocks();
+  });
+
+  it('opens the default Reader Settings popover and updates font settings', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <BibleReader.Root defaultVersionId={3034} defaultBook="JHN" defaultChapter="1">
+        <BibleReader.Toolbar />
+      </BibleReader.Root>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Settings' }));
+
+    expect(await screen.findByText('Reader Settings')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('increase-font-size'));
+    await waitFor(() => {
+      expect(localStorage.getItem('youversion-platform:reader:font-size')).toBe('18');
+    });
+
+    await user.click(screen.getByRole('button', { name: /inter/i }));
+    await waitFor(() => {
+      expect(localStorage.getItem('youversion-platform:reader:font-family')).toBe(INTER_FONT);
+    });
+  });
+
+  it('calls onOpenBibleThemeSettings with current settings/actions and skips popover content', async () => {
+    const user = userEvent.setup();
+    const onOpenBibleThemeSettings = vi.fn();
+
+    render(
+      <BibleReader.Root
+        defaultVersionId={3034}
+        defaultBook="JHN"
+        defaultChapter="1"
+        fontSize={18}
+        fontFamily={INTER_FONT}
+      >
+        <BibleReader.Toolbar onOpenBibleThemeSettings={onOpenBibleThemeSettings} />
+      </BibleReader.Root>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Settings' }));
+
+    expect(onOpenBibleThemeSettings).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Reader Settings')).not.toBeInTheDocument();
+
+    const data = onOpenBibleThemeSettings.mock.calls[0]![0] as BibleThemeSettingsData;
+    expect(data).toMatchObject({
+      fontSize: 18,
+      fontFamily: INTER_FONT,
+      minFontSize: 12,
+      maxFontSize: 20,
+    });
+    expect(data.onFontIncreased).toEqual(expect.any(Function));
+    expect(data.onFontDecreased).toEqual(expect.any(Function));
+    expect(data.onFontSelected).toEqual(expect.any(Function));
+  });
+
+  it('returns next settings when override actions update SDK-owned state', async () => {
+    const user = userEvent.setup();
+    const onOpenBibleThemeSettings = vi.fn();
+
+    render(
+      <BibleReader.Root defaultVersionId={3034} defaultBook="JHN" defaultChapter="1">
+        <BibleReader.Toolbar onOpenBibleThemeSettings={onOpenBibleThemeSettings} />
+      </BibleReader.Root>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Settings' }));
+
+    const data = onOpenBibleThemeSettings.mock.calls[0]![0] as BibleThemeSettingsData;
+
+    expect(data.onFontIncreased()).toEqual({
+      fontSize: 18,
+      fontFamily: SOURCE_SERIF_FONT,
+    });
+    expect(data.onFontIncreased()).toEqual({
+      fontSize: 20,
+      fontFamily: SOURCE_SERIF_FONT,
+    });
+    expect(data.onFontIncreased()).toEqual({
+      fontSize: 20,
+      fontFamily: SOURCE_SERIF_FONT,
+    });
+    expect(data.onFontDecreased()).toEqual({
+      fontSize: 18,
+      fontFamily: SOURCE_SERIF_FONT,
+    });
+    expect(data.onFontSelected(INTER_FONT)).toEqual({
+      fontSize: 18,
+      fontFamily: INTER_FONT,
+    });
+
+    await waitFor(() => {
+      expect(localStorage.getItem('youversion-platform:reader:font-size')).toBe('18');
+      expect(localStorage.getItem('youversion-platform:reader:font-family')).toBe(INTER_FONT);
+    });
+  });
+});

--- a/packages/ui/src/components/bible-reader.tsx
+++ b/packages/ui/src/components/bible-reader.tsx
@@ -73,11 +73,9 @@ export type RootProps = {
   versionId?: number;
   defaultVersionId?: number;
   onVersionChange?: (versionId: number) => void;
-  /** Controlled font size; omit with `defaultFontSize` for uncontrolled (persists via localStorage on web). */
   fontSize?: number;
   defaultFontSize?: number;
   onFontSizeChange?: (fontSize: number) => void;
-  /** Controlled font family; omit with `defaultFontFamily` for uncontrolled (persists via localStorage on web). */
   fontFamily?: FontFamily;
   defaultFontFamily?: FontFamily;
   onFontFamilyChange?: (fontFamily: FontFamily) => void;
@@ -88,7 +86,6 @@ export type RootProps = {
   children?: ReactNode;
 };
 
-/** Bounds and defaults for reader typography (stable across Web and Expo DOM hosts). */
 export const BIBLE_READER_FONT = {
   MIN: 12,
   MAX: 20,
@@ -106,7 +103,6 @@ export type BibleThemeSettingsValues = {
   fontFamily: FontFamily;
 };
 
-/** Serializable settings state for `onOpenBibleThemeSettings` (Expo DOM / native-safe). */
 export type BibleThemeSettingsSnapshot = BibleThemeSettingsValues & {
   minFontSize: number;
   maxFontSize: number;
@@ -125,8 +121,7 @@ export function clampBibleReaderFontSize(fontSize: number): number {
   return Math.min(MAX_FONT_SIZE, Math.max(MIN_FONT_SIZE, fontSize));
 }
 
-/** Initial / seeded font size: out-of-range values fall back to default (matches legacy reader behavior). */
-function normalizeReaderFontSizeForInitial(size: number): number {
+function normalizeReaderFontSizeForInitialization(size: number): number {
   if (size > MAX_FONT_SIZE || size < MIN_FONT_SIZE) {
     return DEFAULT_FONT_SIZE;
   }
@@ -214,7 +209,7 @@ function Root({
   const isFontSizeControlled = onFontSizeChange !== undefined;
   const isFontFamilyControlled = onFontFamilyChange !== undefined;
 
-  const defaultPropFontSize = normalizeReaderFontSizeForInitial(
+  const defaultPropFontSize = normalizeReaderFontSizeForInitialization(
     fontSizeProp ?? validatedDefaultFontSize,
   );
 
@@ -232,7 +227,6 @@ function Root({
     onChange: onFontFamilyChange,
   });
 
-  // Load saved preferences from localStorage before paint (uncontrolled axis only; avoids flash of defaults)
   useLayoutEffect(() => {
     if (!isFontSizeControlled) {
       const savedFontSize = localStorage.getItem('youversion-platform:reader:font-size');
@@ -252,7 +246,6 @@ function Root({
     }
   }, [isFontFamilyControlled, isFontSizeControlled, setCurrentFontFamily, setCurrentFontSize]);
 
-  // Save preferences to localStorage when they change (uncontrolled axis only)
   useEffect(() => {
     if (!isFontSizeControlled) {
       localStorage.setItem('youversion-platform:reader:font-size', currentFontSize.toString());

--- a/packages/ui/src/components/bible-reader.tsx
+++ b/packages/ui/src/components/bible-reader.tsx
@@ -478,22 +478,24 @@ function Toolbar({ border = 'top', onOpenBibleThemeSettings }: BibleReaderToolba
     fontFamily: currentFontFamily,
   };
 
-  const applySettings = (settings: BibleThemeSettingsValues): BibleThemeSettingsValues => {
-    const nextSettings = {
-      fontSize: clampFontSize(settings.fontSize),
-      fontFamily: settings.fontFamily,
+  const applyThemeSettings = (
+    themeSettings: BibleThemeSettingsValues,
+  ): BibleThemeSettingsValues => {
+    const nextThemeSettings = {
+      fontSize: clampFontSize(themeSettings.fontSize),
+      fontFamily: themeSettings.fontFamily,
     };
 
-    settingsValuesRef.current = nextSettings;
-    setCurrentFontSize(nextSettings.fontSize);
-    setCurrentFontFamily(nextSettings.fontFamily);
+    settingsValuesRef.current = nextThemeSettings;
+    setCurrentFontSize(nextThemeSettings.fontSize);
+    setCurrentFontFamily(nextThemeSettings.fontFamily);
 
-    return nextSettings;
+    return nextThemeSettings;
   };
 
   const handleFontIncreased = (): BibleThemeSettingsValues => {
     const settings = settingsValuesRef.current;
-    return applySettings({
+    return applyThemeSettings({
       ...settings,
       fontSize: settings.fontSize + FONT_SIZE_STEP,
     });
@@ -501,14 +503,14 @@ function Toolbar({ border = 'top', onOpenBibleThemeSettings }: BibleReaderToolba
 
   const handleFontDecreased = (): BibleThemeSettingsValues => {
     const settings = settingsValuesRef.current;
-    return applySettings({
+    return applyThemeSettings({
       ...settings,
       fontSize: settings.fontSize - FONT_SIZE_STEP,
     });
   };
 
   const handleFontSelected = (fontFamily: FontFamily): BibleThemeSettingsValues => {
-    return applySettings({
+    return applyThemeSettings({
       ...settingsValuesRef.current,
       fontFamily,
     });

--- a/packages/ui/src/components/bible-reader.tsx
+++ b/packages/ui/src/components/bible-reader.tsx
@@ -17,7 +17,6 @@ import {
   useLayoutEffect,
   useMemo,
   useRef,
-  useState,
   type ReactElement,
 } from 'react';
 import { cn } from '@/lib/utils';
@@ -74,8 +73,14 @@ export type RootProps = {
   versionId?: number;
   defaultVersionId?: number;
   onVersionChange?: (versionId: number) => void;
-  fontFamily?: FontFamily;
+  /** Controlled font size; omit with `defaultFontSize` for uncontrolled (persists via localStorage on web). */
   fontSize?: number;
+  defaultFontSize?: number;
+  onFontSizeChange?: (fontSize: number) => void;
+  /** Controlled font family; omit with `defaultFontFamily` for uncontrolled (persists via localStorage on web). */
+  fontFamily?: FontFamily;
+  defaultFontFamily?: FontFamily;
+  onFontFamilyChange?: (fontFamily: FontFamily) => void;
   lineHeight?: number;
   showVerseNumbers?: boolean;
   background?: 'light' | 'dark';
@@ -83,22 +88,28 @@ export type RootProps = {
   children?: ReactNode;
 };
 
-const MIN_FONT_SIZE = 12;
-const MAX_FONT_SIZE = 20;
-const DEFAULT_FONT_SIZE = 16;
-const FONT_SIZE_STEP = 2;
+/** Bounds and defaults for reader typography (stable across Web and Expo DOM hosts). */
+export const BIBLE_READER_FONT = {
+  MIN: 12,
+  MAX: 20,
+  DEFAULT: 16,
+  STEP: 2,
+} as const;
+
+const MIN_FONT_SIZE = BIBLE_READER_FONT.MIN;
+const MAX_FONT_SIZE = BIBLE_READER_FONT.MAX;
+const DEFAULT_FONT_SIZE = BIBLE_READER_FONT.DEFAULT;
+const FONT_SIZE_STEP = BIBLE_READER_FONT.STEP;
 
 export type BibleThemeSettingsValues = {
   fontSize: number;
   fontFamily: FontFamily;
 };
 
-export type BibleThemeSettingsData = BibleThemeSettingsValues & {
+/** Serializable settings state for `onOpenBibleThemeSettings` (Expo DOM / native-safe). */
+export type BibleThemeSettingsSnapshot = BibleThemeSettingsValues & {
   minFontSize: number;
   maxFontSize: number;
-  onFontIncreased: () => BibleThemeSettingsValues;
-  onFontDecreased: () => BibleThemeSettingsValues;
-  onFontSelected: (fontFamily: FontFamily) => BibleThemeSettingsValues;
 };
 
 export type BibleThemeSettingsContentProps = {
@@ -110,8 +121,49 @@ export type BibleThemeSettingsContentProps = {
   onFontDecreased: () => void;
 };
 
-function clampFontSize(fontSize: number): number {
+export function clampBibleReaderFontSize(fontSize: number): number {
   return Math.min(MAX_FONT_SIZE, Math.max(MIN_FONT_SIZE, fontSize));
+}
+
+/** Initial / seeded font size: out-of-range values fall back to default (matches legacy reader behavior). */
+function normalizeReaderFontSizeForInitial(size: number): number {
+  if (size > MAX_FONT_SIZE || size < MIN_FONT_SIZE) {
+    return DEFAULT_FONT_SIZE;
+  }
+  return size;
+}
+
+export function nextBibleReaderFontSizeUp(current: number): number {
+  return clampBibleReaderFontSize(current + FONT_SIZE_STEP);
+}
+
+export function nextBibleReaderFontSizeDown(current: number): number {
+  return clampBibleReaderFontSize(current - FONT_SIZE_STEP);
+}
+
+/**
+ * Builds the three handler props for {@link BibleThemeSettingsContent} from host-owned font state.
+ * Use this on the same side as `setFontSize` / `setFontFamily` (e.g. React Native before passing
+ * **top-level** props into a `BibleThemeSettingsContent` Expo DOM wrapper). Expo allows functions as
+ * top-level DOM props; do not nest these inside a {@link BibleThemeSettingsSnapshot}.
+ */
+export function createBibleThemeSettingsContentHandlers(options: {
+  getFontSize: () => number;
+  getFontFamily: () => FontFamily;
+  setFontSize: (size: number) => void;
+  setFontFamily: (fontFamily: FontFamily) => void;
+}): Pick<BibleThemeSettingsContentProps, 'onFontIncreased' | 'onFontDecreased' | 'onFontSelected'> {
+  return {
+    onFontIncreased: () => {
+      options.setFontSize(nextBibleReaderFontSizeUp(options.getFontSize()));
+    },
+    onFontDecreased: () => {
+      options.setFontSize(nextBibleReaderFontSizeDown(options.getFontSize()));
+    },
+    onFontSelected: (fontFamily) => {
+      options.setFontFamily(fontFamily);
+    },
+  };
 }
 
 function Root({
@@ -124,8 +176,12 @@ function Root({
   versionId: controlledVersionId,
   defaultVersionId = DEFAULT_LICENSE_FREE_BIBLE_VERSION,
   onVersionChange,
-  fontFamily = SOURCE_SERIF_FONT,
-  fontSize = DEFAULT_FONT_SIZE,
+  fontSize: fontSizeProp,
+  defaultFontSize = DEFAULT_FONT_SIZE,
+  onFontSizeChange,
+  fontFamily: fontFamilyProp,
+  defaultFontFamily = SOURCE_SERIF_FONT,
+  onFontFamilyChange,
   lineHeight,
   showVerseNumbers = true,
   background,
@@ -150,36 +206,64 @@ function Root({
     onChange: onVersionChange,
   });
 
-  const validatedFontSize =
-    fontSize > MAX_FONT_SIZE || fontSize < MIN_FONT_SIZE ? DEFAULT_FONT_SIZE : fontSize;
+  const validatedDefaultFontSize =
+    defaultFontSize > MAX_FONT_SIZE || defaultFontSize < MIN_FONT_SIZE
+      ? DEFAULT_FONT_SIZE
+      : defaultFontSize;
 
-  const [currentFontSize, setCurrentFontSize] = useState(validatedFontSize);
-  const [currentFontFamily, setCurrentFontFamily] = useState(fontFamily);
+  const isFontSizeControlled = onFontSizeChange !== undefined;
+  const isFontFamilyControlled = onFontFamilyChange !== undefined;
 
-  // Load saved preferences from localStorage before paint (avoids flash of default values)
+  const defaultPropFontSize = normalizeReaderFontSizeForInitial(
+    fontSizeProp ?? validatedDefaultFontSize,
+  );
+
+  const [currentFontSize, setCurrentFontSize] = useControllableState({
+    prop: isFontSizeControlled ? fontSizeProp : undefined,
+    defaultProp: defaultPropFontSize,
+    onChange: onFontSizeChange,
+  });
+
+  const defaultPropFontFamily = fontFamilyProp ?? defaultFontFamily;
+
+  const [currentFontFamily, setCurrentFontFamily] = useControllableState({
+    prop: isFontFamilyControlled ? fontFamilyProp : undefined,
+    defaultProp: defaultPropFontFamily,
+    onChange: onFontFamilyChange,
+  });
+
+  // Load saved preferences from localStorage before paint (uncontrolled axis only; avoids flash of defaults)
   useLayoutEffect(() => {
-    const savedFontSize = localStorage.getItem('youversion-platform:reader:font-size');
-    if (savedFontSize) {
-      const parsed = parseInt(savedFontSize);
-      if (parsed >= MIN_FONT_SIZE && parsed <= MAX_FONT_SIZE) {
-        setCurrentFontSize(parsed);
+    if (!isFontSizeControlled) {
+      const savedFontSize = localStorage.getItem('youversion-platform:reader:font-size');
+      if (savedFontSize) {
+        const parsed = parseInt(savedFontSize);
+        if (parsed >= MIN_FONT_SIZE && parsed <= MAX_FONT_SIZE) {
+          setCurrentFontSize(parsed);
+        }
       }
     }
 
-    const savedFontFamily = localStorage.getItem('youversion-platform:reader:font-family');
-    if (savedFontFamily) {
-      setCurrentFontFamily(savedFontFamily);
+    if (!isFontFamilyControlled) {
+      const savedFontFamily = localStorage.getItem('youversion-platform:reader:font-family');
+      if (savedFontFamily) {
+        setCurrentFontFamily(savedFontFamily);
+      }
     }
-  }, []);
+  }, [isFontFamilyControlled, isFontSizeControlled, setCurrentFontFamily, setCurrentFontSize]);
 
-  // Save preferences to localStorage when they change
+  // Save preferences to localStorage when they change (uncontrolled axis only)
   useEffect(() => {
-    localStorage.setItem('youversion-platform:reader:font-size', currentFontSize.toString());
-  }, [currentFontSize]);
+    if (!isFontSizeControlled) {
+      localStorage.setItem('youversion-platform:reader:font-size', currentFontSize.toString());
+    }
+  }, [currentFontSize, isFontSizeControlled]);
 
   useEffect(() => {
-    localStorage.setItem('youversion-platform:reader:font-family', currentFontFamily);
-  }, [currentFontFamily]);
+    if (!isFontFamilyControlled) {
+      localStorage.setItem('youversion-platform:reader:font-family', currentFontFamily);
+    }
+  }, [currentFontFamily, isFontFamilyControlled]);
 
   const providerTheme = useTheme();
   const theme = background || providerTheme;
@@ -450,7 +534,7 @@ export function BibleThemeSettingsContent({
 
 export type BibleReaderToolbarProps = {
   border?: 'top' | 'bottom';
-  onOpenBibleThemeSettings?: (data: BibleThemeSettingsData) => void;
+  onOpenBibleThemeSettings?: (snapshot: BibleThemeSettingsSnapshot) => void;
 };
 
 function Toolbar({ border = 'top', onOpenBibleThemeSettings }: BibleReaderToolbarProps) {
@@ -484,7 +568,7 @@ function Toolbar({ border = 'top', onOpenBibleThemeSettings }: BibleReaderToolba
     themeSettings: BibleThemeSettingsValues,
   ): BibleThemeSettingsValues => {
     const nextThemeSettings = {
-      fontSize: clampFontSize(themeSettings.fontSize),
+      fontSize: clampBibleReaderFontSize(themeSettings.fontSize),
       fontFamily: themeSettings.fontFamily,
     };
 
@@ -499,7 +583,7 @@ function Toolbar({ border = 'top', onOpenBibleThemeSettings }: BibleReaderToolba
     const settings = themesSettingsValuesRef.current;
     return applyThemeSettings({
       ...settings,
-      fontSize: settings.fontSize + FONT_SIZE_STEP,
+      fontSize: nextBibleReaderFontSizeUp(settings.fontSize),
     });
   };
 
@@ -507,7 +591,7 @@ function Toolbar({ border = 'top', onOpenBibleThemeSettings }: BibleReaderToolba
     const settings = themesSettingsValuesRef.current;
     return applyThemeSettings({
       ...settings,
-      fontSize: settings.fontSize - FONT_SIZE_STEP,
+      fontSize: nextBibleReaderFontSizeDown(settings.fontSize),
     });
   };
 
@@ -518,13 +602,10 @@ function Toolbar({ border = 'top', onOpenBibleThemeSettings }: BibleReaderToolba
     });
   };
 
-  const buildBibleThemeSettingsPayload = (): BibleThemeSettingsData => ({
+  const buildBibleThemeSettingsSnapshot = (): BibleThemeSettingsSnapshot => ({
     ...themesSettingsValuesRef.current,
     minFontSize: MIN_FONT_SIZE,
     maxFontSize: MAX_FONT_SIZE,
-    onFontIncreased: handleFontIncreased,
-    onFontDecreased: handleFontDecreased,
-    onFontSelected: handleFontSelected,
   });
 
   const prevResult = getAdjacentChapter(booksData, book, chapter, 'previous');
@@ -560,10 +641,7 @@ function Toolbar({ border = 'top', onOpenBibleThemeSettings }: BibleReaderToolba
         >
           <BibleChapterPicker.Trigger>
             {({ chapterLabel, currentBook, loading }) => (
-              <div
-                className="yv:grid yv:grid-cols-[auto_1fr_auto]
- yv:justify-start yv:grid-rows-1 yv:overflow-hidden yv:rounded-full yv:min-w-30 yv:bg-muted yv:text-muted-foreground yv:hover:bg-muted/80"
-              >
+              <div className="yv:grid yv:grid-cols-[auto_1fr_auto] yv:justify-start yv:grid-rows-1 yv:overflow-hidden yv:rounded-full yv:min-w-30 yv:bg-muted yv:text-muted-foreground yv:hover:bg-muted/80">
                 <Button
                   className="yv:min-w-0 yv:group yv:place-self-center yv:max-size-9 yv:touch-hitbox"
                   size="icon"
@@ -658,7 +736,7 @@ function Toolbar({ border = 'top', onOpenBibleThemeSettings }: BibleReaderToolba
             size="sm"
             variant="secondary"
             aria-label="Settings"
-            onClick={() => onOpenBibleThemeSettings(buildBibleThemeSettingsPayload())}
+            onClick={() => onOpenBibleThemeSettings(buildBibleThemeSettingsSnapshot())}
           >
             <GearIcon className="yv:text-foreground" />
           </Button>

--- a/packages/ui/src/components/bible-reader.tsx
+++ b/packages/ui/src/components/bible-reader.tsx
@@ -102,6 +102,7 @@ export type BibleThemeSettingsData = BibleThemeSettingsValues & {
 };
 
 export type BibleThemeSettingsContentProps = {
+  theme: 'light' | 'dark';
   fontSize: number;
   fontFamily: FontFamily;
   onFontSelected: (fontFamily: FontFamily) => void;
@@ -361,6 +362,7 @@ function UserMenu() {
 }
 
 export function BibleThemeSettingsContent({
+  theme,
   fontSize,
   fontFamily,
   onFontSelected,
@@ -368,7 +370,7 @@ export function BibleThemeSettingsContent({
   onFontDecreased,
 }: BibleThemeSettingsContentProps): ReactElement {
   return (
-    <div data-yv-sdk className="yv:flex yv:flex-col yv:gap-4 yv:p-4">
+    <div data-yv-sdk data-yv-theme={theme} className="yv:flex yv:flex-col yv:gap-4 yv:p-4">
       <div className="yv:grid yv:grid-cols-2">
         <Button
           className="yv:text-xs yv:text-black yv:dark:text-muted-foreground yv:rounded-l-[8px] yv:rounded-r-none yv:border yv:border-white yv:dark:border-border yv:h-auto yv:py-2"
@@ -670,6 +672,7 @@ function Toolbar({ border = 'top', onOpenBibleThemeSettings }: BibleReaderToolba
 
             <PopoverContent sideOffset={16} heading="Reader Settings" theme={background}>
               <BibleThemeSettingsContent
+                theme={background}
                 fontSize={currentFontSize}
                 fontFamily={currentFontFamily}
                 onFontDecreased={handleFontDecreased}

--- a/packages/ui/src/components/bible-reader.tsx
+++ b/packages/ui/src/components/bible-reader.tsx
@@ -460,6 +460,7 @@ export function BibleThemeSettingsContent({
           size="lg"
           variant="secondary"
           data-testid="decrease-font-size"
+          disabled={fontSize <= MIN_FONT_SIZE}
           aria-disabled={fontSize <= MIN_FONT_SIZE}
         >
           A
@@ -470,6 +471,7 @@ export function BibleThemeSettingsContent({
           size="lg"
           variant="secondary"
           data-testid="increase-font-size"
+          disabled={fontSize >= MAX_FONT_SIZE}
           aria-disabled={fontSize >= MAX_FONT_SIZE}
         >
           A

--- a/packages/ui/src/components/bible-reader.tsx
+++ b/packages/ui/src/components/bible-reader.tsx
@@ -227,7 +227,12 @@ function Root({
     onChange: onFontFamilyChange,
   });
 
+  const didHydrateThemeSettingsRef = useRef(false);
+
   useLayoutEffect(() => {
+    if (didHydrateThemeSettingsRef.current) return;
+    didHydrateThemeSettingsRef.current = true;
+
     if (!isFontSizeControlled) {
       const savedFontSize = localStorage.getItem('youversion-platform:reader:font-size');
       if (savedFontSize) {

--- a/packages/ui/src/components/bible-reader.tsx
+++ b/packages/ui/src/components/bible-reader.tsx
@@ -16,7 +16,9 @@ import {
   useEffect,
   useLayoutEffect,
   useMemo,
+  useRef,
   useState,
+  type ReactElement,
 } from 'react';
 import { cn } from '@/lib/utils';
 import { DEFAULT_LICENSE_FREE_BIBLE_VERSION, getAdjacentChapter } from '@youversion/platform-core';
@@ -84,6 +86,32 @@ export type RootProps = {
 const MIN_FONT_SIZE = 12;
 const MAX_FONT_SIZE = 20;
 const DEFAULT_FONT_SIZE = 16;
+const FONT_SIZE_STEP = 2;
+
+export type BibleThemeSettingsValues = {
+  fontSize: number;
+  fontFamily: FontFamily;
+};
+
+export type BibleThemeSettingsData = BibleThemeSettingsValues & {
+  minFontSize: number;
+  maxFontSize: number;
+  onFontIncreased: () => BibleThemeSettingsValues;
+  onFontDecreased: () => BibleThemeSettingsValues;
+  onFontSelected: (fontFamily: FontFamily) => BibleThemeSettingsValues;
+};
+
+export type BibleThemeSettingsContentProps = {
+  fontSize: number;
+  fontFamily: FontFamily;
+  onFontSelected: (fontFamily: FontFamily) => void;
+  onFontIncreased: () => void;
+  onFontDecreased: () => void;
+};
+
+function clampFontSize(fontSize: number): number {
+  return Math.min(MAX_FONT_SIZE, Math.max(MIN_FONT_SIZE, fontSize));
+}
 
 function Root({
   book: controlledBook,
@@ -332,7 +360,98 @@ function UserMenu() {
   );
 }
 
-function Toolbar({ border = 'top' }: { border?: 'top' | 'bottom' }) {
+export function BibleThemeSettingsContent({
+  fontSize,
+  fontFamily,
+  onFontSelected,
+  onFontIncreased,
+  onFontDecreased,
+}: BibleThemeSettingsContentProps): ReactElement {
+  return (
+    <div data-yv-sdk className="yv:flex yv:flex-col yv:gap-4 yv:p-4">
+      <div className="yv:grid yv:grid-cols-2">
+        <Button
+          className="yv:text-xs yv:text-black yv:dark:text-muted-foreground yv:rounded-l-[8px] yv:rounded-r-none yv:border yv:border-white yv:dark:border-border yv:h-auto yv:py-2"
+          onClick={onFontDecreased}
+          size="lg"
+          variant="secondary"
+          data-testid="decrease-font-size"
+          aria-disabled={fontSize <= MIN_FONT_SIZE}
+        >
+          A
+        </Button>
+        <Button
+          className="yv:text-3xl yv:text-black yv:dark:text-muted-foreground yv:rounded-r-[8px] yv:rounded-l-none yv:border yv:border-white yv:dark:border-border yv:h-auto yv:py-2"
+          onClick={onFontIncreased}
+          size="lg"
+          variant="secondary"
+          data-testid="increase-font-size"
+          aria-disabled={fontSize >= MAX_FONT_SIZE}
+        >
+          A
+        </Button>
+      </div>
+
+      <div className="yv:grid yv:grid-cols-2">
+        <Button
+          className={cn(
+            'yv:group yv:dark:bg-muted yv:rounded-r-none yv:border-r-0.5 yv:dark:border-border yv:rounded-l-[8px] yv:h-auto',
+            fontFamily === INTER_FONT
+              ? 'yv:bg-primary yv:border-primary yv:dark:bg-inherit yv:text-primary-foreground yv:hover:text-primary-foreground yv:hover:bg-primary/80'
+              : '',
+          )}
+          onClick={() => onFontSelected(INTER_FONT)}
+          variant="outline"
+        >
+          <div className="yv:flex yv:flex-col yv:w-full yv:items-start">
+            <span
+              className={cn(
+                'yv:text-xs yv:text-muted-foreground',
+                fontFamily === INTER_FONT
+                  ? 'yv:text-muted yv:dark:text-muted-foreground yv:group-hover:text-muted'
+                  : '',
+              )}
+            >
+              Font
+            </span>
+            <span className="yv:sm:text-xl yv:text-base">Inter</span>
+          </div>
+        </Button>
+        <Button
+          className={cn(
+            'yv:group yv:dark:bg-muted yv:border-l-0.5 yv:rounded-l-none yv:rounded-r-[8px] yv:h-auto',
+            fontFamily === SOURCE_SERIF_FONT
+              ? 'yv:bg-primary yv:border-primary yv:dark:bg-inherit yv:text-primary-foreground yv:hover:text-primary-foreground yv:hover:bg-primary/80'
+              : '',
+          )}
+          onClick={() => onFontSelected(SOURCE_SERIF_FONT)}
+          variant="outline"
+        >
+          <div className="yv:flex yv:flex-col yv:w-full yv:items-start">
+            <span
+              className={cn(
+                'yv:text-xs yv:text-muted-foreground',
+                fontFamily === SOURCE_SERIF_FONT
+                  ? 'yv:text-muted yv:dark:text-muted-foreground yv:group-hover:text-muted'
+                  : '',
+              )}
+            >
+              Font
+            </span>
+            <span className="yv:sm:text-xl yv:text-base yv:font-serif">Source Serif</span>
+          </div>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export type BibleReaderToolbarProps = {
+  border?: 'top' | 'bottom';
+  onOpenBibleThemeSettings?: (data: BibleThemeSettingsData) => void;
+};
+
+function Toolbar({ border = 'top', onOpenBibleThemeSettings }: BibleReaderToolbarProps) {
   const {
     book,
     chapter,
@@ -344,10 +463,65 @@ function Toolbar({ border = 'top' }: { border?: 'top' | 'bottom' }) {
     booksLoading,
     currentFontFamily,
     setCurrentFontFamily,
+    currentFontSize,
     setCurrentFontSize,
     background,
   } = useBibleReaderContext();
   const yvContext = useContext(YouVersionContext);
+  const settingsValuesRef = useRef<BibleThemeSettingsValues>({
+    fontSize: currentFontSize,
+    fontFamily: currentFontFamily,
+  });
+
+  settingsValuesRef.current = {
+    fontSize: currentFontSize,
+    fontFamily: currentFontFamily,
+  };
+
+  const applySettings = (settings: BibleThemeSettingsValues): BibleThemeSettingsValues => {
+    const nextSettings = {
+      fontSize: clampFontSize(settings.fontSize),
+      fontFamily: settings.fontFamily,
+    };
+
+    settingsValuesRef.current = nextSettings;
+    setCurrentFontSize(nextSettings.fontSize);
+    setCurrentFontFamily(nextSettings.fontFamily);
+
+    return nextSettings;
+  };
+
+  const handleFontIncreased = (): BibleThemeSettingsValues => {
+    const settings = settingsValuesRef.current;
+    return applySettings({
+      ...settings,
+      fontSize: settings.fontSize + FONT_SIZE_STEP,
+    });
+  };
+
+  const handleFontDecreased = (): BibleThemeSettingsValues => {
+    const settings = settingsValuesRef.current;
+    return applySettings({
+      ...settings,
+      fontSize: settings.fontSize - FONT_SIZE_STEP,
+    });
+  };
+
+  const handleFontSelected = (fontFamily: FontFamily): BibleThemeSettingsValues => {
+    return applySettings({
+      ...settingsValuesRef.current,
+      fontFamily,
+    });
+  };
+
+  const buildBibleThemeSettingsPayload = (): BibleThemeSettingsData => ({
+    ...settingsValuesRef.current,
+    minFontSize: MIN_FONT_SIZE,
+    maxFontSize: MAX_FONT_SIZE,
+    onFontIncreased: handleFontIncreased,
+    onFontDecreased: handleFontDecreased,
+    onFontSelected: handleFontSelected,
+  });
 
   const prevResult = getAdjacentChapter(booksData, book, chapter, 'previous');
   const nextResult = getAdjacentChapter(booksData, book, chapter, 'next');
@@ -475,99 +649,34 @@ function Toolbar({ border = 'top' }: { border?: 'top' | 'bottom' }) {
           <BibleVersionPicker.Content />
         </BibleVersionPicker.Root>
 
-        <Popover>
-          <PopoverTrigger asChild aria-label="Settings">
-            <Button size="sm" variant="secondary">
-              <GearIcon className="yv:text-foreground" />
-            </Button>
-          </PopoverTrigger>
+        {onOpenBibleThemeSettings ? (
+          <Button
+            size="sm"
+            variant="secondary"
+            aria-label="Settings"
+            onClick={() => onOpenBibleThemeSettings(buildBibleThemeSettingsPayload())}
+          >
+            <GearIcon className="yv:text-foreground" />
+          </Button>
+        ) : (
+          <Popover>
+            <PopoverTrigger asChild aria-label="Settings">
+              <Button size="sm" variant="secondary">
+                <GearIcon className="yv:text-foreground" />
+              </Button>
+            </PopoverTrigger>
 
-          <PopoverContent sideOffset={16} heading="Reader Settings" theme={background}>
-            <div className="yv:flex yv:flex-col yv:gap-4 yv:p-4">
-              <div className="yv:grid yv:grid-cols-2">
-                <Button
-                  className="yv:text-xs yv:text-black yv:dark:text-muted-foreground yv:rounded-l-[8px] yv:rounded-r-none yv:border yv:border-white yv:dark:border-border yv:h-auto yv:py-2"
-                  onClick={() =>
-                    setCurrentFontSize((prev) => {
-                      if (prev > MIN_FONT_SIZE) return prev - 2;
-                      return prev;
-                    })
-                  }
-                  size="lg"
-                  variant="secondary"
-                  data-testid="decrease-font-size"
-                >
-                  A
-                </Button>
-                <Button
-                  className="yv:text-3xl yv:text-black yv:dark:text-muted-foreground yv:rounded-r-[8px] yv:rounded-l-none yv:border yv:border-white yv:dark:border-border yv:h-auto yv:py-2"
-                  onClick={() =>
-                    setCurrentFontSize((prev) => {
-                      if (prev < MAX_FONT_SIZE) return prev + 2;
-                      return prev;
-                    })
-                  }
-                  size="lg"
-                  variant="secondary"
-                  data-testid="increase-font-size"
-                >
-                  A
-                </Button>
-              </div>
-
-              <div className="yv:grid yv:grid-cols-2">
-                <Button
-                  className={cn(
-                    'yv:group yv:dark:bg-muted yv:rounded-r-none yv:border-r-0.5 yv:dark:border-border yv:rounded-l-[8px] yv:h-auto',
-                    currentFontFamily === INTER_FONT
-                      ? 'yv:bg-primary yv:border-primary yv:dark:bg-inherit yv:text-primary-foreground yv:hover:text-primary-foreground yv:hover:bg-primary/80'
-                      : '',
-                  )}
-                  onClick={() => setCurrentFontFamily(INTER_FONT)}
-                  variant="outline"
-                >
-                  <div className="yv:flex yv:flex-col yv:w-full yv:items-start">
-                    <span
-                      className={cn(
-                        'yv:text-xs yv:text-muted-foreground',
-                        currentFontFamily === INTER_FONT
-                          ? 'yv:text-muted yv:dark:text-muted-foreground yv:group-hover:text-muted'
-                          : '',
-                      )}
-                    >
-                      Font
-                    </span>
-                    <span className="yv:sm:text-xl yv:text-base">Inter</span>
-                  </div>
-                </Button>
-                <Button
-                  className={cn(
-                    'yv:group yv:dark:bg-muted yv:border-l-0.5 yv:rounded-l-none yv:rounded-r-[8px] yv:h-auto',
-                    currentFontFamily === SOURCE_SERIF_FONT
-                      ? 'yv:bg-primary yv:border-primary yv:dark:bg-inherit yv:text-primary-foreground yv:hover:text-primary-foreground yv:hover:bg-primary/80'
-                      : '',
-                  )}
-                  onClick={() => setCurrentFontFamily(SOURCE_SERIF_FONT)}
-                  variant="outline"
-                >
-                  <div className="yv:flex yv:flex-col yv:w-full yv:items-start">
-                    <span
-                      className={cn(
-                        'yv:text-xs yv:text-muted-foreground',
-                        currentFontFamily === SOURCE_SERIF_FONT
-                          ? 'yv:text-muted yv:dark:text-muted-foreground yv:group-hover:text-muted'
-                          : '',
-                      )}
-                    >
-                      Font
-                    </span>
-                    <span className="yv:sm:text-xl yv:text-base yv:font-serif">Source Serif</span>
-                  </div>
-                </Button>
-              </div>
-            </div>
-          </PopoverContent>
-        </Popover>
+            <PopoverContent sideOffset={16} heading="Reader Settings" theme={background}>
+              <BibleThemeSettingsContent
+                fontSize={currentFontSize}
+                fontFamily={currentFontFamily}
+                onFontDecreased={handleFontDecreased}
+                onFontIncreased={handleFontIncreased}
+                onFontSelected={handleFontSelected}
+              />
+            </PopoverContent>
+          </Popover>
+        )}
       </div>
     </section>
   );

--- a/packages/ui/src/components/bible-reader.tsx
+++ b/packages/ui/src/components/bible-reader.tsx
@@ -468,12 +468,12 @@ function Toolbar({ border = 'top', onOpenBibleThemeSettings }: BibleReaderToolba
     background,
   } = useBibleReaderContext();
   const yvContext = useContext(YouVersionContext);
-  const settingsValuesRef = useRef<BibleThemeSettingsValues>({
+  const themesSettingsValuesRef = useRef<BibleThemeSettingsValues>({
     fontSize: currentFontSize,
     fontFamily: currentFontFamily,
   });
 
-  settingsValuesRef.current = {
+  themesSettingsValuesRef.current = {
     fontSize: currentFontSize,
     fontFamily: currentFontFamily,
   };
@@ -486,7 +486,7 @@ function Toolbar({ border = 'top', onOpenBibleThemeSettings }: BibleReaderToolba
       fontFamily: themeSettings.fontFamily,
     };
 
-    settingsValuesRef.current = nextThemeSettings;
+    themesSettingsValuesRef.current = nextThemeSettings;
     setCurrentFontSize(nextThemeSettings.fontSize);
     setCurrentFontFamily(nextThemeSettings.fontFamily);
 
@@ -494,7 +494,7 @@ function Toolbar({ border = 'top', onOpenBibleThemeSettings }: BibleReaderToolba
   };
 
   const handleFontIncreased = (): BibleThemeSettingsValues => {
-    const settings = settingsValuesRef.current;
+    const settings = themesSettingsValuesRef.current;
     return applyThemeSettings({
       ...settings,
       fontSize: settings.fontSize + FONT_SIZE_STEP,
@@ -502,7 +502,7 @@ function Toolbar({ border = 'top', onOpenBibleThemeSettings }: BibleReaderToolba
   };
 
   const handleFontDecreased = (): BibleThemeSettingsValues => {
-    const settings = settingsValuesRef.current;
+    const settings = themesSettingsValuesRef.current;
     return applyThemeSettings({
       ...settings,
       fontSize: settings.fontSize - FONT_SIZE_STEP,
@@ -511,13 +511,13 @@ function Toolbar({ border = 'top', onOpenBibleThemeSettings }: BibleReaderToolba
 
   const handleFontSelected = (fontFamily: FontFamily): BibleThemeSettingsValues => {
     return applyThemeSettings({
-      ...settingsValuesRef.current,
+      ...themesSettingsValuesRef.current,
       fontFamily,
     });
   };
 
   const buildBibleThemeSettingsPayload = (): BibleThemeSettingsData => ({
-    ...settingsValuesRef.current,
+    ...themesSettingsValuesRef.current,
     minFontSize: MIN_FONT_SIZE,
     maxFontSize: MAX_FONT_SIZE,
     onFontIncreased: handleFontIncreased,

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -6,7 +6,15 @@ export {
   type BibleChapterPickerContentProps,
   type BibleChapterPickerPressData,
 } from './bible-chapter-picker';
-export { BibleReader, type BibleReaderRootProps } from './bible-reader';
+export {
+  BibleReader,
+  BibleThemeSettingsContent,
+  type BibleReaderRootProps,
+  type BibleReaderToolbarProps,
+  type BibleThemeSettingsData,
+  type BibleThemeSettingsContentProps,
+  type BibleThemeSettingsValues,
+} from './bible-reader';
 export {
   BibleVersionPicker,
   type BibleVersionPickerRootProps,

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -7,12 +7,17 @@ export {
   type BibleChapterPickerPressData,
 } from './bible-chapter-picker';
 export {
+  BIBLE_READER_FONT,
   BibleReader,
   BibleThemeSettingsContent,
+  clampBibleReaderFontSize,
+  createBibleThemeSettingsContentHandlers,
+  nextBibleReaderFontSizeDown,
+  nextBibleReaderFontSizeUp,
   type BibleReaderRootProps,
   type BibleReaderToolbarProps,
-  type BibleThemeSettingsData,
   type BibleThemeSettingsContentProps,
+  type BibleThemeSettingsSnapshot,
   type BibleThemeSettingsValues,
 } from './bible-reader';
 export {


### PR DESCRIPTION
## Summary

Make `BibleReader`'s theme settings reusable from the React Native Expo SDK by extracting the settings UI from its web-only popover shell, exposing a serializable callback payload, and inverting font-state ownership so a native host can drive it across the Expo DOM bridge.

The Web SDK's default behavior is unchanged when no callback is provided.

## What changed

### New / changed public API

- **`BibleThemeSettingsContent`** — exported standalone settings UI (font size A/A controls + Inter / Source Serif picker). Renders without a popover so it can live inside a native sheet, modal, route, etc.
- **`onOpenBibleThemeSettings(snapshot)`** — optional callback on `BibleReader.Toolbar`. When provided, the gear button skips the Radix popover and fires this with a serializable snapshot. Suitable as an Expo DOM native action.
- **`BibleThemeSettingsSnapshot`** — pure data payload: `{ fontSize, fontFamily, minFontSize, maxFontSize }`. No functions, no DOM refs.
- **Controllable typography on `BibleReader.Root`** — `fontSize`, `defaultFontSize`, `onFontSizeChange` (and the `fontFamily` triplet). Implemented via `useControllableState`. When the change handler is provided, the SDK treats that axis as controlled and skips its own `localStorage` reads/writes. Uncontrolled axes keep persisting to `localStorage` exactly like before.
- **Exported font math** — `BIBLE_READER_FONT` (bounds + step), `clampBibleReaderFontSize`, `nextBibleReaderFontSizeUp`, `nextBibleReaderFontSizeDown`. Lets a native host compute next state locally without a bridge round-trip.
- **`createBibleThemeSettingsContentHandlers`** — helper that builds the three top-level handler props (`onFontIncreased`, `onFontDecreased`, `onFontSelected`) for `BibleThemeSettingsContent` from host-owned `getFontSize` / `getFontFamily` / `setFontSize` / `setFontFamily`. Required because Expo DOM only allows functions as top-level props, not nested in objects.

### Behavior by environment

| Mode | Settings shell | Source of truth | Persistence |
|---|---|---|---|
| Web (default) | Radix popover with `BibleThemeSettingsContent` | Web SDK internal | `localStorage` |
| Web with `onOpenBibleThemeSettings` | Consumer-owned UI | Consumer (when also controlled) | Consumer's choice |
| RN via Expo DOM | `NativeSheet` rendering a pre-warmed `BibleThemeSettingsContent` DOM component | Native (RN state / store) | Native (AsyncStorage / etc.) |

The same source file covers all three by varying which props the consumer passes.

## Why these shapes

This PR aligns the surface with the [RN Expo migration playbook](https://github.com/youversion/platform-sdk-reactnative-expo)'s native-action contract:

- Payloads must be plain serializable data (no closures over Web SDK state).
- Functions across the WebView bridge must be top-level props, never nested in objects.
- Coordination state must be owned outside the DOM runtime — hence the controllable props.

Earlier iterations of this PR shipped `onFontIncreased` / `onFontDecreased` / `onFontSelected` *inside* the callback payload. Those are removed: closures over `themesSettingsValuesRef` / `setCurrentFontSize` couldn't survive the Expo DOM bridge, and they fought any attempt by native to be the source of truth.

## Backward compatibility

- Default `<BibleReader.Toolbar />` (no callback) renders the same Radix popover with the same controls and the same `localStorage` keys.
- `<BibleReader.Root />` without controlled props behaves exactly as before, including the `localStorage` seed-on-mount.
- Existing `fontSize` / `fontFamily` props still work as initial values when no `onFontSizeChange` / `onFontFamilyChange` is supplied.

## Test plan

- [x] `pnpm --filter @youversion/platform-react-ui test -- bible-reader.test` — 6 passing
  - default popover path: opens, A+ updates `localStorage`, font selection updates `localStorage`
  - callback path: snapshot is exactly `{ fontSize, fontFamily, minFontSize, maxFontSize }`, popover is suppressed
  - controlled-host path: native ownership simulated, `localStorage` stays untouched
  - `clampBibleReaderFontSize`, `nextBibleReaderFontSizeUp/Down`
  - `createBibleThemeSettingsContentHandlers` calls host setters with stepped values
- [x] Manual: web reader toolbar settings popover still opens, font and size persist across reloads

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts the Bible reader theme-settings UI into a standalone `BibleThemeSettingsContent` component and adds an optional `onOpenBibleThemeSettings` callback to `BibleReader.Toolbar`. Together, these allow React Native Expo DOM hosts to own font state and render the settings UI in a native sheet rather than the web Radix popover.

- **New exports**: `BibleThemeSettingsContent`, `BibleThemeSettingsSnapshot`, `BIBLE_READER_FONT`, `clampBibleReaderFontSize`, `nextBibleReaderFontSizeUp/Down`, and `createBibleThemeSettingsContentHandlers` for native-side use.
- **Controlled typography on `BibleReader.Root`**: `fontSize`/`defaultFontSize`/`onFontSizeChange` (and the `fontFamily` triplet) via `useControllableState`, with localStorage reads/writes gated behind `isFontSizeControlled`/`isFontFamilyControlled` flags so the native host is never fighting `localStorage`.
- **Backward compatibility**: all existing uncontrolled, default-popover behavior is preserved exactly; the `disabled` attribute (not just `aria-disabled`) is now applied to A/A buttons at font bounds.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge. The controlled/uncontrolled font state split is implemented correctly, localStorage reads/writes are properly gated, and the serializable snapshot contract is clean.

The two-mode architecture is well-executed: the didHydrateThemeSettingsRef guard addresses the double-hydration risk from the previous dep-array concern, and both disabled and aria-disabled are now set on the A/A buttons at bounds. No logic paths leave state inconsistent across the web and controlled-native modes.

No files require special attention; bible-reader.tsx is the most complex changed file but the state-management logic reads correctly.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/bible-reader.tsx | Core change: introduces useControllableState for font size/family, extracts BibleThemeSettingsContent, adds onOpenBibleThemeSettings callback path. Minor: normalizeReaderFontSizeForInitialization resets out-of-bounds values to DEFAULT rather than clamping. |
| packages/ui/src/components/bible-reader.test.tsx | New test file covering default popover, snapshot callback, controlled host path (localStorage stays clean), font math helpers, and createBibleThemeSettingsContentHandlers including onFontDecreased. |
| packages/ui/src/components/bible-reader.stories.tsx | Story updated to assert buttons are disabled at bounds instead of clicking past them. |
| packages/ui/src/components/index.ts | Expands public exports to include new types, BibleThemeSettingsContent, and font math utilities. All new exports match their definitions in bible-reader.tsx. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fbible-reader.tsx%3A124-129%0A%60normalizeReaderFontSizeForInitialization%60%20resets%20any%20out-of-bounds%20%60fontSize%60%20prop%20to%20%60DEFAULT_FONT_SIZE%60%20%2816%29%20instead%20of%20clamping%20it%20to%20the%20nearest%20bound.%20A%20consumer%20who%20passes%20%60fontSize%3D%7B22%7D%60%20%28or%20picks%20up%20an%20out-of-range%20value%20from%20remote%20config%29%20would%20silently%20start%20at%2016%20rather%20than%20the%20max%20of%2020%2C%20while%20%60clampBibleReaderFontSize%60%20%E2%80%94%20which%20is%20already%20exported%20%E2%80%94%20would%20give%20the%20expected%20clamped%20result.%20Consider%20delegating%20to%20%60clampBibleReaderFontSize%60%20here%20for%20consistent%20semantics.%0A%0A%60%60%60suggestion%0Afunction%20normalizeReaderFontSizeForInitialization%28size%3A%20number%29%3A%20number%20%7B%0A%20%20return%20clampBibleReaderFontSize%28size%29%3B%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fbible-reader.tsx%3A567-603%0AWhen%20%60onOpenBibleThemeSettings%60%20is%20provided%20the%20popover%20branch%20is%20never%20rendered%2C%20making%20%60applyThemeSettings%60%2C%20%60handleFontIncreased%60%2C%20%60handleFontDecreased%60%2C%20and%20%60handleFontSelected%60%20dead%20code%20in%20that%20path.%20They're%20harmless%2C%20but%20defining%20them%20unconditionally%20adds%20noise%20and%20creates%20inline%20arrow-function%20allocations%20on%20every%20render%20even%20when%20the%20popover%20is%20never%20shown.%20Wrapping%20them%20behind%20a%20%60!onOpenBibleThemeSettings%60%20guard%20would%20make%20the%20two%20paths%20explicit%20and%20eliminate%20the%20allocations.%0A%0A&repo=youversion%2Fplatform-sdk-react&pr=227&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fbible-reader.tsx%3A124-129%0A%60normalizeReaderFontSizeForInitialization%60%20resets%20any%20out-of-bounds%20%60fontSize%60%20prop%20to%20%60DEFAULT_FONT_SIZE%60%20%2816%29%20instead%20of%20clamping%20it%20to%20the%20nearest%20bound.%20A%20consumer%20who%20passes%20%60fontSize%3D%7B22%7D%60%20%28or%20picks%20up%20an%20out-of-range%20value%20from%20remote%20config%29%20would%20silently%20start%20at%2016%20rather%20than%20the%20max%20of%2020%2C%20while%20%60clampBibleReaderFontSize%60%20%E2%80%94%20which%20is%20already%20exported%20%E2%80%94%20would%20give%20the%20expected%20clamped%20result.%20Consider%20delegating%20to%20%60clampBibleReaderFontSize%60%20here%20for%20consistent%20semantics.%0A%0A%60%60%60suggestion%0Afunction%20normalizeReaderFontSizeForInitialization%28size%3A%20number%29%3A%20number%20%7B%0A%20%20return%20clampBibleReaderFontSize%28size%29%3B%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fbible-reader.tsx%3A567-603%0AWhen%20%60onOpenBibleThemeSettings%60%20is%20provided%20the%20popover%20branch%20is%20never%20rendered%2C%20making%20%60applyThemeSettings%60%2C%20%60handleFontIncreased%60%2C%20%60handleFontDecreased%60%2C%20and%20%60handleFontSelected%60%20dead%20code%20in%20that%20path.%20They're%20harmless%2C%20but%20defining%20them%20unconditionally%20adds%20noise%20and%20creates%20inline%20arrow-function%20allocations%20on%20every%20render%20even%20when%20the%20popover%20is%20never%20shown.%20Wrapping%20them%20behind%20a%20%60!onOpenBibleThemeSettings%60%20guard%20would%20make%20the%20two%20paths%20explicit%20and%20eliminate%20the%20allocations.%0A%0A&pr=227&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/ui/src/components/bible-reader.tsx:124-129
`normalizeReaderFontSizeForInitialization` resets any out-of-bounds `fontSize` prop to `DEFAULT_FONT_SIZE` (16) instead of clamping it to the nearest bound. A consumer who passes `fontSize={22}` (or picks up an out-of-range value from remote config) would silently start at 16 rather than the max of 20, while `clampBibleReaderFontSize` — which is already exported — would give the expected clamped result. Consider delegating to `clampBibleReaderFontSize` here for consistent semantics.

```suggestion
function normalizeReaderFontSizeForInitialization(size: number): number {
  return clampBibleReaderFontSize(size);
}
```

### Issue 2 of 2
packages/ui/src/components/bible-reader.tsx:567-603
When `onOpenBibleThemeSettings` is provided the popover branch is never rendered, making `applyThemeSettings`, `handleFontIncreased`, `handleFontDecreased`, and `handleFontSelected` dead code in that path. They're harmless, but defining them unconditionally adds noise and creates inline arrow-function allocations on every render even when the popover is never shown. Wrapping them behind a `!onOpenBibleThemeSettings` guard would make the two paths explicit and eliminate the allocations.

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into YPE-2258-react-..."](https://github.com/youversion/platform-sdk-react/commit/92ec6f593e34ff33467095d01ea1a40a5644cb9d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31194664)</sub>

<!-- /greptile_comment -->