### PR TITLE
YPE-2195 - add onVersionPickerPress escape hatch + controlled BibleCard versionId

### DIFF
--- a/.changeset/version-picker-escape-hatch-and-bible-card-controlled.md
+++ b/.changeset/version-picker-escape-hatch-and-bible-card-controlled.md
@@ -1,0 +1,12 @@
+---
+"@youversion/platform-react-ui": minor
+---
+
+Add `onVersionPickerPress` escape-hatch prop to `BibleReader.Root` and `BibleCard`, and make `BibleCard.versionId` controllable.
+
+- `BibleReader.Root` accepts `onVersionPickerPress?: (data: BibleVersionPickerPressData) => void`, threaded through context to Toolbar and then to the internal `BibleVersionPicker.Root` — suppresses the default popover when provided
+- `BibleCard` accepts `onVersionPickerPress`, `defaultVersionId`, and `onVersionChange`; `versionId` is now optional and uses `useControllableState` for controlled/uncontrolled support
+- `BibleVersionPicker.Root` guards `isPopoverOpen` state when escape hatch is active, moves `filteredRecentVersions` to context to eliminate duplication between `Content` and `BibleVersionPickerLanguageTrigger`
+- `BibleChapterPicker.Root` guards `isPopoverOpen` state when `onChapterPickerPress` is active
+- `BibleWidgetView` removed (zero consumers)
+- `BibleVersionPickerPressData` type exported: `{ versionId: number; languageId: string }`

--- a/.changeset/version-picker-escape-hatch-and-bible-card-controlled.md
+++ b/.changeset/version-picker-escape-hatch-and-bible-card-controlled.md
@@ -8,5 +8,5 @@ Add `onVersionPickerPress` escape-hatch prop to `BibleReader.Root` and `BibleCar
 - `BibleCard` accepts `onVersionPickerPress`, `defaultVersionId`, and `onVersionChange`; `versionId` is now optional and uses `useControllableState` for controlled/uncontrolled support
 - `BibleVersionPicker.Root` guards `isPopoverOpen` state when escape hatch is active, moves `filteredRecentVersions` to context to eliminate duplication between `Content` and `BibleVersionPickerLanguageTrigger`
 - `BibleChapterPicker.Root` guards `isPopoverOpen` state when `onChapterPickerPress` is active
-- `BibleWidgetView` removed (zero consumers)
+- `BibleWidgetView` kept as a deprecated alias for `BibleCard`
 - `BibleVersionPickerPressData` type exported: `{ versionId: number; languageId: string }`

--- a/packages/ui/src/components/bible-card.tsx
+++ b/packages/ui/src/components/bible-card.tsx
@@ -1,9 +1,10 @@
 import { usePassage, useVersion, useTheme } from '@youversion/platform-react-hooks';
 import { BibleTextView } from './verse';
 import { BibleAppLogoLockup } from './bible-app-logo-lockup';
-import { BibleVersionPicker } from './bible-version-picker';
+import { BibleVersionPicker, type BibleVersionPickerPressData } from './bible-version-picker';
 import { Button } from './ui/button';
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { SOURCE_SERIF_FONT } from '@/lib/verse-html-utils';
 import { LoaderIcon } from './icons/loader';
 import { AnimatedHeight } from './animated-height';
@@ -29,9 +30,12 @@ type VersionResult = ReturnType<typeof useVersion>;
 
 export type BibleCardProps = {
   reference: string;
-  versionId: number;
+  versionId?: number;
+  defaultVersionId?: number;
+  onVersionChange?: (versionId: number) => void;
   background?: 'light' | 'dark';
   showVersionPicker?: boolean;
+  onVersionPickerPress?: (data: BibleVersionPickerPressData) => void;
 };
 
 function BibleCardHeaderError(): React.ReactNode {
@@ -62,16 +66,19 @@ function BibleCardVersionPicker({
   versionId,
   onVersionChange,
   theme,
+  onVersionPickerPress,
 }: {
   versionId: number;
   onVersionChange: (id: number) => void;
   theme: 'light' | 'dark';
+  onVersionPickerPress?: (data: BibleVersionPickerPressData) => void;
 }): React.ReactNode {
   return (
     <BibleVersionPicker.Root
       onVersionChange={onVersionChange}
       versionId={versionId}
       background={theme}
+      onVersionPickerPress={onVersionPickerPress}
     >
       <BibleVersionPicker.Trigger aria-label="Change Bible version">
         {({ version, loading }) => (
@@ -111,13 +118,22 @@ function BibleCardFooter({ copyright }: { copyright?: string | null }): React.Re
   );
 }
 
+const DEFAULT_VERSION_ID = 3034;
+
 export function BibleCard({
   reference,
-  versionId,
+  versionId: controlledVersionId,
+  defaultVersionId = DEFAULT_VERSION_ID,
+  onVersionChange,
   background,
   showVersionPicker = false,
+  onVersionPickerPress,
 }: BibleCardProps): React.ReactNode {
-  const [versionNum, setVersionNum] = useState(versionId);
+  const [versionNum, setVersionNum] = useControllableState({
+    prop: controlledVersionId,
+    defaultProp: defaultVersionId,
+    onChange: onVersionChange,
+  });
   const { version } = useVersion(versionNum);
   const {
     passage,
@@ -161,6 +177,7 @@ export function BibleCard({
             versionId={versionNum}
             onVersionChange={setVersionNum}
             theme={theme}
+            onVersionPickerPress={onVersionPickerPress}
           />
         ) : null}
       </div>

--- a/packages/ui/src/components/bible-card.tsx
+++ b/packages/ui/src/components/bible-card.tsx
@@ -129,9 +129,14 @@ export function BibleCard({
   showVersionPicker = false,
   onVersionPickerPress,
 }: BibleCardProps): React.ReactNode {
+  // Controlled only when both versionId + onVersionChange are provided.
+  // versionId alone seeds uncontrolled state, preserving backwards compatibility
+  // with consumers who use the version picker without an onChange handler.
+  const isControlled = controlledVersionId !== undefined && onVersionChange !== undefined;
+
   const [versionNum, setVersionNum] = useControllableState({
-    prop: controlledVersionId,
-    defaultProp: defaultVersionId,
+    prop: isControlled ? controlledVersionId : undefined,
+    defaultProp: isControlled ? defaultVersionId : (controlledVersionId ?? defaultVersionId),
     onChange: onVersionChange,
   });
   const { version } = useVersion(versionNum);

--- a/packages/ui/src/components/bible-card.tsx
+++ b/packages/ui/src/components/bible-card.tsx
@@ -1,4 +1,5 @@
 import { usePassage, useVersion, useTheme } from '@youversion/platform-react-hooks';
+import { DEFAULT_LICENSE_FREE_BIBLE_VERSION } from '@youversion/platform-core';
 import { BibleTextView } from './verse';
 import { BibleAppLogoLockup } from './bible-app-logo-lockup';
 import { BibleVersionPicker, type BibleVersionPickerPressData } from './bible-version-picker';
@@ -118,12 +119,10 @@ function BibleCardFooter({ copyright }: { copyright?: string | null }): React.Re
   );
 }
 
-const DEFAULT_VERSION_ID = 3034;
-
 export function BibleCard({
   reference,
   versionId: controlledVersionId,
-  defaultVersionId = DEFAULT_VERSION_ID,
+  defaultVersionId = DEFAULT_LICENSE_FREE_BIBLE_VERSION,
   onVersionChange,
   background,
   showVersionPicker = false,

--- a/packages/ui/src/components/bible-chapter-picker.tsx
+++ b/packages/ui/src/components/bible-chapter-picker.tsx
@@ -104,7 +104,8 @@ function Root({
   const providerTheme = useTheme();
   const theme = background || providerTheme;
 
-  const [isPopoverOpen, setIsPopoverOpenRaw] = useState(false);
+  const [isPopoverOpenRaw, setIsPopoverOpenRaw] = useState(false);
+  const isPopoverOpen = onChapterPickerPress ? false : isPopoverOpenRaw;
   const [searchQuery, setSearchQuery] = useState('');
   const [expandedBook, setExpandedBook] = useState<string | null>(book || null);
 
@@ -167,6 +168,7 @@ function Root({
   }, [expandedBook]);
 
   const setIsPopoverOpen = (open: boolean) => {
+    if (onChapterPickerPress) return;
     setIsPopoverOpenRaw(open);
     if (!open) {
       setSearchQuery('');

--- a/packages/ui/src/components/bible-reader.tsx
+++ b/packages/ui/src/components/bible-reader.tsx
@@ -22,7 +22,7 @@ import {
 import { cn } from '@/lib/utils';
 import { DEFAULT_LICENSE_FREE_BIBLE_VERSION, getAdjacentChapter } from '@youversion/platform-core';
 import { BibleChapterPicker, type BibleChapterPickerPressData } from './bible-chapter-picker';
-import { BibleVersionPicker } from './bible-version-picker';
+import { BibleVersionPicker, type BibleVersionPickerPressData } from './bible-version-picker';
 import { GearIcon } from './icons/gear';
 import { InfoIcon } from './icons/info';
 import { LoaderIcon } from './icons/loader';
@@ -52,6 +52,7 @@ type BibleReaderContextType = {
   background: 'light' | 'dark';
   onFootnotePress?: (data: FootnoteData) => void;
   onChapterPickerPress?: (data: BibleChapterPickerPressData) => void;
+  onVersionPickerPress?: (data: BibleVersionPickerPressData) => void;
 };
 
 const BibleReaderContext = createContext<BibleReaderContextType | null>(null);
@@ -85,6 +86,7 @@ export type RootProps = {
   background?: 'light' | 'dark';
   onFootnotePress?: (data: FootnoteData) => void;
   onChapterPickerPress?: (data: BibleChapterPickerPressData) => void;
+  onVersionPickerPress?: (data: BibleVersionPickerPressData) => void;
   children?: ReactNode;
 };
 
@@ -184,6 +186,7 @@ function Root({
   background,
   onFootnotePress,
   onChapterPickerPress,
+  onVersionPickerPress,
   children,
 }: RootProps) {
   const [book, setBook] = useControllableState({
@@ -290,6 +293,7 @@ function Root({
     background: theme,
     onFootnotePress,
     onChapterPickerPress,
+    onVersionPickerPress,
   };
 
   return (
@@ -557,6 +561,7 @@ function Toolbar({ border = 'top', onOpenBibleThemeSettings }: BibleReaderToolba
     setCurrentFontSize,
     background,
     onChapterPickerPress,
+    onVersionPickerPress,
   } = useBibleReaderContext();
   const yvContext = useContext(YouVersionContext);
   const themesSettingsValuesRef = useRef<BibleThemeSettingsValues>({
@@ -711,6 +716,7 @@ function Toolbar({ border = 'top', onOpenBibleThemeSettings }: BibleReaderToolba
           versionId={versionId}
           onVersionChange={setVersionId}
           background={background}
+          onVersionPickerPress={onVersionPickerPress}
         >
           <BibleVersionPicker.Trigger aria-label="Change Bible version">
             {({ version, loading }) => (

--- a/packages/ui/src/components/bible-version-picker.tsx
+++ b/packages/ui/src/components/bible-version-picker.tsx
@@ -543,7 +543,11 @@ function Content({ open, onRequestClose }: BibleVersionPickerContentProps = {}) 
     wasOpenRef.current = open ?? false;
   }, [open, setIsLanguagesOpen, setSearchQuery]);
 
-  if (!onVersionPickerPress && open === undefined && !onRequestClose) {
+  if (onVersionPickerPress && open === undefined && !onRequestClose) {
+    return null;
+  }
+
+  if (open === undefined && !onRequestClose) {
     return (
       <PopoverContent
         sideOffset={16}

--- a/packages/ui/src/components/bible-version-picker.tsx
+++ b/packages/ui/src/components/bible-version-picker.tsx
@@ -148,6 +148,7 @@ type BibleVersionPickerContextType = {
   setSearchQuery: (query: string) => void;
   suggestedLanguages: Pick<Language, 'id' | 'display_names'>[];
   filteredVersions: BibleVersion[];
+  filteredRecentVersions: RecentVersion[];
   isLanguagesOpen: boolean;
   setIsLanguagesOpen: (open: boolean) => void;
   recentVersions: RecentVersion[];
@@ -232,17 +233,19 @@ function Root({
   const [searchQuery, setSearchQuery] = useState('');
   const [isLanguagesOpen, setIsLanguagesOpen] = useState(false);
   const [recentVersions, setRecentVersions] = useState<RecentVersion[]>(getRecentVersions);
-  const [isPopoverOpen, setIsPopoverOpenRaw] = useState(false);
+  const [isPopoverOpenRaw, setIsPopoverOpenRaw] = useState(false);
+  const isPopoverOpen = onVersionPickerPress ? false : isPopoverOpenRaw;
 
   const setIsPopoverOpen = useCallback(
     (open: boolean) => {
+      if (onVersionPickerPress) return;
       setIsPopoverOpenRaw(open);
       if (!open) {
         setSearchQuery('');
         setIsLanguagesOpen(false);
       }
     },
-    [setSearchQuery],
+    [setSearchQuery, onVersionPickerPress],
   );
 
   const addRecentVersion = useCallback((version: RecentVersion) => {
@@ -270,6 +273,17 @@ function Root({
     selectedLanguageId,
     recentVersions,
   );
+
+  const filteredRecentVersions = useMemo(() => {
+    if (!searchQuery.trim()) return recentVersions;
+    const query = searchQuery.trim().toLowerCase();
+    return recentVersions.filter(
+      (v) =>
+        v.title?.toLowerCase().includes(query) ||
+        v.localized_abbreviation?.toLowerCase().includes(query) ||
+        v.abbreviation?.toLowerCase().includes(query),
+    );
+  }, [recentVersions, searchQuery]);
 
   const getLanguageDisplayName = useCallback(
     (language: Pick<Language, 'id' | 'display_names'>) => {
@@ -345,6 +359,7 @@ function Root({
     setSearchQuery,
     suggestedLanguages,
     filteredVersions,
+    filteredRecentVersions,
     isLanguagesOpen,
     setIsLanguagesOpen,
     recentVersions,
@@ -444,22 +459,11 @@ export function BibleVersionPickerLanguageTrigger({
 }: BibleVersionPickerLanguageTriggerProps): React.ReactElement {
   const {
     filteredVersions,
+    filteredRecentVersions,
     setIsLanguagesOpen,
     selectedLanguageId,
-    recentVersions,
-    searchQuery,
     versionsLoading,
   } = useBibleVersionPickerContext();
-  const filteredRecentVersions = useMemo(() => {
-    if (!searchQuery.trim()) return recentVersions;
-    const query = searchQuery.trim().toLowerCase();
-    return recentVersions.filter(
-      (v) =>
-        v.title?.toLowerCase().includes(query) ||
-        v.localized_abbreviation?.toLowerCase().includes(query) ||
-        v.abbreviation?.toLowerCase().includes(query),
-    );
-  }, [recentVersions, searchQuery]);
   // Fetch the selected language details (may not be in the paginated languages list)
   const { language: selectedLanguage } = useLanguage(selectedLanguageId);
 
@@ -505,9 +509,9 @@ function Content({ open, onRequestClose }: BibleVersionPickerContentProps = {}) 
     searchQuery,
     setSearchQuery,
     filteredVersions,
+    filteredRecentVersions,
     versionId,
     setVersionId,
-    recentVersions,
     addRecentVersion,
     versionsLoading,
     background,
@@ -518,17 +522,6 @@ function Content({ open, onRequestClose }: BibleVersionPickerContentProps = {}) 
     onVersionPickerPress,
   } = useBibleVersionPickerContext();
   const wasOpenRef = useRef(open ?? false);
-
-  const filteredRecentVersions = useMemo(() => {
-    if (!searchQuery.trim()) return recentVersions;
-    const query = searchQuery.trim().toLowerCase();
-    return recentVersions.filter(
-      (v) =>
-        v.title?.toLowerCase().includes(query) ||
-        v.localized_abbreviation?.toLowerCase().includes(query) ||
-        v.abbreviation?.toLowerCase().includes(query),
-    );
-  }, [recentVersions, searchQuery]);
 
   const handleSelectVersion = (version: BibleVersion | RecentVersion) => {
     setVersionId(version.id);

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -42,6 +42,5 @@ export {
   type FootnoteContentProps,
 } from './verse';
 export { BibleCard, type BibleCardProps } from './bible-card';
-export { BibleWidgetView, type BibleWidgetViewProps } from './bible-widget-view';
 export { Separator } from './ui/separator';
 export { Textarea } from './ui/textarea';

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -42,5 +42,6 @@ export {
   type FootnoteContentProps,
 } from './verse';
 export { BibleCard, type BibleCardProps } from './bible-card';
+export { BibleWidgetView, type BibleWidgetViewProps } from './bible-widget-view';
 export { Separator } from './ui/separator';
 export { Textarea } from './ui/textarea';


### PR DESCRIPTION
https://github.com/user-attachments/assets/e7a8b664-5bc9-4798-b807-78191b979f4b

## Summary

Two changes for React Native consumers:

1. **`onVersionPickerPress` escape hatch** — Pass this callback to `BibleReader.Root` or `BibleCard` to intercept version picker taps and show your own native sheet instead of the built-in popover.

2. **Controlled `BibleCard.versionId`** — `versionId` is now optional. Pass `defaultVersionId` + `onVersionChange` for controlled behavior, or just `versionId` for uncontrolled (backwards compatible).

Closes [YPE-2195](https://lifechurch.atlassian.net/browse/YPE-2195)

[YPE-2195]: https://lifechurch.atlassian.net/browse/YPE-2195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an `onVersionPickerPress` escape-hatch prop to `BibleReader.Root` and `BibleCard`, allowing React Native consumers to intercept version-picker presses and render native sheets instead of the web popover. It also makes `BibleCard.versionId` properly controllable via `useControllableState`, with a carefully guarded `isControlled` check that preserves uncontrolled backwards-compat when only `versionId` (no `onVersionChange`) is supplied.

- **Escape hatch (version + chapter picker):** `Root` skips the `<Popover>` wrapper, `Trigger` becomes a plain `<button>` that calls `onVersionPickerPress`, and `Content` returns `null` early — cleanly suppressing the popover on all three sides.
- **`filteredRecentVersions` refactor:** computation moved from `Content` and `BibleVersionPickerLanguageTrigger` into the Root context, eliminating duplication.
- **`BibleCard` controllable state:** `isControlled` gate (`versionId !== undefined && onVersionChange !== undefined`) ensures existing consumers who pass only `versionId` keep their current uncontrolled behaviour.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the escape-hatch and controlled-state logic is correctly guarded on all three sides (Root wrapper, Trigger rendering, Content early-return), and the isControlled gate preserves existing consumer behaviour.

All three surfaces of the escape hatch (Root skips Popover, Trigger renders plain button, Content returns null) are consistent and mutually reinforcing. The BibleCard controllable-state gate correctly distinguishes fully-controlled from uncontrolled-seeded-by-prop scenarios. The filteredRecentVersions move to Root context is a clean dedup with no functional change. No regressions were found in the changed paths.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/bible-version-picker.tsx | Adds onVersionPickerPress escape-hatch: guards isPopoverOpen via renamed raw state + derived value, skips Popover wrapper in Root, returns null in Content when active, and moves filteredRecentVersions computation to Root context to eliminate duplication. |
| packages/ui/src/components/bible-card.tsx | Makes versionId controllable via useControllableState with an isControlled guard that preserves uncontrolled backwards-compat when only versionId (no onVersionChange) is supplied; threads onVersionPickerPress to BibleCardVersionPicker. |
| packages/ui/src/components/bible-chapter-picker.tsx | Mirrors the version-picker escape-hatch pattern: renames isPopoverOpen to isPopoverOpenRaw, derives isPopoverOpen as always-false when onChapterPickerPress is active, and guards the setter. |
| packages/ui/src/components/bible-reader.tsx | Adds onVersionPickerPress to BibleReaderContext, RootProps, and Root; threads it through to Toolbar then BibleVersionPicker.Root. Minimal, straightforward plumbing. |
| .changeset/version-picker-escape-hatch-and-bible-card-controlled.md | Minor changeset correctly notes the new props, escape-hatch behavior, filteredRecentVersions move, and that BibleWidgetView is kept as a deprecated alias rather than removed. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Consumer as Native Consumer
    participant Root as BibleVersionPicker.Root
    participant Trigger as BibleVersionPicker.Trigger
    participant Content as BibleVersionPicker.Content

    note over Root: onVersionPickerPress provided

    Root->>Root: Renders Context.Provider only (no Popover wrapper)
    Consumer->>Trigger: user taps version button
    Trigger->>Trigger: renders plain button (not PopoverTrigger)
    Trigger->>Consumer: calls onVersionPickerPress with versionId and languageId
    Content->>Content: returns null (escape hatch guard fires)

    note over Root: onVersionPickerPress NOT provided

    Root->>Root: Renders Context.Provider + Popover wrapper
    Consumer->>Trigger: user taps version button
    Trigger->>Root: PopoverTrigger toggles isPopoverOpen
    Root->>Content: isPopoverOpen true, renders PopoverContent
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/ui/src/components/bible-version-picker.tsx`, line 546-598 ([link](https://github.com/youversion/platform-sdk-react/blob/d001c70f82e7cb77cdb36118b1686e7817dd7806/packages/ui/src/components/bible-version-picker.tsx#L546-L598)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Content div always renders when escape hatch is active**

   When `onVersionPickerPress` is set, the `Content` component falls through the `!onVersionPickerPress` guard and renders a plain, always-visible `<div>` containing the full version picker UI. Both `BibleReader`'s Toolbar and `BibleCard`'s `BibleCardVersionPicker` unconditionally include `<BibleVersionPicker.Content />` as a child, so enabling the escape hatch immediately injects a permanently-expanded version list inline into the toolbar / card — the opposite of the "suppress popover" intent.

   The simplest fix is to return `null` early when the escape hatch is active and the caller hasn't supplied explicit `open`/`onRequestClose` props (i.e., the default usage inside Toolbar and `BibleCardVersionPicker`).

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/ui/src/components/bible-version-picker.tsx
   Line: 546-598

   Comment:
   **Content div always renders when escape hatch is active**

   When `onVersionPickerPress` is set, the `Content` component falls through the `!onVersionPickerPress` guard and renders a plain, always-visible `<div>` containing the full version picker UI. Both `BibleReader`'s Toolbar and `BibleCard`'s `BibleCardVersionPicker` unconditionally include `<BibleVersionPicker.Content />` as a child, so enabling the escape hatch immediately injects a permanently-expanded version list inline into the toolbar / card — the opposite of the "suppress popover" intent.

   The simplest fix is to return `null` early when the escape hatch is active and the caller hasn't supplied explicit `open`/`onRequestClose` props (i.e., the default usage inside Toolbar and `BibleCardVersionPicker`).

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fui%2Fsrc%2Fcomponents%2Fbible-version-picker.tsx%0ALine%3A%20546-598%0A%0AComment%3A%0A**Content%20div%20always%20renders%20when%20escape%20hatch%20is%20active**%0A%0AWhen%20%60onVersionPickerPress%60%20is%20set%2C%20the%20%60Content%60%20component%20falls%20through%20the%20%60!onVersionPickerPress%60%20guard%20and%20renders%20a%20plain%2C%20always-visible%20%60%3Cdiv%3E%60%20containing%20the%20full%20version%20picker%20UI.%20Both%20%60BibleReader%60's%20Toolbar%20and%20%60BibleCard%60's%20%60BibleCardVersionPicker%60%20unconditionally%20include%20%60%3CBibleVersionPicker.Content%20%2F%3E%60%20as%20a%20child%2C%20so%20enabling%20the%20escape%20hatch%20immediately%20injects%20a%20permanently-expanded%20version%20list%20inline%20into%20the%20toolbar%20%2F%20card%20%E2%80%94%20the%20opposite%20of%20the%20%22suppress%20popover%22%20intent.%0A%0AThe%20simplest%20fix%20is%20to%20return%20%60null%60%20early%20when%20the%20escape%20hatch%20is%20active%20and%20the%20caller%20hasn't%20supplied%20explicit%20%60open%60%2F%60onRequestClose%60%20props%20%28i.e.%2C%20the%20default%20usage%20inside%20Toolbar%20and%20%60BibleCardVersionPicker%60%29.%0A%0A%60%60%60suggestion%0A%20%20if%20%28onVersionPickerPress%20%26%26%20open%20%3D%3D%3D%20undefined%20%26%26%20!onRequestClose%29%20%7B%0A%20%20%20%20return%20null%3B%0A%20%7D%0A%0A%20%20if%20%28!onVersionPickerPress%20%26%26%20open%20%3D%3D%3D%20undefined%20%26%26%20!onRequestClose%29%20%7B%0A%20%20%20%20return%20%28%0A%20%20%20%20%20%20%3CPopoverContent%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-react&pr=239&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fui%2Fsrc%2Fcomponents%2Fbible-version-picker.tsx%0ALine%3A%20546-598%0A%0AComment%3A%0A**Content%20div%20always%20renders%20when%20escape%20hatch%20is%20active**%0A%0AWhen%20%60onVersionPickerPress%60%20is%20set%2C%20the%20%60Content%60%20component%20falls%20through%20the%20%60!onVersionPickerPress%60%20guard%20and%20renders%20a%20plain%2C%20always-visible%20%60%3Cdiv%3E%60%20containing%20the%20full%20version%20picker%20UI.%20Both%20%60BibleReader%60's%20Toolbar%20and%20%60BibleCard%60's%20%60BibleCardVersionPicker%60%20unconditionally%20include%20%60%3CBibleVersionPicker.Content%20%2F%3E%60%20as%20a%20child%2C%20so%20enabling%20the%20escape%20hatch%20immediately%20injects%20a%20permanently-expanded%20version%20list%20inline%20into%20the%20toolbar%20%2F%20card%20%E2%80%94%20the%20opposite%20of%20the%20%22suppress%20popover%22%20intent.%0A%0AThe%20simplest%20fix%20is%20to%20return%20%60null%60%20early%20when%20the%20escape%20hatch%20is%20active%20and%20the%20caller%20hasn't%20supplied%20explicit%20%60open%60%2F%60onRequestClose%60%20props%20%28i.e.%2C%20the%20default%20usage%20inside%20Toolbar%20and%20%60BibleCardVersionPicker%60%29.%0A%0A%60%60%60suggestion%0A%20%20if%20%28onVersionPickerPress%20%26%26%20open%20%3D%3D%3D%20undefined%20%26%26%20!onRequestClose%29%20%7B%0A%20%20%20%20return%20null%3B%0A%20%7D%0A%0A%20%20if%20%28!onVersionPickerPress%20%26%26%20open%20%3D%3D%3D%20undefined%20%26%26%20!onRequestClose%29%20%7B%0A%20%20%20%20return%20%28%0A%20%20%20%20%20%20%3CPopoverContent%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=239&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["refactor(ui): use shared DEFAULT\_LICENSE..."](https://github.com/youversion/platform-sdk-react/commit/f6e7294ba46da4cbe2e32c66ce47eef367ab82f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32372826)</sub>

<!-- /greptile_comment -->