### PR TITLE
Use using for scoped spies

### DIFF
--- a/packages/core/src/__tests__/StorageStrategy.test.ts
+++ b/packages/core/src/__tests__/StorageStrategy.test.ts
@@ -125,7 +125,7 @@ describe('SessionStorageStrategy', () => {
       // @ts-expect-error - Testing undefined sessionStorage
       delete global.sessionStorage;
 
-      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      using consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 
       const strategy = new SessionStorageStrategy();
 
@@ -139,7 +139,6 @@ describe('SessionStorageStrategy', () => {
       expect(() => strategy.removeItem('test')).not.toThrow();
       expect(() => strategy.clear()).not.toThrow();
 
-      consoleSpy.mockRestore();
       global.sessionStorage = originalSessionStorage;
     });
   });

--- a/packages/core/src/__tests__/Users.test.ts
+++ b/packages/core/src/__tests__/Users.test.ts
@@ -193,7 +193,7 @@ describe('YouVersionAPIUsers', () => {
       );
 
       // Mock YouVersionPlatformConfiguration.saveAuthData
-      const saveAuthDataSpy = vi.spyOn(YouVersionPlatformConfiguration, 'saveAuthData');
+      using saveAuthDataSpy = vi.spyOn(YouVersionPlatformConfiguration, 'saveAuthData');
 
       const result = await YouVersionAPIUsers.handleAuthCallback();
 
@@ -217,8 +217,6 @@ describe('YouVersionAPIUsers', () => {
         '',
         'https://example.com/callback',
       );
-
-      saveAuthDataSpy.mockRestore();
     });
 
     it('should handle token exchange failure', async () => {
@@ -395,13 +393,11 @@ describe('YouVersionAPIUsers', () => {
 
   describe('signOut', () => {
     it('should call setAccessToken with null', () => {
-      const setAccessTokenSpy = vi.spyOn(YouVersionPlatformConfiguration, 'clearAuthTokens');
+      using setAccessTokenSpy = vi.spyOn(YouVersionPlatformConfiguration, 'clearAuthTokens');
 
       YouVersionAPIUsers.signOut();
 
       expect(setAccessTokenSpy).toHaveBeenCalled();
-
-      setAccessTokenSpy.mockRestore();
     });
   });
 
@@ -527,7 +523,7 @@ describe('YouVersionAPIUsers', () => {
 
       mockFetch.mockResolvedValue(mockResponse);
 
-      const saveAuthDataSpy = vi.spyOn(YouVersionPlatformConfiguration, 'saveAuthData');
+      using saveAuthDataSpy = vi.spyOn(YouVersionPlatformConfiguration, 'saveAuthData');
 
       const result = await YouVersionAPIUsers.refreshTokens();
 
@@ -567,8 +563,6 @@ describe('YouVersionAPIUsers', () => {
         existingIdToken,
         expect.any(Date),
       );
-
-      saveAuthDataSpy.mockRestore();
     });
 
     it('should handle refresh token request failure', async () => {
@@ -707,14 +701,12 @@ describe('YouVersionAPIUsers', () => {
         statusText: 'Unauthorized',
       });
 
-      const clearAuthTokensSpy = vi.spyOn(YouVersionPlatformConfiguration, 'clearAuthTokens');
+      using clearAuthTokensSpy = vi.spyOn(YouVersionPlatformConfiguration, 'clearAuthTokens');
 
       const result = await YouVersionAPIUsers.refreshTokenIfNeeded();
 
       expect(result).toBe(false);
       expect(clearAuthTokensSpy).toHaveBeenCalled();
-
-      clearAuthTokensSpy.mockRestore();
     });
   });
 });

--- a/packages/core/src/__tests__/languages.test.ts
+++ b/packages/core/src/__tests__/languages.test.ts
@@ -62,7 +62,7 @@ describe('LanguagesClient', () => {
     });
 
     it('should normalize lowercase country codes to uppercase', async () => {
-      const getSpy = vi.spyOn(apiClient, 'get');
+      using getSpy = vi.spyOn(apiClient, 'get');
 
       await languagesClient.getLanguages({ country: 'us', page_size: 5 });
 
@@ -70,7 +70,6 @@ describe('LanguagesClient', () => {
         '/v1/languages',
         expect.objectContaining({ country: 'US' }),
       );
-      getSpy.mockRestore();
     });
 
     it('should fetch languages with valid fields filter', async () => {

--- a/packages/ui/src/components/bible-version-picker.test.tsx
+++ b/packages/ui/src/components/bible-version-picker.test.tsx
@@ -158,7 +158,7 @@ describe('BibleVersionPicker', () => {
           abbreviation: 'NIV',
         },
       ];
-      const getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation((key) => {
+      using _getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation((key) => {
         if (key === RECENT_VERSIONS_KEY) return JSON.stringify(recentVersions);
         return null;
       });
@@ -175,8 +175,6 @@ describe('BibleVersionPicker', () => {
       });
 
       expect(screen.queryByText('No versions found')).toBeNull();
-
-      getItemSpy.mockRestore();
     });
 
     it('should show spinner in badge when versions are loading', async () => {


### PR DESCRIPTION
## Summary

Use `using` for scoped Vitest spies so cleanup happens automatically when the test block exits.

Inspired by: https://x.com/sebastienlorber/status/2057033638827483236

## Testing

- `pnpm --filter @youversion/platform-core test -- StorageStrategy.test.ts languages.test.ts Users.test.ts`
- `pnpm --filter @youversion/platform-react-ui test -- bible-version-picker.test.tsx`
