### PR TITLE
YPE-2257 - Add Bible version picker composition APIs for later use in Expo DOM

### DIFF
--- a/.changeset/extract-version-picker-content.md
+++ b/.changeset/extract-version-picker-content.md
@@ -1,0 +1,5 @@
+---
+"@youversion/platform-react-ui": minor
+---
+
+Add advanced Bible version picker composition surfaces for Expo DOM integrations.

--- a/packages/ui/src/components/bible-version-picker.stories.tsx
+++ b/packages/ui/src/components/bible-version-picker.stories.tsx
@@ -151,7 +151,9 @@ export const InteractiveLanguageSelection: Story = {
 
     // Click language button
     const languageButton = await screen.findByRole('button', { name: /select language/i });
-    await expect(languageButton).toHaveTextContent('English');
+    await waitFor(async () => {
+      await expect(languageButton).toHaveTextContent('English');
+    });
     await userEvent.click(languageButton);
 
     // Verify language list is visible
@@ -168,7 +170,6 @@ export const InteractiveLanguageSelection: Story = {
         await screen.findByRole('button', { name: /select language/i }),
       ).toHaveTextContent(/korean/i);
     });
-    await userEvent.click(languageButton);
   },
 };
 

--- a/packages/ui/src/components/bible-version-picker.test.tsx
+++ b/packages/ui/src/components/bible-version-picker.test.tsx
@@ -14,7 +14,12 @@ class ResizeObserverMock {
 }
 globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
 
-import { BibleVersionPicker, RECENT_VERSIONS_KEY } from './bible-version-picker';
+import {
+  BibleLanguagePickerContent,
+  BibleVersionPicker,
+  BibleVersionPickerLanguageTrigger,
+  RECENT_VERSIONS_KEY,
+} from './bible-version-picker';
 import {
   useVersions,
   useVersion,
@@ -23,7 +28,7 @@ import {
   useFilteredVersions,
   useTheme,
 } from '@youversion/platform-react-hooks';
-import type { BibleVersion } from '@youversion/platform-core';
+import type { BibleVersion, Language } from '@youversion/platform-core';
 
 vi.mock('@youversion/platform-react-hooks');
 
@@ -50,6 +55,21 @@ const mockVersions: BibleVersion[] = [
   },
 ];
 
+const mockLanguages: Language[] = [
+  {
+    id: 'en',
+    language: 'English',
+    display_names: { en: 'English' },
+    speaking_population: 1500000000,
+  },
+  {
+    id: 'es',
+    language: 'Spanish',
+    display_names: { en: 'Spanish', es: 'Español' },
+    speaking_population: 500000000,
+  },
+];
+
 function setupDefaultMocks({
   versionsLoading = false,
   filteredVersions = mockVersions,
@@ -71,12 +91,15 @@ function setupDefaultMocks({
     refetch: vi.fn(),
   });
 
-  vi.mocked(useLanguages).mockReturnValue({
-    languages: { data: [], next_page_token: null },
+  vi.mocked(useLanguages).mockImplementation((params: Parameters<typeof useLanguages>[0]) => ({
+    languages: {
+      data: params && 'country' in params ? [mockLanguages[0]!] : mockLanguages,
+      next_page_token: null,
+    },
     loading: false,
     error: null,
     refetch: vi.fn(),
-  });
+  }));
 
   vi.mocked(useLanguage).mockReturnValue({
     language: { id: 'en', display_names: { en: 'English' }, language: 'English' },
@@ -217,6 +240,168 @@ describe('BibleVersionPicker', () => {
           screen.getByRole('listitem', { name: /new living translation/i }),
         ).toBeInTheDocument();
       });
+    });
+  });
+
+  describe('onVersionPickerPress override', () => {
+    it('calls onVersionPickerPress with { versionId, languageId } when Trigger is clicked', async () => {
+      const user = userEvent.setup();
+      const onVersionPickerPress = vi.fn();
+
+      setupDefaultMocks();
+      render(
+        <BibleVersionPicker.Root versionId={111} onVersionPickerPress={onVersionPickerPress}>
+          <BibleVersionPicker.Trigger />
+        </BibleVersionPicker.Root>,
+      );
+
+      await user.click(screen.getByRole('button'));
+
+      expect(onVersionPickerPress).toHaveBeenCalledTimes(1);
+      expect(onVersionPickerPress).toHaveBeenCalledWith({
+        versionId: 111,
+        languageId: 'en',
+      });
+    });
+
+    it('does NOT render popover content when onVersionPickerPress is provided', () => {
+      setupDefaultMocks();
+      render(
+        <BibleVersionPicker.Root versionId={111} onVersionPickerPress={vi.fn()}>
+          <BibleVersionPicker.Trigger />
+        </BibleVersionPicker.Root>,
+      );
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      expect(screen.queryByPlaceholderText('Search')).not.toBeInTheDocument();
+    });
+
+    it('uses controlled languageId in onVersionPickerPress payload', async () => {
+      const user = userEvent.setup();
+      const onVersionPickerPress = vi.fn();
+
+      setupDefaultMocks();
+      render(
+        <BibleVersionPicker.Root
+          versionId={111}
+          languageId="es"
+          onVersionPickerPress={onVersionPickerPress}
+        >
+          <BibleVersionPicker.Trigger />
+        </BibleVersionPicker.Root>,
+      );
+
+      await user.click(screen.getByRole('button'));
+
+      expect(onVersionPickerPress).toHaveBeenCalledWith({
+        versionId: 111,
+        languageId: 'es',
+      });
+    });
+
+    it('does not call onVersionPickerPress when trigger click is prevented', async () => {
+      const user = userEvent.setup();
+      const onVersionPickerPress = vi.fn();
+
+      setupDefaultMocks();
+      render(
+        <BibleVersionPicker.Root versionId={111} onVersionPickerPress={onVersionPickerPress}>
+          <BibleVersionPicker.Trigger onClick={(event) => event.preventDefault()} />
+        </BibleVersionPicker.Root>,
+      );
+
+      await user.click(screen.getByRole('button'));
+
+      expect(onVersionPickerPress).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('standalone content', () => {
+    it('renders version content and calls onRequestClose after version selection', async () => {
+      const user = userEvent.setup();
+      const onVersionChange = vi.fn();
+      const onRequestClose = vi.fn();
+
+      setupDefaultMocks();
+      render(
+        <BibleVersionPicker.Root
+          versionId={111}
+          onVersionChange={onVersionChange}
+          onVersionPickerPress={vi.fn()}
+        >
+          <BibleVersionPicker.Content onRequestClose={onRequestClose} />
+        </BibleVersionPicker.Root>,
+      );
+
+      await user.click(screen.getByRole('listitem', { name: /new living translation/i }));
+
+      expect(onVersionChange).toHaveBeenCalledWith(206);
+      expect(onRequestClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders language content and calls onRequestClose after language selection', async () => {
+      const user = userEvent.setup();
+      const onLanguageChange = vi.fn();
+      const onRequestClose = vi.fn();
+
+      setupDefaultMocks();
+      render(
+        <BibleVersionPicker.Root
+          versionId={111}
+          defaultLanguageId="es"
+          onLanguageChange={onLanguageChange}
+          onVersionPickerPress={vi.fn()}
+        >
+          <BibleLanguagePickerContent onRequestClose={onRequestClose} />
+        </BibleVersionPicker.Root>,
+      );
+
+      expect(screen.queryByText('Select Language')).not.toBeInTheDocument();
+      expect(screen.getByText('Suggested')).toBeInTheDocument();
+      await user.click(screen.getByRole('listitem', { name: /english/i }));
+
+      expect(onLanguageChange).toHaveBeenCalledWith('en');
+      expect(onRequestClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('language trigger calls custom click handler without opening default language view', async () => {
+      const user = userEvent.setup();
+      const onClick = vi.fn();
+
+      setupDefaultMocks();
+      render(
+        <BibleVersionPicker.Root versionId={111} onVersionPickerPress={vi.fn()}>
+          <BibleVersionPickerLanguageTrigger onClick={onClick} />
+          <BibleVersionPicker.Content open />
+        </BibleVersionPicker.Root>,
+      );
+
+      await user.click(screen.getByRole('button', { name: /select language/i }));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+      expect(screen.queryByText('All Languages')).not.toBeInTheDocument();
+    });
+
+    it('open=false clears version search for pre-warmed standalone content', async () => {
+      const user = userEvent.setup();
+
+      setupDefaultMocks();
+      const { rerender } = render(
+        <BibleVersionPicker.Root versionId={111} onVersionPickerPress={vi.fn()}>
+          <BibleVersionPicker.Content open />
+        </BibleVersionPicker.Root>,
+      );
+
+      await user.type(screen.getByPlaceholderText('Search'), 'nlt');
+      expect(screen.getByPlaceholderText('Search')).toHaveValue('nlt');
+
+      rerender(
+        <BibleVersionPicker.Root versionId={111} onVersionPickerPress={vi.fn()}>
+          <BibleVersionPicker.Content open={false} />
+        </BibleVersionPicker.Root>,
+      );
+
+      expect(screen.getByPlaceholderText('Search')).toHaveValue('');
     });
   });
 });

--- a/packages/ui/src/components/bible-version-picker.test.tsx
+++ b/packages/ui/src/components/bible-version-picker.test.tsx
@@ -364,7 +364,7 @@ describe('BibleVersionPicker', () => {
       expect(onRequestClose).toHaveBeenCalledTimes(1);
     });
 
-    it('language trigger calls custom click handler without opening default language view', async () => {
+    it('language trigger calls custom click handler without preventing default behavior', async () => {
       const user = userEvent.setup();
       const onClick = vi.fn();
 
@@ -372,13 +372,29 @@ describe('BibleVersionPicker', () => {
       render(
         <BibleVersionPicker.Root versionId={111} onVersionPickerPress={vi.fn()}>
           <BibleVersionPickerLanguageTrigger onClick={onClick} />
-          <BibleVersionPicker.Content open />
         </BibleVersionPicker.Root>,
       );
 
       await user.click(screen.getByRole('button', { name: /select language/i }));
 
       expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('language trigger does not open default language view when click is prevented', async () => {
+      const user = userEvent.setup();
+
+      setupDefaultMocks();
+      render(
+        <BibleVersionPicker.Root versionId={111}>
+          <BibleVersionPicker.Trigger />
+          <BibleVersionPickerLanguageTrigger onClick={(event) => event.preventDefault()} />
+          <BibleVersionPicker.Content />
+        </BibleVersionPicker.Root>,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'NIV' }));
+      await user.click(screen.getAllByRole('button', { name: /select language/i })[0]!);
+
       expect(screen.queryByText('All Languages')).not.toBeInTheDocument();
     });
 

--- a/packages/ui/src/components/bible-version-picker.tsx
+++ b/packages/ui/src/components/bible-version-picker.tsx
@@ -9,7 +9,10 @@ import {
   useVersions,
 } from '@youversion/platform-react-hooks';
 import {
+  cloneElement,
   createContext,
+  isValidElement,
+  type MouseEvent,
   type ReactNode,
   useCallback,
   useContext,
@@ -152,6 +155,7 @@ type BibleVersionPickerContextType = {
   isPopoverOpen: boolean;
   setIsPopoverOpen: (open: boolean) => void;
   versionsLoading: boolean;
+  onVersionPickerPress?: (data: BibleVersionPickerPressData) => void;
 };
 
 const BibleVersionPickerContext = createContext<BibleVersionPickerContextType | null>(null);
@@ -167,16 +171,44 @@ function useBibleVersionPickerContext() {
 export type RootProps = {
   versionId: number;
   onVersionChange?: (versionId: number) => void;
+  languageId?: string;
+  defaultLanguageId?: string;
+  onLanguageChange?: (languageId: string) => void;
   background?: 'light' | 'dark';
   side?: 'top' | 'right' | 'bottom' | 'left';
+  onVersionPickerPress?: (data: BibleVersionPickerPressData) => void;
   children?: ReactNode;
 };
+
+export type BibleVersionPickerPressData = {
+  versionId: number;
+  languageId: string;
+};
+
+export type BibleVersionPickerContentProps = {
+  open?: boolean;
+  onRequestClose?: () => void;
+};
+
+export type BibleLanguagePickerContentProps = {
+  open?: boolean;
+  onRequestClose?: () => void;
+};
+
+export type BibleVersionPickerLanguageTriggerProps = Omit<
+  React.ComponentProps<typeof Button>,
+  'children'
+>;
 
 function Root({
   versionId: controlledVersionId,
   onVersionChange,
+  languageId: controlledLanguageId,
+  defaultLanguageId,
+  onLanguageChange,
   background,
   side = 'top',
+  onVersionPickerPress,
   children,
 }: RootProps) {
   const [versionId, setVersionIdState] = useControllableState({
@@ -188,9 +220,15 @@ function Root({
   const providerTheme = useTheme();
   const theme = background || providerTheme;
 
-  const [selectedLanguageId, setSelectedLanguageId] = useState(
-    (typeof navigator !== 'undefined' && navigator.languages[0]?.split('-')[0]) || 'en',
-  );
+  const fallbackLanguageId =
+    defaultLanguageId ||
+    (typeof navigator !== 'undefined' && navigator.languages[0]?.split('-')[0]) ||
+    'en';
+  const [selectedLanguageId, setSelectedLanguageId] = useControllableState({
+    prop: controlledLanguageId,
+    defaultProp: fallbackLanguageId,
+    onChange: onLanguageChange,
+  });
   const [searchQuery, setSearchQuery] = useState('');
   const [isLanguagesOpen, setIsLanguagesOpen] = useState(false);
   const [recentVersions, setRecentVersions] = useState<RecentVersion[]>(getRecentVersions);
@@ -314,7 +352,16 @@ function Root({
     isPopoverOpen,
     setIsPopoverOpen,
     versionsLoading,
+    onVersionPickerPress,
   };
+
+  if (onVersionPickerPress) {
+    return (
+      <BibleVersionPickerContext.Provider value={contextValue}>
+        {children}
+      </BibleVersionPickerContext.Provider>
+    );
+  }
 
   return (
     <BibleVersionPickerContext.Provider value={contextValue}>
@@ -335,7 +382,8 @@ export type BibleVersionPickerTriggerProps = Omit<
 };
 
 function Trigger({ asChild = true, children, ...props }: BibleVersionPickerTriggerProps) {
-  const { versionId, background } = useBibleVersionPickerContext();
+  const { versionId, selectedLanguageId, background, onVersionPickerPress } =
+    useBibleVersionPickerContext();
   const { version, loading } = useVersion(versionId);
 
   const content =
@@ -347,6 +395,30 @@ function Trigger({ asChild = true, children, ...props }: BibleVersionPickerTrigg
           </Button>
         );
 
+  const handlePress = (event: MouseEvent<HTMLButtonElement>) => {
+    props.onClick?.(event);
+    if (!event.defaultPrevented) {
+      onVersionPickerPress?.({ versionId, languageId: selectedLanguageId });
+    }
+  };
+
+  if (onVersionPickerPress) {
+    if (asChild && isValidElement<Record<string, unknown>>(content)) {
+      return cloneElement(content, {
+        'data-yv-sdk': true,
+        'data-yv-theme': background,
+        ...props,
+        onClick: handlePress,
+      });
+    }
+
+    return (
+      <button type="button" data-yv-sdk data-yv-theme={background} {...props} onClick={handlePress}>
+        {content}
+      </button>
+    );
+  }
+
   return (
     <PopoverTrigger data-yv-sdk data-yv-theme={background} asChild={asChild} {...props}>
       {content}
@@ -354,30 +426,23 @@ function Trigger({ asChild = true, children, ...props }: BibleVersionPickerTrigg
   );
 }
 
-function Content() {
+/** @internal Advanced composition surface for SDK integrations. */
+export function BibleVersionPickerLanguageTrigger({
+  'aria-label': ariaLabel = 'Select language',
+  className,
+  onClick,
+  size = 'sm',
+  variant = 'secondary',
+  ...props
+}: BibleVersionPickerLanguageTriggerProps): React.ReactElement {
   const {
-    searchQuery,
-    setSearchQuery,
     filteredVersions,
-    versionId,
-    setVersionId,
-    background,
-    side,
     setIsLanguagesOpen,
-    isLanguagesOpen,
-    totalLanguages,
     selectedLanguageId,
-    setSelectedLanguageId,
     recentVersions,
-    addRecentVersion,
-    suggestedLanguages,
-    languages,
-    setIsPopoverOpen,
+    searchQuery,
     versionsLoading,
   } = useBibleVersionPickerContext();
-  const providerTheme = useTheme();
-  const theme = background || providerTheme;
-
   const filteredRecentVersions = useMemo(() => {
     if (!searchQuery.trim()) return recentVersions;
     const query = searchQuery.trim().toLowerCase();
@@ -391,10 +456,72 @@ function Content() {
   // Fetch the selected language details (may not be in the paginated languages list)
   const { language: selectedLanguage } = useLanguage(selectedLanguageId);
 
-  const handleSelectLanguage = (languageId: string) => {
-    setSelectedLanguageId(languageId);
-    setIsLanguagesOpen(false);
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+    if (!onClick && !event.defaultPrevented) {
+      setIsLanguagesOpen(true);
+    }
   };
+
+  return (
+    <Button
+      aria-label={ariaLabel}
+      className={cn(
+        'yv:ml-auto yv:bg-card yv:border yv:border-transparent yv:hover:bg-card yv:hover:border-border yv:max-w-40',
+        className,
+      )}
+      size={size}
+      onClick={handleClick}
+      variant={variant}
+      {...props}
+    >
+      <GlobeIcon className="yv:size-4" />
+      <span className="yv:text-sm yv:font-medium yv:truncate">
+        {selectedLanguage?.display_names?.en || selectedLanguage?.language}
+      </span>
+      <Badge
+        variant="secondary"
+        className="yv:h-5 yv:min-w-5 yv:rounded-full yv:px-1 yv:font-mono yv:tabular-nums"
+      >
+        {versionsLoading ? (
+          <LoaderIcon className="yv:size-3 yv:animate-spin" />
+        ) : (
+          filteredVersions.length + filteredRecentVersions.length
+        )}
+      </Badge>
+    </Button>
+  );
+}
+
+function Content({ open, onRequestClose }: BibleVersionPickerContentProps = {}) {
+  const {
+    searchQuery,
+    setSearchQuery,
+    filteredVersions,
+    versionId,
+    setVersionId,
+    recentVersions,
+    addRecentVersion,
+    versionsLoading,
+    background,
+    side,
+    isLanguagesOpen,
+    setIsLanguagesOpen,
+    setIsPopoverOpen,
+    onVersionPickerPress,
+  } = useBibleVersionPickerContext();
+  const wasOpenRef = useRef(open ?? false);
+
+  const filteredRecentVersions = useMemo(() => {
+    if (!searchQuery.trim()) return recentVersions;
+    const query = searchQuery.trim().toLowerCase();
+    return recentVersions.filter(
+      (v) =>
+        v.title?.toLowerCase().includes(query) ||
+        v.localized_abbreviation?.toLowerCase().includes(query) ||
+        v.abbreviation?.toLowerCase().includes(query),
+    );
+  }, [recentVersions, searchQuery]);
 
   const handleSelectVersion = (version: BibleVersion | RecentVersion) => {
     setVersionId(version.id);
@@ -404,102 +531,66 @@ function Content() {
       localized_abbreviation: version.localized_abbreviation,
       abbreviation: version.abbreviation,
     });
-    setIsLanguagesOpen(false);
-    setIsPopoverOpen(false);
+    setSearchQuery('');
+    onRequestClose?.();
   };
 
-  function LanguagePicker() {
+  useEffect(() => {
+    if (wasOpenRef.current && open === false) {
+      setSearchQuery('');
+      setIsLanguagesOpen(false);
+    }
+    wasOpenRef.current = open ?? false;
+  }, [open, setIsLanguagesOpen, setSearchQuery]);
+
+  if (!onVersionPickerPress && open === undefined && !onRequestClose) {
     return (
-      <Button
-        aria-label="Select language"
-        className="yv:ml-auto yv:bg-card yv:border yv:border-transparent yv:hover:bg-card yv:hover:border-border yv:max-w-40"
-        size="sm"
-        onClick={() => setIsLanguagesOpen(true)}
-        variant="secondary"
+      <PopoverContent
+        sideOffset={16}
+        className="yv:h-[66svh]"
+        heading="Bible Versions"
+        headerChild={<BibleVersionPickerLanguageTrigger />}
+        theme={background}
+        side={side}
       >
-        <GlobeIcon className="yv:size-4" />
-        <span className="yv:text-sm yv:font-medium yv:truncate">
-          {selectedLanguage?.display_names?.en || selectedLanguage?.language}
-        </span>
-        <Badge
-          variant="secondary"
-          className="yv:h-5 yv:min-w-5 yv:rounded-full yv:px-1 yv:font-mono yv:tabular-nums"
+        <div
+          className={`yv:h-full yv:min-h-0 ${
+            isLanguagesOpen
+              ? 'yv:opacity-0 yv:pointer-events-none yv:blur-sm yv:scale-95'
+              : 'yv:opacity-100 yv:pointer-events-auto yv:blur-none yv:scale-100'
+          }`}
         >
-          {versionsLoading ? (
-            <LoaderIcon className="yv:size-3 yv:animate-spin" />
-          ) : (
-            filteredVersions.length + filteredRecentVersions.length
-          )}
-        </Badge>
-      </Button>
+          <Content onRequestClose={() => setIsPopoverOpen(false)} />
+        </div>
+        <div
+          className={`yv:h-full yv:absolute yv:inset-0 ${
+            isLanguagesOpen
+              ? 'yv:opacity-100 yv:pointer-events-auto yv:blur-none yv:scale-100'
+              : 'yv:opacity-0 yv:pointer-events-none yv:blur-sm yv:scale-95'
+          }`}
+        >
+          <LanguagePanel onRequestClose={() => setIsLanguagesOpen(false)} />
+        </div>
+      </PopoverContent>
     );
   }
 
   return (
-    <PopoverContent
-      sideOffset={16}
-      className="yv:h-[66svh]"
-      heading="Bible Versions"
-      headerChild={<LanguagePicker />}
-      theme={theme}
-      side={side}
+    <div
+      className="yv:overflow-y-auto yv:h-full yv:flex yv:flex-col yv:transition-all yv:duration-300 yv:rounded-2xl yv:origin-center"
+      data-yv-sdk
+      data-yv-theme={background}
     >
       {/* Versions View */}
-      <div
-        className={`yv:overflow-y-auto yv:h-full yv:flex yv:flex-col yv:transition-all yv:duration-300 yv:rounded-2xl yv:origin-center ${
-          isLanguagesOpen
-            ? 'yv:opacity-0 yv:pointer-events-none yv:blur-sm yv:scale-95'
-            : 'yv:opacity-100 yv:pointer-events-auto yv:blur-none yv:scale-100'
-        }`}
-      >
-        <div className="yv:flex-1 yv:overflow-y-auto yv:py-2">
-          {/* Recent Versions */}
-          {filteredRecentVersions.length > 0 && (
-            <>
-              <h2 className="yv:px-4 yv:py-2 yv:text-lg yv:font-bold">Recently Used Versions</h2>
-              <ItemGroup data-testid="recent-version-list">
-                {filteredRecentVersions.map((version) => (
-                  <Item
-                    key={`recent-${version.id}`}
-                    className={cn(
-                      'yv:hover:bg-muted yv:rounded-[8px]',
-                      versionId === version.id ? 'yv:bg-muted' : '',
-                    )}
-                    size="sm"
-                    variant="default"
-                    role="listitem"
-                    asChild
-                    aria-label={version.title}
-                  >
-                    <button
-                      type="button"
-                      className="yv:w-full"
-                      onClick={() => handleSelectVersion(version)}
-                    >
-                      <ItemMedia
-                        variant="icon"
-                        className="yv:rounded-[8px] yv:size-12 yv:border-border yv:flex yv:flex-col yv:justify-center yv:items-center"
-                      >
-                        <VersionAbbreviationIcon text={version.localized_abbreviation} />
-                      </ItemMedia>
-                      <ItemContent>
-                        <ItemTitle className="yv:line-clamp-2 yv:text-left">
-                          {version.title}
-                        </ItemTitle>
-                      </ItemContent>
-                    </button>
-                  </Item>
-                ))}
-              </ItemGroup>
-            </>
-          )}
-          {/* All Versions */}
-          {filteredVersions.length > 0 ? (
-            <ItemGroup data-testid="version-list">
-              <h3 className="yv:px-4 yv:py-2 yv:font-bold">All Versions</h3>
-              {filteredVersions.map((version: BibleVersion) => (
+      <div className="yv:flex-1 yv:overflow-y-auto yv:py-2">
+        {/* Recent Versions */}
+        {filteredRecentVersions.length > 0 && (
+          <>
+            <h2 className="yv:px-4 yv:py-2 yv:text-lg yv:font-bold">Recently Used Versions</h2>
+            <ItemGroup data-testid="recent-version-list">
+              {filteredRecentVersions.map((version) => (
                 <Item
-                  key={version.id}
+                  key={`recent-${version.id}`}
                   className={cn(
                     'yv:hover:bg-muted yv:rounded-[8px]',
                     versionId === version.id ? 'yv:bg-muted' : '',
@@ -530,18 +621,56 @@ function Content() {
                 </Item>
               ))}
             </ItemGroup>
-          ) : versionsLoading ? (
-            <div className="yv:w-full yv:flex yv:items-center yv:justify-center yv:py-8 yv:text-center yv:text-muted-foreground yv:text-sm">
-              <LoaderIcon className="yv:size-6 yv:animate-spin yv:text-muted-foreground" />
-            </div>
-          ) : !filteredRecentVersions.length ? (
-            <div className="yv:w-full yv:flex yv:items-center yv:justify-center yv:py-8 yv:text-center yv:text-muted-foreground yv:text-sm">
-              No versions found
-            </div>
-          ) : null}
-        </div>
+          </>
+        )}
+        {/* All Versions */}
+        {filteredVersions.length > 0 ? (
+          <ItemGroup data-testid="version-list">
+            <h3 className="yv:px-4 yv:py-2 yv:font-bold">All Versions</h3>
+            {filteredVersions.map((version: BibleVersion) => (
+              <Item
+                key={version.id}
+                className={cn(
+                  'yv:hover:bg-muted yv:rounded-[8px]',
+                  versionId === version.id ? 'yv:bg-muted' : '',
+                )}
+                size="sm"
+                variant="default"
+                role="listitem"
+                asChild
+                aria-label={version.title}
+              >
+                <button
+                  type="button"
+                  className="yv:w-full"
+                  onClick={() => handleSelectVersion(version)}
+                >
+                  <ItemMedia
+                    variant="icon"
+                    className="yv:rounded-[8px] yv:size-12 yv:border-border yv:flex yv:flex-col yv:justify-center yv:items-center"
+                  >
+                    <VersionAbbreviationIcon text={version.localized_abbreviation} />
+                  </ItemMedia>
+                  <ItemContent>
+                    <ItemTitle className="yv:line-clamp-2 yv:text-left">{version.title}</ItemTitle>
+                  </ItemContent>
+                </button>
+              </Item>
+            ))}
+          </ItemGroup>
+        ) : versionsLoading ? (
+          <div className="yv:w-full yv:flex yv:items-center yv:justify-center yv:py-8 yv:text-center yv:text-muted-foreground yv:text-sm">
+            <LoaderIcon className="yv:size-6 yv:animate-spin yv:text-muted-foreground" />
+          </div>
+        ) : !filteredRecentVersions.length ? (
+          <div className="yv:w-full yv:flex yv:items-center yv:justify-center yv:py-8 yv:text-center yv:text-muted-foreground yv:text-sm">
+            No versions found
+          </div>
+        ) : null}
+      </div>
 
-        <section className="yv:bg-muted yv:border-s yv:border-muted yv:p-4">
+      <section className="yv:bg-muted yv:border-s yv:border-muted yv:p-4">
+        <div className="yv:grid yv:grid-cols-[1fr_auto] yv:gap-2">
           <InputGroup className="yv:bg-background yv:shadow-none yv:border-border">
             <InputGroupInput
               tabIndex={1}
@@ -554,123 +683,150 @@ function Content() {
               <SearchIcon className="yv:size-5 yv:text-muted-foreground" />
             </InputGroupAddon>
           </InputGroup>
-        </section>
-      </div>
+        </div>
+      </section>
+    </div>
+  );
+}
 
-      {/* Languages View */}
-      <div
-        className={`yv:h-full yv:absolute yv:inset-0 yv:flex yv:flex-col yv:transition-all yv:duration-300 yv:rounded-2xl yv:origin-center ${
-          isLanguagesOpen
-            ? 'yv:opacity-100 yv:pointer-events-auto yv:blur-none yv:scale-100'
-            : 'yv:opacity-0 yv:pointer-events-none yv:blur-sm yv:scale-95'
-        }`}
-      >
-        <section className="yv:bg-muted yv:px-2 yv:py-3 yv:w-full yv:rounded-t-2xl yv:border-b yv:border-border yv:grid yv:grid-cols-[auto_1fr] yv:gap-2 yv:items-center">
-          <Button
-            onClick={() => setIsLanguagesOpen(false)}
-            variant="ghost"
-            size="icon"
-            className="yv:w-8 yv:h-8 yv:text-muted-foreground"
-          >
-            <ArrowLeftIcon className="yv:size-4" />
-            <span className="yv:sr-only">Close Language selector</span>
-          </Button>
-          <h2 className="yv:font-bold yv:text-base">Select Language</h2>
-        </section>
-
-        <Tabs
-          className="yv:mt-4 yv:gap-4 yv:flex-1 yv:min-h-0 yv:flex yv:flex-col"
-          defaultValue="suggested"
+function LanguagePanel({ onRequestClose }: BibleLanguagePickerContentProps = {}) {
+  return (
+    <div className="yv:h-full yv:flex yv:flex-col yv:transition-all yv:duration-300 yv:rounded-2xl yv:origin-center">
+      <section className="yv:bg-muted yv:px-2 yv:py-3 yv:w-full yv:rounded-t-2xl yv:border-b yv:border-border yv:grid yv:grid-cols-[auto_1fr] yv:gap-2 yv:items-center">
+        <Button
+          onClick={onRequestClose}
+          variant="ghost"
+          size="icon"
+          className="yv:w-8 yv:h-8 yv:text-muted-foreground"
         >
-          <TabsList className="yv:mx-4 yv:w-[calc(100%-4*var(--spacing))]">
-            <TabsTrigger className="yv:p-0" value="suggested">
-              Suggested
-            </TabsTrigger>
-            <TabsTrigger className="yv:p-0" value="all">
-              All ({totalLanguages})
-            </TabsTrigger>
-          </TabsList>
+          <ArrowLeftIcon className="yv:size-4" />
+          <span className="yv:sr-only">Close Language selector</span>
+        </Button>
+        <h2 className="yv:font-bold yv:text-base">Select Language</h2>
+      </section>
+      <BibleLanguagePickerContent onRequestClose={onRequestClose} />
+    </div>
+  );
+}
 
-          <TabsContent value="suggested" className="yv:overflow-y-auto yv:flex-1 yv:min-h-0">
-            {suggestedLanguages.length > 0 ? (
-              <>
-                <h3 className="yv:bg-popover yv:px-4 yv:pb-2 yv:text-lg yv:font-bold">Regional</h3>
-                <ItemGroup className="yv:gap-1">
-                  {suggestedLanguages.map((suggestedLanguage) => (
-                    <Item
-                      key={suggestedLanguage.id}
-                      className={cn(
-                        'yv:hover:bg-muted yv:rounded-[8px] yv:px-4',
-                        selectedLanguageId === suggestedLanguage.id ? 'yv:bg-muted' : '',
-                      )}
-                      size="sm"
-                      role="listitem"
-                      aria-label={suggestedLanguage.display_names?.en}
-                      asChild
-                    >
-                      <Button
-                        className="yv:w-full yv:h-auto"
-                        onClick={() => handleSelectLanguage(suggestedLanguage.id)}
-                        type="button"
-                        variant="ghost"
-                      >
-                        <ItemContent className="yv:flex yv:flex-row yv:justify-between yv:items-center">
-                          <ItemTitle className="yv:text-start yv:line-clamp-2 yv:min-w-0 yv:flex-1 yv:truncate">
-                            {suggestedLanguage.display_names?.en}
-                          </ItemTitle>
-                          <ItemDescription className="yv:shrink-0">
-                            {suggestedLanguage.display_names?.[suggestedLanguage.id]}
-                          </ItemDescription>
-                        </ItemContent>
-                      </Button>
-                    </Item>
-                  ))}
-                </ItemGroup>
-              </>
-            ) : (
-              <p className="yv:px-4 yv:py-8 yv:text-center yv:text-muted-foreground">
-                No regional languages available
-              </p>
-            )}
-          </TabsContent>
+/** @internal Advanced composition surface for SDK integrations. */
+export function BibleLanguagePickerContent({
+  open,
+  onRequestClose,
+}: BibleLanguagePickerContentProps = {}): React.ReactElement {
+  const {
+    totalLanguages,
+    selectedLanguageId,
+    setSelectedLanguageId,
+    suggestedLanguages,
+    languages,
+    background,
+  } = useBibleVersionPickerContext();
 
-          <TabsContent value="all" className="yv:overflow-y-auto yv:flex-1 yv:min-h-0">
-            <h3 className="yv:bg-popover yv:px-4 yv:pb-2 yv:text-lg yv:font-bold">All Languages</h3>
-            <ItemGroup className="yv:gap-1">
-              {languages.map((language) => (
-                <Item
-                  key={language.id}
-                  className={cn(
-                    'yv:hover:bg-muted yv:rounded-[8px] yv:px-4',
-                    selectedLanguageId === language.id ? 'yv:bg-muted' : '',
-                  )}
-                  size="sm"
-                  role="listitem"
-                  aria-label={language.display_names?.en}
-                  asChild
-                >
-                  <Button
-                    className="yv:w-full yv:h-auto"
-                    onClick={() => handleSelectLanguage(language.id)}
-                    type="button"
-                    variant="ghost"
+  const handleSelectLanguage = (languageId: string) => {
+    setSelectedLanguageId(languageId);
+    onRequestClose?.();
+  };
+
+  return (
+    <div
+      className="yv:h-full yv:flex yv:flex-col"
+      data-yv-sdk
+      data-yv-theme={background}
+      data-open={open}
+    >
+      <Tabs
+        className="yv:mt-4 yv:gap-4 yv:flex-1 yv:min-h-0 yv:flex yv:flex-col"
+        defaultValue="suggested"
+      >
+        <TabsList className="yv:mx-4 yv:w-[calc(100%-4*var(--spacing)*2)]">
+          <TabsTrigger className="yv:p-0" value="suggested">
+            Suggested
+          </TabsTrigger>
+          <TabsTrigger className="yv:p-0" value="all">
+            All ({totalLanguages})
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="suggested" className="yv:overflow-y-auto yv:flex-1 yv:min-h-0">
+          {suggestedLanguages.length > 0 ? (
+            <>
+              <h3 className="yv:bg-popover yv:px-4 yv:pb-2 yv:text-lg yv:font-bold">Regional</h3>
+              <ItemGroup className="yv:gap-1">
+                {suggestedLanguages.map((suggestedLanguage) => (
+                  <Item
+                    key={suggestedLanguage.id}
+                    className={cn(
+                      'yv:hover:bg-muted yv:rounded-[8px] yv:px-4',
+                      selectedLanguageId === suggestedLanguage.id ? 'yv:bg-muted' : '',
+                    )}
+                    size="sm"
+                    role="listitem"
+                    aria-label={suggestedLanguage.display_names?.en}
+                    asChild
                   >
-                    <ItemContent className="yv:flex yv:flex-row yv:justify-between yv:items-center">
-                      <ItemTitle className="yv:text-start yv:line-clamp-2 yv:truncate yv:min-w-0 yv:max-w-2/3 yv:flex-1">
-                        {language.display_names?.en}
-                      </ItemTitle>
-                      <ItemDescription className="yv:text-end yv:shrink-0 yv:max-w-1/3">
-                        {language.display_names?.[language.id]}
-                      </ItemDescription>
-                    </ItemContent>
-                  </Button>
-                </Item>
-              ))}
-            </ItemGroup>
-          </TabsContent>
-        </Tabs>
-      </div>
-    </PopoverContent>
+                    <Button
+                      className="yv:w-full yv:h-auto"
+                      onClick={() => handleSelectLanguage(suggestedLanguage.id)}
+                      type="button"
+                      variant="ghost"
+                    >
+                      <ItemContent className="yv:flex yv:flex-row yv:justify-between yv:items-center">
+                        <ItemTitle className="yv:text-start yv:line-clamp-2 yv:min-w-0 yv:flex-1 yv:truncate">
+                          {suggestedLanguage.display_names?.en}
+                        </ItemTitle>
+                        <ItemDescription className="yv:shrink-0">
+                          {suggestedLanguage.display_names?.[suggestedLanguage.id]}
+                        </ItemDescription>
+                      </ItemContent>
+                    </Button>
+                  </Item>
+                ))}
+              </ItemGroup>
+            </>
+          ) : (
+            <p className="yv:px-4 yv:py-8 yv:text-center yv:text-muted-foreground">
+              No regional languages available
+            </p>
+          )}
+        </TabsContent>
+
+        <TabsContent value="all" className="yv:overflow-y-auto yv:flex-1 yv:min-h-0">
+          <h3 className="yv:bg-popover yv:px-4 yv:pb-2 yv:text-lg yv:font-bold">All Languages</h3>
+          <ItemGroup className="yv:gap-1">
+            {languages.map((language) => (
+              <Item
+                key={language.id}
+                className={cn(
+                  'yv:hover:bg-muted yv:rounded-[8px] yv:px-4',
+                  selectedLanguageId === language.id ? 'yv:bg-muted' : '',
+                )}
+                size="sm"
+                role="listitem"
+                aria-label={language.display_names?.en}
+                asChild
+              >
+                <Button
+                  className="yv:w-full yv:h-auto"
+                  onClick={() => handleSelectLanguage(language.id)}
+                  type="button"
+                  variant="ghost"
+                >
+                  <ItemContent className="yv:flex yv:flex-row yv:justify-between yv:items-center">
+                    <ItemTitle className="yv:text-start yv:line-clamp-2 yv:truncate yv:min-w-0 yv:max-w-2/3 yv:flex-1">
+                      {language.display_names?.en}
+                    </ItemTitle>
+                    <ItemDescription className="yv:text-end yv:shrink-0 yv:max-w-1/3">
+                      {language.display_names?.[language.id]}
+                    </ItemDescription>
+                  </ItemContent>
+                </Button>
+              </Item>
+            ))}
+          </ItemGroup>
+        </TabsContent>
+      </Tabs>
+    </div>
   );
 }
 

--- a/packages/ui/src/components/bible-version-picker.tsx
+++ b/packages/ui/src/components/bible-version-picker.tsx
@@ -431,7 +431,8 @@ function Trigger({ asChild = true, children, ...props }: BibleVersionPickerTrigg
  *
  * `onClick` is a DOM-local event handler. Expo DOM wrappers should expose a
  * top-level async native action prop and call it from an internal `onClick`
- * adapter instead of passing native callbacks through as React event handlers.
+ * adapter that calls `event.preventDefault()` instead of passing native
+ * callbacks through as React event handlers.
  */
 export function BibleVersionPickerLanguageTrigger({
   'aria-label': ariaLabel = 'Select language',
@@ -464,7 +465,7 @@ export function BibleVersionPickerLanguageTrigger({
 
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
     onClick?.(event);
-    if (!onClick && !event.defaultPrevented) {
+    if (!event.defaultPrevented) {
       setIsLanguagesOpen(true);
     }
   };

--- a/packages/ui/src/components/bible-version-picker.tsx
+++ b/packages/ui/src/components/bible-version-picker.tsx
@@ -426,7 +426,13 @@ function Trigger({ asChild = true, children, ...props }: BibleVersionPickerTrigg
   );
 }
 
-/** @internal Advanced composition surface for SDK integrations. */
+/**
+ * @internal Advanced composition surface for SDK integrations.
+ *
+ * `onClick` is a DOM-local event handler. Expo DOM wrappers should expose a
+ * top-level async native action prop and call it from an internal `onClick`
+ * adapter instead of passing native callbacks through as React event handlers.
+ */
 export function BibleVersionPickerLanguageTrigger({
   'aria-label': ariaLabel = 'Select language',
   className,
@@ -709,7 +715,12 @@ function LanguagePanel({ onRequestClose }: BibleLanguagePickerContentProps = {})
   );
 }
 
-/** @internal Advanced composition surface for SDK integrations. */
+/**
+ * @internal Advanced composition surface for SDK integrations.
+ *
+ * Expo DOM wrappers should compose this content inside the `'use dom'` file and
+ * expose only serializable props plus top-level async native actions to native.
+ */
 export function BibleLanguagePickerContent({
   open,
   onRequestClose,

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -9,8 +9,14 @@ export {
 export { BibleReader, type BibleReaderRootProps } from './bible-reader';
 export {
   BibleVersionPicker,
+  BibleLanguagePickerContent,
+  BibleVersionPickerLanguageTrigger,
   type BibleVersionPickerRootProps,
   type BibleVersionPickerTriggerProps,
+  type BibleVersionPickerPressData,
+  type BibleVersionPickerContentProps,
+  type BibleLanguagePickerContentProps,
+  type BibleVersionPickerLanguageTriggerProps,
 } from './bible-version-picker';
 export { YouVersionAuthButton, type YouVersionAuthButtonProps } from './YouVersionAuthButton';
 export { VerseOfTheDay, type VerseOfTheDayProps } from './verse-of-the-day';


### PR DESCRIPTION
https://lifechurch.atlassian.net/browse/YPE-2257

https://github.com/user-attachments/assets/be7beba4-ab74-4190-badf-47837d292a19

## Summary

Adds advanced composition surfaces for the Bible version picker so the React Native Expo SDK can reuse Web SDK picker content inside Expo DOM/native presentation.

## Changes

- Adds controlled language state to `BibleVersionPicker.Root` via `languageId`, `defaultLanguageId`, and `onLanguageChange`.
- Adds `BibleVersionPickerLanguageTrigger` for reusable Web SDK language trigger UI.
- Extracts `BibleLanguagePickerContent` as body-only language picker content for SDK/native sheet composition.
- Adds `open` handling to picker content so pre-warmed DOM surfaces can clear transient search state on close.
- Adds a minor changeset for the new UI composition APIs.
- Expands picker tests for callback mode, controlled language state, close reset behavior, and standalone content.

## Validation

- `pnpm --filter @youversion/platform-react-ui test -- bible-version-picker`
- `pnpm --filter @youversion/platform-react-ui test -- bible-chapter-picker`
- `pnpm --filter @youversion/platform-react-ui typecheck`
- `pnpm --filter @youversion/platform-react-ui build`
- pre-commit lint-staged hook passed during commit

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds composition surfaces for the Bible version picker so Expo DOM/native sheets can reuse the existing Web SDK picker UI. It introduces controlled language state, `BibleVersionPickerLanguageTrigger`, and `BibleLanguagePickerContent` as standalone exported components, and refactors `Content` to serve both popover and standalone scenarios via a runtime branch.

- **Controlled language state** is wired through `useControllableState` on `Root`, with `languageId`, `defaultLanguageId`, and `onLanguageChange` props; `onVersionPickerPress` bypasses the `Popover` wrapper so Expo can open a native sheet instead.
- **`BibleVersionPickerLanguageTrigger`** and **`BibleLanguagePickerContent`** are extracted from `Content` into individually exportable components, each reading shared state from context.
- **`Content` refactor** adds an `open` prop for pre-warmed DOM reset and splits into popover vs. standalone render paths based on whether `onVersionPickerPress`, `open`, or `onRequestClose` are present.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all changes are additive composition APIs with good test coverage, and the one visual regression is minor and easily patched.

The refactor is well-scoped: new exports are additive, the Root branching logic is straightforward, and controlled state is handled by the existing useControllableState primitive. The only concrete defect found — missing transition classes on the popover-mode animation wrappers — causes panels to snap rather than blend but has no effect on correctness or state management.

The animation wrapper divs inside the popover branch of Content in bible-version-picker.tsx are missing transition-all duration-300.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/ui/src/components/bible-version-picker.tsx | Extracts language trigger and language content into standalone exported components; adds controlled language state and onVersionPickerPress to Root; refactors Content into popover/standalone branches. Animation transition classes are missing from the popover-mode wrapper divs, causing snap instead of smooth blend. |
| packages/ui/src/components/bible-version-picker.test.tsx | Adds thorough tests for onVersionPickerPress callback mode, controlled languageId, open-prop reset behavior, and standalone BibleLanguagePickerContent/BibleVersionPickerLanguageTrigger. |
| packages/ui/src/components/index.ts | Exports the two new composition components and their prop types; no issues. |
| packages/ui/src/components/bible-version-picker.stories.tsx | Wraps assertion in waitFor to handle async rendering and removes a spurious extra click; straightforward fix. |
| .changeset/extract-version-picker-content.md | Minor changeset entry for the new composition APIs; correctly categorised as minor. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Root["BibleVersionPicker.Root\n(versionId, languageId, onVersionPickerPress, ...)"]
    Root -->|onVersionPickerPress set| CtxOnly["Context.Provider\n(no Popover wrapper)"]
    Root -->|no onVersionPickerPress| PopoverWrap["Context.Provider\n+ Popover wrapper"]

    CtxOnly --> Trigger["BibleVersionPicker.Trigger\n→ calls onVersionPickerPress on click"]
    CtxOnly --> LangTrigger["BibleVersionPickerLanguageTrigger\n→ sets isLanguagesOpen via context"]
    CtxOnly --> StandaloneContent["BibleVersionPicker.Content\n(open, onRequestClose)\n→ standalone div"]
    CtxOnly --> LangContent["BibleLanguagePickerContent\n(open, onRequestClose)\n→ standalone div"]

    PopoverWrap --> PopoverTrigger["BibleVersionPicker.Trigger\n→ PopoverTrigger"]
    PopoverWrap --> PopoverContent["BibleVersionPicker.Content\n(no props)\n→ PopoverContent\n  ├─ Content (onRequestClose)\n  └─ LanguagePanel (onRequestClose)"]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/ui/src/components/bible-version-picker.tsx`, line 853-870 ([link](https://github.com/youversion/platform-sdk-react/blob/56aac3ee3674ba37e7c26e01e3fdca51997f7572/packages/ui/src/components/bible-version-picker.tsx#L853-L870)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`BibleLanguagePickerContent` does not reset its tab state when `open` transitions to `false`**

   `Content` has a `useEffect` that calls `setSearchQuery('')` and `setIsLanguagesOpen(false)` when `open` flips to `false`, ensuring pre-warmed surfaces return to a clean state on close. `BibleLanguagePickerContent` accepts the same `open` prop but only writes it to a `data-open` attribute — it has no equivalent cleanup effect. In Expo pre-warmed DOM scenarios, a user who navigated to the "All" tab would see it still selected on reopen.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/ui/src/components/bible-version-picker.tsx
   Line: 853-870

   Comment:
   **`BibleLanguagePickerContent` does not reset its tab state when `open` transitions to `false`**

   `Content` has a `useEffect` that calls `setSearchQuery('')` and `setIsLanguagesOpen(false)` when `open` flips to `false`, ensuring pre-warmed surfaces return to a clean state on close. `BibleLanguagePickerContent` accepts the same `open` prop but only writes it to a `data-open` attribute — it has no equivalent cleanup effect. In Expo pre-warmed DOM scenarios, a user who navigated to the "All" tab would see it still selected on reopen.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fui%2Fsrc%2Fcomponents%2Fbible-version-picker.tsx%0ALine%3A%20853-870%0A%0AComment%3A%0A**%60BibleLanguagePickerContent%60%20does%20not%20reset%20its%20tab%20state%20when%20%60open%60%20transitions%20to%20%60false%60**%0A%0A%60Content%60%20has%20a%20%60useEffect%60%20that%20calls%20%60setSearchQuery%28''%29%60%20and%20%60setIsLanguagesOpen%28false%29%60%20when%20%60open%60%20flips%20to%20%60false%60%2C%20ensuring%20pre-warmed%20surfaces%20return%20to%20a%20clean%20state%20on%20close.%20%60BibleLanguagePickerContent%60%20accepts%20the%20same%20%60open%60%20prop%20but%20only%20writes%20it%20to%20a%20%60data-open%60%20attribute%20%E2%80%94%20it%20has%20no%20equivalent%20cleanup%20effect.%20In%20Expo%20pre-warmed%20DOM%20scenarios%2C%20a%20user%20who%20navigated%20to%20the%20%22All%22%20tab%20would%20see%20it%20still%20selected%20on%20reopen.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-react&pr=228&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fui%2Fsrc%2Fcomponents%2Fbible-version-picker.tsx%0ALine%3A%20853-870%0A%0AComment%3A%0A**%60BibleLanguagePickerContent%60%20does%20not%20reset%20its%20tab%20state%20when%20%60open%60%20transitions%20to%20%60false%60**%0A%0A%60Content%60%20has%20a%20%60useEffect%60%20that%20calls%20%60setSearchQuery%28''%29%60%20and%20%60setIsLanguagesOpen%28false%29%60%20when%20%60open%60%20flips%20to%20%60false%60%2C%20ensuring%20pre-warmed%20surfaces%20return%20to%20a%20clean%20state%20on%20close.%20%60BibleLanguagePickerContent%60%20accepts%20the%20same%20%60open%60%20prop%20but%20only%20writes%20it%20to%20a%20%60data-open%60%20attribute%20%E2%80%94%20it%20has%20no%20equivalent%20cleanup%20effect.%20In%20Expo%20pre-warmed%20DOM%20scenarios%2C%20a%20user%20who%20navigated%20to%20the%20%22All%22%20tab%20would%20see%20it%20still%20selected%20on%20reopen.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=228&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>

2. `packages/ui/src/components/bible-version-picker.tsx`, line 674-681 ([link](https://github.com/youversion/platform-sdk-react/blob/56aac3ee3674ba37e7c26e01e3fdca51997f7572/packages/ui/src/components/bible-version-picker.tsx#L674-L681)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Unused second grid column in standalone `Content` search bar**

   The wrapper `div` uses `grid-cols-[1fr_auto]` with a gap, but only the `<InputGroup>` is rendered inside it — the `auto` column is always empty in standalone mode. The `[1fr_auto]` template collapses harmlessly but is dead CSS.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/ui/src/components/bible-version-picker.tsx
   Line: 674-681

   Comment:
   **Unused second grid column in standalone `Content` search bar**

   The wrapper `div` uses `grid-cols-[1fr_auto]` with a gap, but only the `<InputGroup>` is rendered inside it — the `auto` column is always empty in standalone mode. The `[1fr_auto]` template collapses harmlessly but is dead CSS.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fui%2Fsrc%2Fcomponents%2Fbible-version-picker.tsx%0ALine%3A%20674-681%0A%0AComment%3A%0A**Unused%20second%20grid%20column%20in%20standalone%20%60Content%60%20search%20bar**%0A%0AThe%20wrapper%20%60div%60%20uses%20%60grid-cols-%5B1fr_auto%5D%60%20with%20a%20gap%2C%20but%20only%20the%20%60%3CInputGroup%3E%60%20is%20rendered%20inside%20it%20%E2%80%94%20the%20%60auto%60%20column%20is%20always%20empty%20in%20standalone%20mode.%20The%20%60%5B1fr_auto%5D%60%20template%20collapses%20harmlessly%20but%20is%20dead%20CSS.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-react&pr=228&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fui%2Fsrc%2Fcomponents%2Fbible-version-picker.tsx%0ALine%3A%20674-681%0A%0AComment%3A%0A**Unused%20second%20grid%20column%20in%20standalone%20%60Content%60%20search%20bar**%0A%0AThe%20wrapper%20%60div%60%20uses%20%60grid-cols-%5B1fr_auto%5D%60%20with%20a%20gap%2C%20but%20only%20the%20%60%3CInputGroup%3E%60%20is%20rendered%20inside%20it%20%E2%80%94%20the%20%60auto%60%20column%20is%20always%20empty%20in%20standalone%20mode.%20The%20%60%5B1fr_auto%5D%60%20template%20collapses%20harmlessly%20but%20is%20dead%20CSS.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=228&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fbible-version-picker.tsx%3A563-578%0AThe%20wrapper%20divs%20that%20apply%20the%20%60opacity%60%2F%60blur%60%2F%60scale%60%20animation%20classes%20have%20no%20%60transition-all%20duration-300%60%20of%20their%20own.%20The%20transition%20classes%20live%20on%20the%20inner%20%60Content%60%20div%20%28the%20standalone%20return%20path%29%2C%20which%20is%20a%20different%20element%20from%20the%20one%20whose%20classes%20are%20actually%20changing%20%E2%80%94%20so%20CSS%20will%20not%20animate%20the%20transition%20and%20the%20version%2Flanguage%20panels%20will%20snap%20instead%20of%20blend%20in%20popover%20mode.%20Adding%20the%20transition%20utilities%20directly%20to%20these%20wrappers%20restores%20the%20original%20smooth%20animation.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%3Cdiv%0A%20%20%20%20%20%20%20%20%20%20className%3D%7B%60yv%3Ah-full%20yv%3Amin-h-0%20yv%3Atransition-all%20yv%3Aduration-300%20yv%3Arounded-2xl%20yv%3Aorigin-center%20%24%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20isLanguagesOpen%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3F%20'yv%3Aopacity-0%20yv%3Apointer-events-none%20yv%3Ablur-sm%20yv%3Ascale-95'%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3A%20'yv%3Aopacity-100%20yv%3Apointer-events-auto%20yv%3Ablur-none%20yv%3Ascale-100'%0A%20%20%20%20%20%20%20%20%20%20%7D%60%7D%0A%20%20%20%20%20%20%20%20%3E%0A%20%20%20%20%20%20%20%20%20%20%3CContent%20onRequestClose%3D%7B%28%29%20%3D%3E%20setIsPopoverOpen%28false%29%7D%20%2F%3E%0A%20%20%20%20%20%20%20%20%3C%2Fdiv%3E%0A%20%20%20%20%20%20%20%20%3Cdiv%0A%20%20%20%20%20%20%20%20%20%20className%3D%7B%60yv%3Ah-full%20yv%3Aabsolute%20yv%3Ainset-0%20yv%3Atransition-all%20yv%3Aduration-300%20yv%3Arounded-2xl%20yv%3Aorigin-center%20%24%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20isLanguagesOpen%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3F%20'yv%3Aopacity-100%20yv%3Apointer-events-auto%20yv%3Ablur-none%20yv%3Ascale-100'%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3A%20'yv%3Aopacity-0%20yv%3Apointer-events-none%20yv%3Ablur-sm%20yv%3Ascale-95'%0A%20%20%20%20%20%20%20%20%20%20%7D%60%7D%0A%20%20%20%20%20%20%20%20%3E%0A%60%60%60%0A%0A&repo=youversion%2Fplatform-sdk-react&pr=228&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fbible-version-picker.tsx%3A563-578%0AThe%20wrapper%20divs%20that%20apply%20the%20%60opacity%60%2F%60blur%60%2F%60scale%60%20animation%20classes%20have%20no%20%60transition-all%20duration-300%60%20of%20their%20own.%20The%20transition%20classes%20live%20on%20the%20inner%20%60Content%60%20div%20%28the%20standalone%20return%20path%29%2C%20which%20is%20a%20different%20element%20from%20the%20one%20whose%20classes%20are%20actually%20changing%20%E2%80%94%20so%20CSS%20will%20not%20animate%20the%20transition%20and%20the%20version%2Flanguage%20panels%20will%20snap%20instead%20of%20blend%20in%20popover%20mode.%20Adding%20the%20transition%20utilities%20directly%20to%20these%20wrappers%20restores%20the%20original%20smooth%20animation.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%3Cdiv%0A%20%20%20%20%20%20%20%20%20%20className%3D%7B%60yv%3Ah-full%20yv%3Amin-h-0%20yv%3Atransition-all%20yv%3Aduration-300%20yv%3Arounded-2xl%20yv%3Aorigin-center%20%24%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20isLanguagesOpen%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3F%20'yv%3Aopacity-0%20yv%3Apointer-events-none%20yv%3Ablur-sm%20yv%3Ascale-95'%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3A%20'yv%3Aopacity-100%20yv%3Apointer-events-auto%20yv%3Ablur-none%20yv%3Ascale-100'%0A%20%20%20%20%20%20%20%20%20%20%7D%60%7D%0A%20%20%20%20%20%20%20%20%3E%0A%20%20%20%20%20%20%20%20%20%20%3CContent%20onRequestClose%3D%7B%28%29%20%3D%3E%20setIsPopoverOpen%28false%29%7D%20%2F%3E%0A%20%20%20%20%20%20%20%20%3C%2Fdiv%3E%0A%20%20%20%20%20%20%20%20%3Cdiv%0A%20%20%20%20%20%20%20%20%20%20className%3D%7B%60yv%3Ah-full%20yv%3Aabsolute%20yv%3Ainset-0%20yv%3Atransition-all%20yv%3Aduration-300%20yv%3Arounded-2xl%20yv%3Aorigin-center%20%24%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20isLanguagesOpen%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3F%20'yv%3Aopacity-100%20yv%3Apointer-events-auto%20yv%3Ablur-none%20yv%3Ascale-100'%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3A%20'yv%3Aopacity-0%20yv%3Apointer-events-none%20yv%3Ablur-sm%20yv%3Ascale-95'%0A%20%20%20%20%20%20%20%20%20%20%7D%60%7D%0A%20%20%20%20%20%20%20%20%3E%0A%60%60%60%0A%0A&pr=228&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/ui/src/components/bible-version-picker.tsx:563-578
The wrapper divs that apply the `opacity`/`blur`/`scale` animation classes have no `transition-all duration-300` of their own. The transition classes live on the inner `Content` div (the standalone return path), which is a different element from the one whose classes are actually changing — so CSS will not animate the transition and the version/language panels will snap instead of blend in popover mode. Adding the transition utilities directly to these wrappers restores the original smooth animation.

```suggestion
        <div
          className={`yv:h-full yv:min-h-0 yv:transition-all yv:duration-300 yv:rounded-2xl yv:origin-center ${
            isLanguagesOpen
              ? 'yv:opacity-0 yv:pointer-events-none yv:blur-sm yv:scale-95'
              : 'yv:opacity-100 yv:pointer-events-auto yv:blur-none yv:scale-100'
          }`}
        >
          <Content onRequestClose={() => setIsPopoverOpen(false)} />
        </div>
        <div
          className={`yv:h-full yv:absolute yv:inset-0 yv:transition-all yv:duration-300 yv:rounded-2xl yv:origin-center ${
            isLanguagesOpen
              ? 'yv:opacity-100 yv:pointer-events-auto yv:blur-none yv:scale-100'
              : 'yv:opacity-0 yv:pointer-events-none yv:blur-sm yv:scale-95'
          }`}
        >
```


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ui): preserve language trigger defau..."](https://github.com/youversion/platform-sdk-react/commit/61234788dd8d4077a18f05f62e3f19e1450f6020) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31049198)</sub>

<!-- /greptile_comment -->