### PR TITLE
hot fix UI bug - BibleVersionPicker scroll overflow issue

### DIFF
--- a/.changeset/smart-windows-knock.md
+++ b/.changeset/smart-windows-knock.md
@@ -1,5 +1,5 @@
 ---
-'@youversion/platform-react-ui': minor
+'@youversion/platform-react-ui': patch
 ---
 
 Fixed a UI bug on the `BibleVersionPicker` component where switching to the language picker view would result in the scrollable contents overflowing off of the view container.

--- a/.changeset/smart-windows-knock.md
+++ b/.changeset/smart-windows-knock.md
@@ -1,0 +1,5 @@
+---
+'@youversion/platform-react-ui': minor
+---
+
+Fixed a UI bug on the `BibleVersionPicker` component where switching to the language picker view would result in the scrollable contents overflowing off of the view container.

--- a/.gitignore
+++ b/.gitignore
@@ -73,5 +73,6 @@ storybook-static
 !.yarn/versions
 .yarn/install-state.gz
 
-.opencode/plans
-.superset/*
+.opencode/
+.superset/
+.codex/

--- a/packages/ui/src/components/bible-version-picker.test.tsx
+++ b/packages/ui/src/components/bible-version-picker.test.tsx
@@ -398,6 +398,32 @@ describe('BibleVersionPicker', () => {
       expect(screen.queryByText('All Languages')).not.toBeInTheDocument();
     });
 
+    it('bounds and animates the default language view inside the popover content', async () => {
+      const user = userEvent.setup();
+
+      setupDefaultMocks();
+      renderPicker();
+
+      await openPicker();
+      await user.click(screen.getByRole('button', { name: /select language/i }));
+
+      expect(screen.getByRole('heading', { name: /select language/i })).toBeInTheDocument();
+
+      const dialog = screen.getByRole('dialog');
+      const viewport = dialog.querySelector('.yv\\:relative.yv\\:min-h-0.yv\\:overflow-hidden');
+      expect(viewport).not.toBeNull();
+
+      const animatedPanels = dialog.querySelectorAll(
+        '.yv\\:transition-all.yv\\:duration-300.yv\\:ease-out',
+      );
+      expect(animatedPanels).toHaveLength(2);
+
+      const languagePanel = screen
+        .getByRole('heading', { name: /select language/i })
+        .closest('.yv\\:h-full.yv\\:min-h-0.yv\\:overflow-hidden');
+      expect(languagePanel).not.toBeNull();
+    });
+
     it('open=false clears version search for pre-warmed standalone content', async () => {
       const user = userEvent.setup();
 

--- a/packages/ui/src/components/bible-version-picker.test.tsx
+++ b/packages/ui/src/components/bible-version-picker.test.tsx
@@ -419,7 +419,7 @@ describe('BibleVersionPicker', () => {
       expect(animatedPanels).toHaveLength(2);
 
       const languagePanel = screen
-        .getByRole('heading', { name: /select language/i })
+        .getByRole('tab', { name: /suggested/i })
         .closest('.yv\\:h-full.yv\\:min-h-0.yv\\:overflow-hidden');
       expect(languagePanel).not.toBeNull();
     });

--- a/packages/ui/src/components/bible-version-picker.tsx
+++ b/packages/ui/src/components/bible-version-picker.tsx
@@ -572,7 +572,9 @@ function Content({ open, onRequestClose }: BibleVersionPickerContentProps = {}) 
         headerChild={
           <BibleVersionPickerLanguageTrigger
             disabled={isLanguagesOpen}
-            style={isLanguagesOpen ? { visibility: 'hidden' } : {}}
+            style={
+              isLanguagesOpen ? { visibility: 'hidden', opacity: 0, pointerEvents: 'none' } : {}
+            }
           />
         }
         theme={background}

--- a/packages/ui/src/components/bible-version-picker.tsx
+++ b/packages/ui/src/components/bible-version-picker.tsx
@@ -555,28 +555,48 @@ function Content({ open, onRequestClose }: BibleVersionPickerContentProps = {}) 
       <PopoverContent
         sideOffset={16}
         className="yv:h-[66svh]"
-        heading="Bible Versions"
-        headerChild={<BibleVersionPickerLanguageTrigger />}
+        heading={isLanguagesOpen ? 'Select Language' : 'Bible Versions'}
+        headerLeading={
+          isLanguagesOpen ? (
+            <Button
+              onClick={() => setIsLanguagesOpen(false)}
+              variant="ghost"
+              size="icon"
+              className="yv:w-6 yv:h-6 yv:text-muted-foreground"
+            >
+              <ArrowLeftIcon className="yv:size-5" />
+              <span className="yv:sr-only">Back to Bible versions</span>
+            </Button>
+          ) : null
+        }
+        headerChild={
+          <BibleVersionPickerLanguageTrigger
+            disabled={isLanguagesOpen}
+            style={isLanguagesOpen ? { visibility: 'hidden' } : {}}
+          />
+        }
         theme={background}
         side={side}
       >
-        <div
-          className={`yv:h-full yv:min-h-0 ${
-            isLanguagesOpen
-              ? 'yv:opacity-0 yv:pointer-events-none yv:blur-sm yv:scale-95'
-              : 'yv:opacity-100 yv:pointer-events-auto yv:blur-none yv:scale-100'
-          }`}
-        >
-          <Content onRequestClose={() => setIsPopoverOpen(false)} />
-        </div>
-        <div
-          className={`yv:h-full yv:absolute yv:inset-0 ${
-            isLanguagesOpen
-              ? 'yv:opacity-100 yv:pointer-events-auto yv:blur-none yv:scale-100'
-              : 'yv:opacity-0 yv:pointer-events-none yv:blur-sm yv:scale-95'
-          }`}
-        >
-          <LanguagePanel onRequestClose={() => setIsLanguagesOpen(false)} />
+        <div className="yv:relative yv:min-h-0 yv:overflow-hidden">
+          <div
+            className={`yv:h-full yv:min-h-0 yv:overflow-hidden yv:transition-all yv:duration-300 yv:ease-out yv:motion-reduce:transition-none ${
+              isLanguagesOpen
+                ? 'yv:opacity-0 yv:pointer-events-none yv:blur-sm yv:scale-95'
+                : 'yv:opacity-100 yv:pointer-events-auto yv:blur-none yv:scale-100'
+            }`}
+          >
+            <Content onRequestClose={() => setIsPopoverOpen(false)} />
+          </div>
+          <div
+            className={`yv:h-full yv:min-h-0 yv:overflow-hidden yv:absolute yv:inset-0 yv:transition-all yv:duration-300 yv:ease-out yv:motion-reduce:transition-none ${
+              isLanguagesOpen
+                ? 'yv:opacity-100 yv:pointer-events-auto yv:blur-none yv:scale-100'
+                : 'yv:opacity-0 yv:pointer-events-none yv:blur-sm yv:scale-95'
+            }`}
+          >
+            <LanguagePanel onRequestClose={() => setIsLanguagesOpen(false)} />
+          </div>
         </div>
       </PopoverContent>
     );
@@ -698,20 +718,10 @@ function Content({ open, onRequestClose }: BibleVersionPickerContentProps = {}) 
 
 function LanguagePanel({ onRequestClose }: BibleLanguagePickerContentProps = {}) {
   return (
-    <div className="yv:h-full yv:flex yv:flex-col yv:transition-all yv:duration-300 yv:rounded-2xl yv:origin-center">
-      <section className="yv:bg-muted yv:px-2 yv:py-3 yv:w-full yv:rounded-t-2xl yv:border-b yv:border-border yv:grid yv:grid-cols-[auto_1fr] yv:gap-2 yv:items-center">
-        <Button
-          onClick={onRequestClose}
-          variant="ghost"
-          size="icon"
-          className="yv:w-8 yv:h-8 yv:text-muted-foreground"
-        >
-          <ArrowLeftIcon className="yv:size-4" />
-          <span className="yv:sr-only">Close Language selector</span>
-        </Button>
-        <h2 className="yv:font-bold yv:text-base">Select Language</h2>
-      </section>
-      <BibleLanguagePickerContent onRequestClose={onRequestClose} />
+    <div className="yv:h-full yv:min-h-0 yv:overflow-hidden yv:flex yv:flex-col yv:transition-all yv:duration-300 yv:rounded-2xl yv:origin-center">
+      <div className="yv:flex-1 yv:min-h-0 yv:overflow-hidden">
+        <BibleLanguagePickerContent onRequestClose={onRequestClose} />
+      </div>
     </div>
   );
 }
@@ -742,7 +752,7 @@ export function BibleLanguagePickerContent({
 
   return (
     <div
-      className="yv:h-full yv:flex yv:flex-col"
+      className="yv:h-full yv:min-h-0 yv:overflow-hidden yv:flex yv:flex-col"
       data-yv-sdk
       data-yv-theme={background}
       data-open={open}

--- a/packages/ui/src/components/ui/popover.tsx
+++ b/packages/ui/src/components/ui/popover.tsx
@@ -20,6 +20,7 @@ function PopoverTrigger({
 function PopoverContent({
   className,
   children,
+  headerLeading,
   headerChild,
   align = 'center',
   heading,
@@ -29,7 +30,8 @@ function PopoverContent({
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Content> & {
   showHeader?: boolean;
-  heading?: string;
+  heading?: React.ReactNode;
+  headerLeading?: React.ReactNode;
   headerChild?: React.ReactNode;
   theme?: 'light' | 'dark';
 }): React.ReactNode {
@@ -53,8 +55,11 @@ function PopoverContent({
             className={cn([
               'yv:bg-muted yv:py-3 yv:rounded-t-2xl yv:px-4 yv:border-b yv:border-border yv:grid yv:grid-cols-[1fr_auto] yv:justify-between yv:items-center yv:gap-2',
               headerChild ? 'yv:grid-cols-[1fr_auto_auto]' : '',
+              headerLeading ? 'yv:grid-cols-[auto_1fr_auto]' : '',
+              headerLeading && headerChild ? 'yv:grid-cols-[auto_1fr_auto_auto]' : '',
             ])}
           >
+            {headerLeading}
             <h2 className="yv:font-bold yv:text-base">{heading}</h2>
             {headerChild}
             <PopoverClose asChild>


### PR DESCRIPTION
I pushed a UI bug in #228 and am sorry.

Here's a demo of the overflow scroll issue/bug and a video of the fixed state

https://github.com/user-attachments/assets/5882fe13-241c-4193-ae06-623d232329be

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This hot-fix addresses a scroll-overflow regression in `BibleVersionPicker` introduced in #228 by properly bounding the two-panel (versions / language) layout with `min-h-0` and `overflow-hidden`, and by moving the language picker's header into the shared `PopoverContent` header slot rather than rendering a duplicate header inside the absolute panel.

- **`bible-version-picker.tsx`**: Wraps the two animated panels in a `relative min-h-0 overflow-hidden` container so neither panel can overflow the popover's height; removes the duplicate header from `LanguagePanel` and drives the back button and dynamic title through new `headerLeading`/`heading` props on `PopoverContent`.
- **`popover.tsx`**: Adds a `headerLeading` slot and widens `heading` from `string` to `React.ReactNode`, with grid-column logic that correctly composes 2-, 3-, or 4-column header layouts depending on which slots are provided.
- **`bible-version-picker.test.tsx`**: Adds a test that opens the language view and asserts the overflow-bounding CSS classes are present on the container and both animated panels.

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted layout fix with no logic mutations and no API surface changes.

The overflow fix is mechanically sound: the panels live inside a grid 1fr row that already has a bounded height, and min-h-0 overflow-hidden on the wrapper correctly clips both the static and absolute-positioned panel. The PopoverContent grid-column composition handles all four header-slot combinations correctly, and tailwind-merge resolves any conflicting grid-cols classes to the last winner. No new API contracts are broken and the changeset is correctly marked patch.

No files require special attention. The new test couples assertions to CSS class names, which is a minor maintenance concern but not a blocker.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/bible-version-picker.tsx | Core fix: adds overflow-bounding wrapper around panel switcher and consolidates language-picker header into PopoverContent. Logic is correct — grid stretches the wrapper to fill the 1fr row, min-h-0 prevents expansion, overflow-hidden clips panels as expected. |
| packages/ui/src/components/ui/popover.tsx | Adds headerLeading slot and ReactNode heading. Grid-column class composition correctly handles all four presence combinations; tailwind-merge resolves the last winning grid-cols class when multiple conditions are true. |
| packages/ui/src/components/bible-version-picker.test.tsx | New test asserts overflow-bounding classes and animated-panel count. Anchors on CSS class names so a styling refactor would break the test without any behaviour change. |
| .changeset/smart-windows-knock.md | Changeset correctly set to patch for a bug-fix-only change. |
| .gitignore | Cleans up gitignore entries: broadens .opencode/ and .superset/ to cover entire directories and adds .codex/. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[BibleVersionPicker opens] --> B{isLanguagesOpen?}

    B -- false --> C[PopoverContent header
heading: 'Bible Versions'
headerLeading: null
headerChild: LanguageTrigger visible]
    B -- true --> D[PopoverContent header
heading: 'Select Language'
headerLeading: Back button
headerChild: LanguageTrigger hidden]

    C --> E[relative min-h-0 overflow-hidden wrapper]
    D --> E

    E --> F[Panel 1 versions
opacity-100 scale-100
when NOT isLanguagesOpen]
    E --> G[Panel 2 languages
absolute inset-0
opacity-100 scale-100
when isLanguagesOpen]

    F -- transition-all 300ms --> G
    G -- Back button setIsLanguagesOpen false --> F
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fbible-version-picker.test.tsx%3A415-427%0A**Test%20anchored%20on%20CSS%20class%20names**%0A%0AThe%20assertions%20query%20the%20DOM%20by%20raw%20Tailwind%20class%20strings%20%28%60.yv%5C%5C%3Arelative.yv%5C%5C%3Amin-h-0.yv%5C%5C%3Aoverflow-hidden%60%2C%20%60.yv%5C%5C%3Atransition-all.yv%5C%5C%3Aduration-300.yv%5C%5C%3Aease-out%60%2C%20%60.yv%5C%5C%3Ah-full.yv%5C%5C%3Amin-h-0.yv%5C%5C%3Aoverflow-hidden%60%29.%20Any%20styling%20refactor%20that%20achieves%20the%20same%20visual%20constraint%20via%20different%20class%20names%20would%20break%20these%20tests%20without%20changing%20behaviour.%20Consider%20asserting%20the%20overflow%20constraint%20indirectly%20%E2%80%94%20for%20example%2C%20verifying%20that%20neither%20panel's%20content%20is%20accessible%20to%20pointer%20events%20in%20the%20hidden%20state%2C%20or%20wrapping%20the%20bounding%20element%20in%20a%20%60data-testid%60%20that%20can%20be%20targeted%20without%20coupling%20to%20class%20names.%0A%0A&repo=youversion%2Fplatform-sdk-react&pr=230&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fbible-version-picker.test.tsx%3A415-427%0A**Test%20anchored%20on%20CSS%20class%20names**%0A%0AThe%20assertions%20query%20the%20DOM%20by%20raw%20Tailwind%20class%20strings%20%28%60.yv%5C%5C%3Arelative.yv%5C%5C%3Amin-h-0.yv%5C%5C%3Aoverflow-hidden%60%2C%20%60.yv%5C%5C%3Atransition-all.yv%5C%5C%3Aduration-300.yv%5C%5C%3Aease-out%60%2C%20%60.yv%5C%5C%3Ah-full.yv%5C%5C%3Amin-h-0.yv%5C%5C%3Aoverflow-hidden%60%29.%20Any%20styling%20refactor%20that%20achieves%20the%20same%20visual%20constraint%20via%20different%20class%20names%20would%20break%20these%20tests%20without%20changing%20behaviour.%20Consider%20asserting%20the%20overflow%20constraint%20indirectly%20%E2%80%94%20for%20example%2C%20verifying%20that%20neither%20panel's%20content%20is%20accessible%20to%20pointer%20events%20in%20the%20hidden%20state%2C%20or%20wrapping%20the%20bounding%20element%20in%20a%20%60data-testid%60%20that%20can%20be%20targeted%20without%20coupling%20to%20class%20names.%0A%0A&pr=230&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/ui/src/components/bible-version-picker.test.tsx:415-427
**Test anchored on CSS class names**

The assertions query the DOM by raw Tailwind class strings (`.yv\\:relative.yv\\:min-h-0.yv\\:overflow-hidden`, `.yv\\:transition-all.yv\\:duration-300.yv\\:ease-out`, `.yv\\:h-full.yv\\:min-h-0.yv\\:overflow-hidden`). Any styling refactor that achieves the same visual constraint via different class names would break these tests without changing behaviour. Consider asserting the overflow constraint indirectly — for example, verifying that neither panel's content is accessible to pointer events in the hidden state, or wrapping the bounding element in a `data-testid` that can be targeted without coupling to class names.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: moved from minor to patch"](https://github.com/youversion/platform-sdk-react/commit/8a4dc414f026a95f8686934a4a9cb2307c61590f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31387507)</sub>

<!-- /greptile_comment -->