### PR TITLE
YPE-2479 - feat(ui): add onFootnotePress callback to BibleCard

### DIFF
--- a/.changeset/bible-card-footnote-press.md
+++ b/.changeset/bible-card-footnote-press.md
@@ -1,0 +1,4 @@
+---
+"@youversion/platform-react-ui": patch
+---
+Add optional `onFootnotePress` callback to `BibleCard` for custom footnote handling (same pattern as `BibleReader`).

--- a/packages/ui/src/components/bible-card.test.tsx
+++ b/packages/ui/src/components/bible-card.test.tsx
@@ -2,8 +2,10 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, act, within } from '@testing-library/react';
+import { render, act, within, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { BibleCard } from './bible-card';
+import type { FootnoteData } from './verse';
 import { usePassage, useVersion, useTheme } from '@youversion/platform-react-hooks';
 import type { BiblePassage, BibleVersion } from '@youversion/platform-core';
 
@@ -117,5 +119,50 @@ describe('BibleCard - Delayed spinner', () => {
     expect(within(container).getAllByRole('status', { name: /loading/i }).length).toBeGreaterThan(
       0,
     );
+  });
+});
+
+describe('BibleCard - onFootnotePress callback', () => {
+  const mockPassageWithFootnote: BiblePassage = {
+    id: 'JHN.1',
+    content: `<div class="p"><span class="yv-v" v="5"></span><span class="yv-vlbl">5</span>The light shines<span class="yv-n f"><span class="fr">1:5 </span><span class="ft">Or understood</span></span>.</div>`,
+    reference: 'JHN.1',
+  };
+
+  beforeEach(() => {
+    vi.mocked(useTheme).mockReturnValue('light');
+    vi.mocked(useVersion).mockReturnValue({
+      version: mockVersion,
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    vi.mocked(usePassage).mockReturnValue({
+      passage: mockPassageWithFootnote,
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+  });
+
+  it('should call onFootnotePress when provided via BibleCard', async () => {
+    const onFootnotePress = vi.fn();
+
+    const { container } = render(
+      <BibleCard reference="JHN.1" versionId={3034} onFootnotePress={onFootnotePress} />,
+    );
+
+    const button = await waitFor(() => {
+      const btn = container.querySelector('[data-verse-footnote="5"] button');
+      expect(btn).not.toBeNull();
+      return btn as HTMLButtonElement;
+    });
+
+    await userEvent.click(button);
+
+    expect(onFootnotePress).toHaveBeenCalledTimes(1);
+    const data = onFootnotePress.mock.calls[0]![0] as FootnoteData;
+    expect(data.verseNum).toBe('5');
+    expect(data.reference).toBe('JHN.1');
   });
 });

--- a/packages/ui/src/components/bible-card.tsx
+++ b/packages/ui/src/components/bible-card.tsx
@@ -1,5 +1,5 @@
 import { usePassage, useVersion, useTheme } from '@youversion/platform-react-hooks';
-import { BibleTextView } from './verse';
+import { BibleTextView, type FootnoteData } from './verse';
 import { BibleAppLogoLockup } from './bible-app-logo-lockup';
 import { BibleVersionPicker } from './bible-version-picker';
 import { Button } from './ui/button';
@@ -32,6 +32,7 @@ export type BibleCardProps = {
   versionId: number;
   background?: 'light' | 'dark';
   showVersionPicker?: boolean;
+  onFootnotePress?: (data: FootnoteData) => void;
 };
 
 function BibleCardHeaderError(): React.ReactNode {
@@ -116,6 +117,7 @@ export function BibleCard({
   versionId,
   background,
   showVersionPicker = false,
+  onFootnotePress,
 }: BibleCardProps): React.ReactNode {
   const [versionNum, setVersionNum] = useState(versionId);
   const { version } = useVersion(versionNum);
@@ -177,6 +179,7 @@ export function BibleCard({
             loading: passageLoading,
             error: passageError,
           }}
+          onFootnotePress={onFootnotePress}
         />
       </AnimatedHeight>
 


### PR DESCRIPTION
## Summary
- Add optional `onFootnotePress` to `BibleCardProps` and pass it through to `BibleTextView` (same pattern as `BibleReader`)
- Add unit test verifying footnote tap invokes the callback with `FootnoteData`
- Add patch changeset for `@youversion/platform-react-ui`

## Test plan
- [x] `pnpm --filter @youversion/platform-react-ui test -- bible-card.test.tsx`
- [x] `pnpm --filter @youversion/platform-react-ui typecheck`
- [x] `pnpm --filter @youversion/platform-react-ui lint`

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an optional `onFootnotePress` callback to `BibleCard`, mirroring the identical pattern already established in `BibleReader`. When provided, it replaces the default footnote popover with a custom handler receiving `FootnoteData`; when omitted, behaviour is unchanged.

- **`bible-card.tsx`**: Adds `onFootnotePress?: (data: FootnoteData) => void` to `BibleCardProps` and threads it through to `BibleTextView`, consistent with `BibleReader`'s implementation.
- **`bible-card.test.tsx`**: Adds a new `describe` block that renders `BibleCard` with footnote-containing HTML, clicks the footnote button, and asserts the callback receives the correct `verseNum` and `reference`.
- **`.changeset/bible-card-footnote-press.md`**: Correct patch-level changeset entry for a non-breaking additive API change.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is a purely additive, optional prop that does not alter existing behaviour when omitted.

The new prop is optional and defaults to `undefined`, so all existing `BibleCard` usages are unaffected. The implementation is a direct copy of the established `BibleReader` pattern with no novel logic. The unit test correctly uses `waitFor` to accommodate `useLayoutEffect`-driven DOM mutations and asserts both call count and payload fields.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/bible-card.tsx | Adds `onFootnotePress` prop to `BibleCardProps` and passes it to `BibleTextView`; follows the exact same pattern as `BibleReader`. |
| packages/ui/src/components/bible-card.test.tsx | New `describe` block covers the footnote press callback path; uses `waitFor` correctly for `useLayoutEffect`-driven DOM mutations. |
| .changeset/bible-card-footnote-press.md | Patch changeset for `@youversion/platform-react-ui`; correctly scoped for a non-breaking additive change. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Consumer
    participant BibleCard
    participant BibleTextView
    participant Verse.Html
    participant VerseFootnoteButton

    Consumer->>BibleCard: onFootnotePress (optional)
    BibleCard->>BibleTextView: onFootnotePress
    BibleTextView->>Verse.Html: onFootnotePress
    Verse.Html->>VerseFootnoteButton: onFootnotePress

    alt onFootnotePress provided
        VerseFootnoteButton-->>Consumer: onClick → onFootnotePress(FootnoteData)
    else onFootnotePress not provided
        VerseFootnoteButton-->>Consumer: shows default Popover
    end
```

<sub>Reviews (1): Last reviewed commit: ["feat(ui): add onFootnotePress callback t..."](https://github.com/youversion/platform-sdk-react/commit/79a617bc5c0f4dee8ea413cfb0c1b9d965c1966a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32348213)</sub>

<!-- /greptile_comment -->