### PR TITLE
feat(ui): add onFootnotePress callback to BibleCard

### DIFF
--- a/.changeset/bible-card-footnote-press.md
+++ b/.changeset/bible-card-footnote-press.md
@@ -1,0 +1,4 @@
+---
+"@youversion/platform-react-ui": patch
+---
+Add optional `onFootnotePress` callback to `BibleCard` for custom footnote handling (same pattern as `BibleReader`).

--- a/.changeset/bible-card-footnote-press.md
+++ b/.changeset/bible-card-footnote-press.md
@@ -1,4 +1,4 @@
 ---
-"@youversion/platform-react-ui": patch
+"@youversion/platform-react-ui": minor
 ---
 Add optional `onFootnotePress` callback to `BibleCard` for custom footnote handling (same pattern as `BibleReader`).

--- a/packages/ui/src/components/bible-card.test.tsx
+++ b/packages/ui/src/components/bible-card.test.tsx
@@ -164,5 +164,7 @@ describe('BibleCard - onFootnotePress callback', () => {
     const data = onFootnotePress.mock.calls[0]![0] as FootnoteData;
     expect(data.verseNum).toBe('5');
     expect(data.reference).toBe('JHN.1');
+    expect(data.notes).toHaveLength(1);
+    expect(data.notes[0]).toContain('Or understood');
   });
 });

--- a/packages/ui/src/components/bible-card.test.tsx
+++ b/packages/ui/src/components/bible-card.test.tsx
@@ -2,8 +2,10 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, act, within } from '@testing-library/react';
+import { render, act, within, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { BibleCard } from './bible-card';
+import type { FootnoteData } from './verse';
 import { usePassage, useVersion, useTheme } from '@youversion/platform-react-hooks';
 import type { BiblePassage, BibleVersion } from '@youversion/platform-core';
 
@@ -117,5 +119,50 @@ describe('BibleCard - Delayed spinner', () => {
     expect(within(container).getAllByRole('status', { name: /loading/i }).length).toBeGreaterThan(
       0,
     );
+  });
+});
+
+describe('BibleCard - onFootnotePress callback', () => {
+  const mockPassageWithFootnote: BiblePassage = {
+    id: 'JHN.1',
+    content: `<div class="p"><span class="yv-v" v="5"></span><span class="yv-vlbl">5</span>The light shines<span class="yv-n f"><span class="fr">1:5 </span><span class="ft">Or understood</span></span>.</div>`,
+    reference: 'JHN.1',
+  };
+
+  beforeEach(() => {
+    vi.mocked(useTheme).mockReturnValue('light');
+    vi.mocked(useVersion).mockReturnValue({
+      version: mockVersion,
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    vi.mocked(usePassage).mockReturnValue({
+      passage: mockPassageWithFootnote,
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+  });
+
+  it('should call onFootnotePress when provided via BibleCard', async () => {
+    const onFootnotePress = vi.fn();
+
+    const { container } = render(
+      <BibleCard reference="JHN.1" versionId={3034} onFootnotePress={onFootnotePress} />,
+    );
+
+    const button = await waitFor(() => {
+      const btn = container.querySelector('[data-verse-footnote="5"] button');
+      expect(btn).not.toBeNull();
+      return btn as HTMLButtonElement;
+    });
+
+    await userEvent.click(button);
+
+    expect(onFootnotePress).toHaveBeenCalledTimes(1);
+    const data = onFootnotePress.mock.calls[0]![0] as FootnoteData;
+    expect(data.verseNum).toBe('5');
+    expect(data.reference).toBe('JHN.1');
   });
 });

--- a/packages/ui/src/components/bible-card.tsx
+++ b/packages/ui/src/components/bible-card.tsx
@@ -1,6 +1,6 @@
 import { usePassage, useVersion, useTheme } from '@youversion/platform-react-hooks';
 import { DEFAULT_LICENSE_FREE_BIBLE_VERSION } from '@youversion/platform-core';
-import { BibleTextView } from './verse';
+import { BibleTextView, type FootnoteData } from './verse';
 import { BibleAppLogoLockup } from './bible-app-logo-lockup';
 import { BibleVersionPicker, type BibleVersionPickerPressData } from './bible-version-picker';
 import { Button } from './ui/button';
@@ -37,6 +37,7 @@ export type BibleCardProps = {
   background?: 'light' | 'dark';
   showVersionPicker?: boolean;
   onVersionPickerPress?: (data: BibleVersionPickerPressData) => void;
+  onFootnotePress?: (data: FootnoteData) => void;
 };
 
 function BibleCardHeaderError(): React.ReactNode {
@@ -127,6 +128,7 @@ export function BibleCard({
   background,
   showVersionPicker = false,
   onVersionPickerPress,
+  onFootnotePress,
 }: BibleCardProps): React.ReactNode {
   // Controlled only when both versionId + onVersionChange are provided.
   // versionId alone seeds uncontrolled state, preserving backwards compatibility
@@ -198,6 +200,7 @@ export function BibleCard({
             loading: passageLoading,
             error: passageError,
           }}
+          onFootnotePress={onFootnotePress}
         />
       </AnimatedHeight>
 


### PR DESCRIPTION
## Summary
- Add optional `onFootnotePress` to `BibleCardProps` and forward it to the internal `BibleTextView`
- Add unit test that clicks a footnote marker and asserts callback payload
- Changeset for patch release of `@youversion/platform-react-ui`

## Test plan
- [x] `pnpm test bible-card.test.tsx` in `packages/ui`
- [ ] Consumer: platform-sdk-reactnative-expo links built package and verifies footnote sheet on dev client

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an optional `onFootnotePress` callback to `BibleCard`, mirroring the existing pattern from `BibleReader`, and threads it through to the internal `BibleTextView`. When provided, the callback replaces the built-in popover with a consumer-controlled handler receiving `FootnoteData` (verseNum, notes, verseHtml, reference).

- **`bible-card.tsx`**: Adds `onFootnotePress?: (data: FootnoteData) => void` to `BibleCardProps`, destructures it in `BibleCard`, and forwards it to `BibleTextView`.
- **`bible-card.test.tsx`**: New describe block renders a passage with a raw footnote span, waits for the footnote button, clicks it, and asserts the full `FootnoteData` payload including `verseNum`, `reference`, and the `notes` array content.
- **`.changeset/bible-card-footnote-press.md`**: Changeset correctly marked as `minor` for the new optional public API addition.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive and opt-in, with no modifications to existing behavior.

The new prop is optional and strictly additive: existing consumers who do not pass `onFootnotePress` continue to get the built-in Popover unchanged. The prop is already exported via `FootnoteData` in the package's public index, the test exercises the full click-to-callback path with payload assertions, and the changeset is correctly labeled `minor`.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/bible-card.tsx | Adds optional `onFootnotePress` prop to `BibleCardProps` and forwards it to `BibleTextView`; change is minimal and follows the existing `BibleReader` pattern exactly. |
| packages/ui/src/components/bible-card.test.tsx | New test suite correctly uses `waitFor` + `userEvent` to verify the footnote button click calls `onFootnotePress` with the full `FootnoteData` payload including `notes` content. |
| .changeset/bible-card-footnote-press.md | Changeset correctly uses `minor` bump for the new optional public API prop. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Consumer
    participant BibleCard
    participant BibleTextView
    participant VerseHtml as Verse.Html
    participant BibleTextHtml
    participant VerseFootnoteButton

    Consumer->>BibleCard: render with onFootnotePress
    BibleCard->>BibleTextView: passageState + onFootnotePress
    BibleTextView->>VerseHtml: html + onFootnotePress
    VerseHtml->>BibleTextHtml: transformedHtml + onFootnotePress
    BibleTextHtml->>BibleTextHtml: useLayoutEffect extracts footnote anchors
    BibleTextHtml->>VerseFootnoteButton: portal per anchor with onFootnotePress
    Note over VerseFootnoteButton: onFootnotePress present → plain button (no Popover)
    Consumer->>VerseFootnoteButton: click footnote button
    VerseFootnoteButton->>Consumer: "onFootnotePress({ verseNum, notes, verseHtml, reference })"
```

<sub>Reviews (3): Last reviewed commit: ["fix(ui): address greptile review feedbac..."](https://github.com/youversion/platform-sdk-react/commit/63ec2620ed50290de4894d23457fe9f27625e60a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33304694)</sub>

<!-- /greptile_comment -->