### PR TITLE
feat(ui): add BibleChapterPicker.Content onSelect + BibleReader onChapterPickerPress

### DIFF
--- a/.changeset/chapter-picker-on-select-and-reader-context-threading.md
+++ b/.changeset/chapter-picker-on-select-and-reader-context-threading.md
@@ -1,0 +1,9 @@
+---
+"@youversion/platform-react-ui": minor
+---
+
+Add `onSelect` callback to `BibleChapterPicker.Content` and `onChapterPickerPress` to `BibleReader.Root`
+
+- `BibleChapterPickerSelectData` type exported for `onSelect` payload
+- `onSelect` prop on `Content` fires after internal state updates, before `onRequestClose`
+- `onChapterPickerPress` prop on `BibleReader.Root` threaded through context to `Toolbar`, suppressing default popover when provided

--- a/packages/ui/src/components/bible-chapter-picker.test.tsx
+++ b/packages/ui/src/components/bible-chapter-picker.test.tsx
@@ -4,7 +4,7 @@
 // We stub ResizeObserver for jsdom (used by Radix/@floating-ui). The stub methods are intentionally no-ops.
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 // ResizeObserver is used by @floating-ui/dom (Radix Popover)
@@ -16,6 +16,7 @@ class ResizeObserverMock {
 globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
 
 import { BibleChapterPicker } from './bible-chapter-picker';
+import type { BibleChapterPickerSelectData } from './bible-chapter-picker';
 import { useBooks, useTheme } from '@youversion/platform-react-hooks';
 import type { BibleBook } from '@youversion/platform-core';
 
@@ -113,5 +114,87 @@ describe('BibleChapterPicker - default popover mode', () => {
 
     expect(await screen.findByText('Books')).toBeInTheDocument();
     expect(await screen.findByPlaceholderText('Search')).toBeInTheDocument();
+  });
+});
+
+describe('BibleChapterPicker.Content onSelect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDefaultMocks();
+  });
+
+  it('calls onSelect with { book, chapter, versionId } when a normal chapter is clicked (with onChapterPickerPress)', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+
+    render(
+      <BibleChapterPicker.Root
+        versionId={3034}
+        book="GEN"
+        chapter="1"
+        onChapterPickerPress={vi.fn()}
+      >
+        <BibleChapterPicker.Trigger />
+        <BibleChapterPicker.Content onSelect={onSelect} />
+      </BibleChapterPicker.Root>,
+    );
+
+    await user.click(screen.getByText('2'));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    const payload = onSelect.mock.calls[0]![0] as BibleChapterPickerSelectData;
+    expect(payload).toEqual({
+      book: 'GEN',
+      chapter: '2',
+      versionId: 3034,
+    });
+  });
+
+  it('calls onSelect when intro chapter is clicked (with onChapterPickerPress)', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+
+    render(
+      <BibleChapterPicker.Root
+        versionId={3034}
+        book="GEN"
+        chapter="1"
+        onChapterPickerPress={vi.fn()}
+      >
+        <BibleChapterPicker.Trigger />
+        <BibleChapterPicker.Content onSelect={onSelect} />
+      </BibleChapterPicker.Root>,
+    );
+
+    const introButton = screen
+      .getAllByRole('button')
+      .find((b) => b.querySelector('svg') && !b.textContent?.trim());
+    if (introButton) await user.click(introButton);
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith({
+      book: 'GEN',
+      chapter: 'INTRO',
+      versionId: 3034,
+    });
+  });
+
+  it('preserves default popover behavior when onSelect is not provided', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <BibleChapterPicker.Root versionId={3034} book="GEN" chapter="1">
+        <BibleChapterPicker.Trigger />
+      </BibleChapterPicker.Root>,
+    );
+
+    await user.click(screen.getByRole('button'));
+    expect(await screen.findByText('Books')).toBeInTheDocument();
+
+    await user.click(screen.getByText('2'));
+
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText('Search')).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/ui/src/components/bible-chapter-picker.test.tsx
+++ b/packages/ui/src/components/bible-chapter-picker.test.tsx
@@ -166,10 +166,8 @@ describe('BibleChapterPicker.Content onSelect', () => {
       </BibleChapterPicker.Root>,
     );
 
-    const introButton = screen
-      .getAllByRole('button')
-      .find((b) => b.querySelector('svg') && !b.textContent?.trim());
-    if (introButton) await user.click(introButton);
+    const introButton = screen.getByTestId('intro-chapter-button');
+    await user.click(introButton);
 
     expect(onSelect).toHaveBeenCalledTimes(1);
     expect(onSelect).toHaveBeenCalledWith({

--- a/packages/ui/src/components/bible-chapter-picker.tsx
+++ b/packages/ui/src/components/bible-chapter-picker.tsx
@@ -27,8 +27,14 @@ export interface BibleChapterPickerPressData {
   versionId: number;
 }
 
+export type BibleChapterPickerSelectData = Pick<
+  BibleChapterPickerPressData,
+  'book' | 'chapter' | 'versionId'
+>;
+
 export type BibleChapterPickerContentProps = {
   onRequestClose?: () => void;
+  onSelect?: (data: BibleChapterPickerSelectData) => void;
 };
 
 type BibleChapterPickerContextType = {
@@ -285,7 +291,7 @@ function Trigger({ asChild = true, children, ...props }: TriggerProps) {
   );
 }
 
-function Content({ onRequestClose }: BibleChapterPickerContentProps) {
+function Content({ onRequestClose, onSelect }: BibleChapterPickerContentProps) {
   const {
     book,
     defaultBook,
@@ -297,6 +303,7 @@ function Content({ onRequestClose }: BibleChapterPickerContentProps) {
     registerBookElement,
     setBook,
     setChapter,
+    versionId,
   } = useBibleChapterPickerContext();
 
   const handleChapterButtonClick = (bookId: string, passageId: string) => {
@@ -305,6 +312,7 @@ function Content({ onRequestClose }: BibleChapterPickerContentProps) {
       setBook(bookId);
       setChapter(chapterId);
       setSearchQuery('');
+      onSelect?.({ book: bookId, chapter: chapterId, versionId });
       onRequestClose?.();
     }
   };

--- a/packages/ui/src/components/bible-chapter-picker.tsx
+++ b/packages/ui/src/components/bible-chapter-picker.tsx
@@ -27,10 +27,7 @@ export interface BibleChapterPickerPressData {
   versionId: number;
 }
 
-export type BibleChapterPickerSelectData = Pick<
-  BibleChapterPickerPressData,
-  'book' | 'chapter' | 'versionId'
->;
+export type BibleChapterPickerSelectData = BibleChapterPickerPressData;
 
 export type BibleChapterPickerContentProps = {
   onRequestClose?: () => void;
@@ -345,6 +342,7 @@ function Content({ onRequestClose, onSelect }: BibleChapterPickerContentProps) {
                         key={`${bookItem.id}-${bookItem.intro.passage_id}`}
                         variant="secondary"
                         size="icon"
+                        data-testid="intro-chapter-button"
                         className="yv:aspect-square yv:w-full yv:h-full yv:flex yv:items-center yv:justify-center yv:rounded-[4px]"
                         onClick={() =>
                           handleChapterButtonClick(bookItem.id, bookItem.intro?.passage_id || '')

--- a/packages/ui/src/components/bible-reader.test.tsx
+++ b/packages/ui/src/components/bible-reader.test.tsx
@@ -264,3 +264,38 @@ describe('BibleReader theme settings', () => {
     expect(nextSnap.fontFamily).toBe(INTER_FONT);
   });
 });
+
+describe('BibleReader Toolbar - onChapterPickerPress', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDefaultMocks();
+  });
+
+  it('calls onChapterPickerPress from Root when chapter nav button is clicked and hides popover', async () => {
+    const user = userEvent.setup();
+    const onChapterPickerPress = vi.fn();
+
+    render(
+      <BibleReader.Root
+        defaultVersionId={3034}
+        defaultBook="JHN"
+        defaultChapter="1"
+        onChapterPickerPress={onChapterPickerPress}
+      >
+        <BibleReader.Toolbar />
+      </BibleReader.Root>,
+    );
+
+    const chapterButton = screen.getByRole('button', { name: 'Change Bible book and chapter' });
+    await user.click(chapterButton);
+
+    expect(onChapterPickerPress).toHaveBeenCalledTimes(1);
+    expect(onChapterPickerPress).toHaveBeenCalledWith({
+      book: 'JHN',
+      chapter: '1',
+      versionId: 3034,
+    });
+
+    expect(screen.queryByPlaceholderText('Search')).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/bible-reader.tsx
+++ b/packages/ui/src/components/bible-reader.tsx
@@ -21,7 +21,7 @@ import {
 } from 'react';
 import { cn } from '@/lib/utils';
 import { DEFAULT_LICENSE_FREE_BIBLE_VERSION, getAdjacentChapter } from '@youversion/platform-core';
-import { BibleChapterPicker } from './bible-chapter-picker';
+import { BibleChapterPicker, type BibleChapterPickerPressData } from './bible-chapter-picker';
 import { BibleVersionPicker } from './bible-version-picker';
 import { GearIcon } from './icons/gear';
 import { InfoIcon } from './icons/info';
@@ -51,6 +51,7 @@ type BibleReaderContextType = {
   showVerseNumbers: boolean;
   background: 'light' | 'dark';
   onFootnotePress?: (data: FootnoteData) => void;
+  onChapterPickerPress?: (data: BibleChapterPickerPressData) => void;
 };
 
 const BibleReaderContext = createContext<BibleReaderContextType | null>(null);
@@ -83,6 +84,7 @@ export type RootProps = {
   showVerseNumbers?: boolean;
   background?: 'light' | 'dark';
   onFootnotePress?: (data: FootnoteData) => void;
+  onChapterPickerPress?: (data: BibleChapterPickerPressData) => void;
   children?: ReactNode;
 };
 
@@ -181,6 +183,7 @@ function Root({
   showVerseNumbers = true,
   background,
   onFootnotePress,
+  onChapterPickerPress,
   children,
 }: RootProps) {
   const [book, setBook] = useControllableState({
@@ -286,6 +289,7 @@ function Root({
     showVerseNumbers,
     background: theme,
     onFootnotePress,
+    onChapterPickerPress,
   };
 
   return (
@@ -552,6 +556,7 @@ function Toolbar({ border = 'top', onOpenBibleThemeSettings }: BibleReaderToolba
     currentFontSize,
     setCurrentFontSize,
     background,
+    onChapterPickerPress,
   } = useBibleReaderContext();
   const yvContext = useContext(YouVersionContext);
   const themesSettingsValuesRef = useRef<BibleThemeSettingsValues>({
@@ -638,6 +643,7 @@ function Toolbar({ border = 'top', onOpenBibleThemeSettings }: BibleReaderToolba
           onChapterChange={setChapter}
           versionId={versionId}
           background={background}
+          onChapterPickerPress={onChapterPickerPress}
         >
           <BibleChapterPicker.Trigger>
             {({ chapterLabel, currentBook, loading }) => (

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -2,6 +2,7 @@ export {
   BibleChapterPicker,
   type RootProps,
   type BibleChapterPickerRootProps,
+  type BibleChapterPickerSelectData,
   type TriggerProps,
   type BibleChapterPickerContentProps,
   type BibleChapterPickerPressData,


### PR DESCRIPTION
When working on [YPE-2194](https://lifechurch.atlassian.net/browse/YPE-2194), we found the React Web SDK needed some additional updates to handle what we need for React Native Expo SDK for the BibleChapterPicker in the BibleReader component, so here's the PR for this!

This MUST be merged before https://github.com/youversion/platform-sdk-reactnative-expo/pull/10

## Summary

Adds `onSelect` callback to `BibleChapterPicker.Content` and threads `onChapterPickerPress` through `BibleReader.Root` context to `Toolbar`. This enables React Native consumers to intercept chapter selection without using the default popover.

## Changes

### `BibleChapterPicker`
- New `BibleChapterPickerSelectData` type: `Pick<BibleChapterPickerPressData, 'book' | 'chapter' | 'versionId'>`
- New `onSelect` prop on `BibleChapterPicker.Content` — fires after internal state updates, before `onRequestClose`
- Non-breaking: when `onSelect` is absent, default popover selection/close behavior is preserved

### `BibleReader`
- New `onChapterPickerPress` prop on `Root` — threaded through context to `Toolbar`
- `Toolbar` passes it to `BibleChapterPicker.Root`, which suppresses the default popover and delegates to the consumer

### Exports
- `BibleChapterPickerSelectData` added to barrel (`components/index.ts`)

### Tests
- `bible-chapter-picker.test.tsx`: onSelect normal chapter, intro chapter, default popover preserved
- `bible-reader.test.tsx`: onChapterPickerPress fires when chapter nav button clicked

## Test plan

- [x] 92/92 existing tests pass
- [ ] Manual: BibleReader with `onChapterPickerPress` suppresses default popover
- [ ] Manual: BibleChapterPicker.Content onSelect fires with correct payload
- [x] Downstream: RN Expo SDK uses these hooks to open native sheet (see linked PR)

## Downstream

This is a prerequisite for the React Native Expo chapter picker sheet integration.

[YPE-2194]: https://lifechurch.atlassian.net/browse/YPE-2194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends `BibleChapterPicker.Content` with an `onSelect` callback and threads `onChapterPickerPress` from `BibleReader.Root` through context to `Toolbar`, enabling React Native consumers to intercept chapter selection without triggering the default popover. A changeset file is included and the `BibleChapterPickerSelectData` type is exported from the barrel.

- `BibleChapterPickerSelectData` is now a direct type alias of `BibleChapterPickerPressData`, exported from `components/index.ts` for consumer use.
- `onSelect` fires synchronously in `Content.handleChapterButtonClick` after state setters are called (state commits on next render) and before `onRequestClose`; a `data-testid=\"intro-chapter-button\"` was added to the intro button to stabilise the new test.
- `onChapterPickerPress` is plumbed from `BibleReader.Root` props → context → `Toolbar` → `BibleChapterPicker.Root`, suppressing the default popover when present; the new `BibleReader` test verifies the callback fires and the popover stays hidden.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the new props are strictly additive and the default popover path is unchanged.

All three changed behaviours (onSelect on Content, onChapterPickerPress threading through BibleReader, and the new exports) are opt-in with no side-effects on existing consumers. The changeset is present, tests cover the new paths including the intro-chapter flow, and the type alias simplification from the prior review round was applied.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/ui/src/components/bible-chapter-picker.tsx | Adds BibleChapterPickerSelectData type alias, onSelect prop on Content, and data-testid on the intro button; logic is correct and non-breaking. |
| packages/ui/src/components/bible-reader.tsx | Threads onChapterPickerPress from Root props through context to Toolbar, correctly forwarded to BibleChapterPicker.Root. |
| packages/ui/src/components/bible-chapter-picker.test.tsx | Three new test cases cover normal chapter onSelect, intro chapter onSelect, and default popover-close preservation; mock data keeps a single book so getByTestId is unambiguous. |
| packages/ui/src/components/bible-reader.test.tsx | New test verifies onChapterPickerPress fires with correct payload when the chapter nav button is clicked and confirms the popover is not shown. |
| packages/ui/src/components/index.ts | Exports BibleChapterPickerSelectData from the barrel; change is minimal and correct. |
| .changeset/chapter-picker-on-select-and-reader-context-threading.md | Adds a minor changeset for @youversion/platform-react-ui, correctly describing the new public API additions. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Consumer
    participant BibleReader.Root
    participant BibleReaderContext
    participant Toolbar
    participant BibleChapterPicker.Root
    participant BibleChapterPicker.Trigger
    participant BibleChapterPicker.Content

    Consumer->>BibleReader.Root: onChapterPickerPress prop
    BibleReader.Root->>BibleReaderContext: store onChapterPickerPress
    BibleReaderContext->>Toolbar: onChapterPickerPress (via context)
    Toolbar->>BibleChapterPicker.Root: onChapterPickerPress prop

    alt onChapterPickerPress provided
        BibleChapterPicker.Root->>BibleChapterPicker.Trigger: render as plain button (no Popover)
        Consumer->>BibleChapterPicker.Trigger: click
        BibleChapterPicker.Trigger->>Consumer: onChapterPickerPress
        Consumer->>BibleChapterPicker.Content: render explicitly with onSelect
        Consumer->>BibleChapterPicker.Content: user clicks chapter
        BibleChapterPicker.Content->>BibleChapterPicker.Content: setBook / setChapter / setSearchQuery
        BibleChapterPicker.Content->>Consumer: onSelect
        BibleChapterPicker.Content->>BibleChapterPicker.Content: onRequestClose?.()
    else no onChapterPickerPress (default)
        BibleChapterPicker.Root->>BibleChapterPicker.Root: wrap children in Popover
        Consumer->>BibleChapterPicker.Trigger: click (opens Popover)
        BibleChapterPicker.Root->>BibleChapterPicker.Content: auto-render inside PopoverContent
        Consumer->>BibleChapterPicker.Content: user clicks chapter
        BibleChapterPicker.Content->>BibleChapterPicker.Content: setBook / setChapter / setSearchQuery
        BibleChapterPicker.Content->>BibleChapterPicker.Root: onRequestClose → setIsPopoverOpen(false)
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/ui/src/components/bible-chapter-picker.tsx`, line 197-212 ([link](https://github.com/youversion/platform-sdk-react/blob/d028b7ac1324a299ed1e4a043ceedd2966cb9064/packages/ui/src/components/bible-chapter-picker.tsx#L197-L212)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`onSelect` unusable in default popover mode**

   When `onChapterPickerPress` is absent, `Root` auto-renders `Content` inside `PopoverContent` and does not forward any `onSelect` to it. A consumer who also explicitly renders `<BibleChapterPicker.Content onSelect={...} />` as a child will get two `Content` instances rendered simultaneously — the auto one (inside the popover, fires on click, closes the popover) and the explicit one (always visible, fires `onSelect`, but never receives `onRequestClose`). This API contract should be documented or guarded so that `onSelect` on an explicit `Content` is only valid when `onChapterPickerPress` is also provided on `Root`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/ui/src/components/bible-chapter-picker.tsx
   Line: 197-212

   Comment:
   **`onSelect` unusable in default popover mode**

   When `onChapterPickerPress` is absent, `Root` auto-renders `Content` inside `PopoverContent` and does not forward any `onSelect` to it. A consumer who also explicitly renders `<BibleChapterPicker.Content onSelect={...} />` as a child will get two `Content` instances rendered simultaneously — the auto one (inside the popover, fires on click, closes the popover) and the explicit one (always visible, fires `onSelect`, but never receives `onRequestClose`). This API contract should be documented or guarded so that `onSelect` on an explicit `Content` is only valid when `onChapterPickerPress` is also provided on `Root`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fui%2Fsrc%2Fcomponents%2Fbible-chapter-picker.tsx%0ALine%3A%20197-212%0A%0AComment%3A%0A**%60onSelect%60%20unusable%20in%20default%20popover%20mode**%0A%0AWhen%20%60onChapterPickerPress%60%20is%20absent%2C%20%60Root%60%20auto-renders%20%60Content%60%20inside%20%60PopoverContent%60%20and%20does%20not%20forward%20any%20%60onSelect%60%20to%20it.%20A%20consumer%20who%20also%20explicitly%20renders%20%60%3CBibleChapterPicker.Content%20onSelect%3D%7B...%7D%20%2F%3E%60%20as%20a%20child%20will%20get%20two%20%60Content%60%20instances%20rendered%20simultaneously%20%E2%80%94%20the%20auto%20one%20%28inside%20the%20popover%2C%20fires%20on%20click%2C%20closes%20the%20popover%29%20and%20the%20explicit%20one%20%28always%20visible%2C%20fires%20%60onSelect%60%2C%20but%20never%20receives%20%60onRequestClose%60%29.%20This%20API%20contract%20should%20be%20documented%20or%20guarded%20so%20that%20%60onSelect%60%20on%20an%20explicit%20%60Content%60%20is%20only%20valid%20when%20%60onChapterPickerPress%60%20is%20also%20provided%20on%20%60Root%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-react&pr=234&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fui%2Fsrc%2Fcomponents%2Fbible-chapter-picker.tsx%0ALine%3A%20197-212%0A%0AComment%3A%0A**%60onSelect%60%20unusable%20in%20default%20popover%20mode**%0A%0AWhen%20%60onChapterPickerPress%60%20is%20absent%2C%20%60Root%60%20auto-renders%20%60Content%60%20inside%20%60PopoverContent%60%20and%20does%20not%20forward%20any%20%60onSelect%60%20to%20it.%20A%20consumer%20who%20also%20explicitly%20renders%20%60%3CBibleChapterPicker.Content%20onSelect%3D%7B...%7D%20%2F%3E%60%20as%20a%20child%20will%20get%20two%20%60Content%60%20instances%20rendered%20simultaneously%20%E2%80%94%20the%20auto%20one%20%28inside%20the%20popover%2C%20fires%20on%20click%2C%20closes%20the%20popover%29%20and%20the%20explicit%20one%20%28always%20visible%2C%20fires%20%60onSelect%60%2C%20but%20never%20receives%20%60onRequestClose%60%29.%20This%20API%20contract%20should%20be%20documented%20or%20guarded%20so%20that%20%60onSelect%60%20on%20an%20explicit%20%60Content%60%20is%20only%20valid%20when%20%60onChapterPickerPress%60%20is%20also%20provided%20on%20%60Root%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=234&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(ui): address greptile review — simpl..."](https://github.com/youversion/platform-sdk-react/commit/fa679e1512640f416a2adc1a6a3fcbfa9f17cf81) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31688000)</sub>

<!-- /greptile_comment -->