### PR TITLE
feat(auth)!: stop persisting ID token; persist decoded profile instead

### DIFF
--- a/.changeset/id-token-not-persisted.md
+++ b/.changeset/id-token-not-persisted.md
@@ -4,17 +4,34 @@
 "@youversion/platform-react-ui": major
 ---
 
-Stop persisting the ID token. The ID token is now decoded once at sign-in to
-derive the user profile and then discarded — only the decoded profile is
-persisted (validated with Zod on read), so it survives reloads without keeping
-the signed token in `localStorage`. The stored profile is cleared on sign-out
-and when a session expires and cannot be refreshed.
+Stop persisting the ID token and harden the auth flow against stale/exposed state.
+
+The ID token is now decoded once at sign-in to derive the user profile and then
+discarded — only the decoded profile is persisted (validated with Zod on read),
+so it survives reloads without keeping the signed token in `localStorage`. The
+stored profile is cleared on sign-out and when a session expires and cannot be
+refreshed.
+
+Additional hardening:
+
+- The raw ID token is no longer attached to the sign-in result. It is decoded
+  transiently at sign-in to derive the profile and then discarded, so callback
+  consumers can no longer read it from memory.
+- `YouVersionAPIUsers.getStoredUserInfo()` now returns `null` when the persisted
+  profile has no `id`, so a tampered or empty stored profile cannot present as a
+  signed-in user with an empty profile.
+- `YouVersionAPIUsers.handleAuthCallback()` now clears persisted tokens and the
+  stored profile if an error is thrown after they were written, so a failed
+  callback cannot leave the user looking authenticated.
 
 **Breaking changes:**
 
 - `AuthenticationState.idToken` has been removed. Components that read
   `auth.idToken` from `useYVAuth()` should no longer rely on it; use `userInfo`
   for profile data.
+- `SignInWithYouVersionResult.idToken` has been removed. The result returned by
+  `handleAuthCallback()` (and `processCallback()` in `useYVAuth`) no longer
+  exposes the ID token; use `userInfo`/`yvpUserId` for profile data.
 - `YouVersionPlatformConfiguration.saveAuthData(accessToken, refreshToken, expiryDate)`
   no longer accepts an `idToken` argument.
 - `YouVersionPlatformConfiguration.idToken` getter has been removed. The decoded

--- a/.changeset/id-token-not-persisted.md
+++ b/.changeset/id-token-not-persisted.md
@@ -1,0 +1,23 @@
+---
+"@youversion/platform-core": major
+"@youversion/platform-react-hooks": major
+"@youversion/platform-react-ui": major
+---
+
+Stop persisting the ID token. The ID token is now decoded once at sign-in to
+derive the user profile and then discarded — only the decoded profile is
+persisted (validated with Zod on read), so it survives reloads without keeping
+the signed token in `localStorage`. The stored profile is cleared on sign-out
+and when a session expires and cannot be refreshed.
+
+**Breaking changes:**
+
+- `AuthenticationState.idToken` has been removed. Components that read
+  `auth.idToken` from `useYVAuth()` should no longer rely on it; use `userInfo`
+  for profile data.
+- `YouVersionPlatformConfiguration.saveAuthData(accessToken, refreshToken, expiryDate)`
+  no longer accepts an `idToken` argument.
+- `YouVersionPlatformConfiguration.idToken` getter has been removed. The decoded
+  profile is available via `YouVersionPlatformConfiguration.storedUserInfo` (or
+  `YouVersionAPIUsers.getStoredUserInfo()`).
+- `YouVersionAPIUsers.refreshTokens()` no longer requires a stored ID token.

--- a/packages/core/src/SignInWithYouVersionResult.ts
+++ b/packages/core/src/SignInWithYouVersionResult.ts
@@ -10,7 +10,6 @@ type SignInWithYouVersionResultProps = {
   accessToken?: string;
   expiresIn?: number;
   refreshToken?: string;
-  idToken?: string;
   yvpUserId?: string;
   name?: string;
   profilePicture?: string;
@@ -20,7 +19,6 @@ export class SignInWithYouVersionResult {
   public readonly accessToken: string | undefined;
   public readonly expiryDate: Date | undefined;
   public readonly refreshToken: string | undefined;
-  public readonly idToken: string | undefined;
   public readonly yvpUserId: string | undefined;
   public readonly name: string | undefined;
   public readonly profilePicture: string | undefined;
@@ -30,7 +28,6 @@ export class SignInWithYouVersionResult {
     accessToken,
     expiresIn,
     refreshToken,
-    idToken,
     yvpUserId,
     name,
     profilePicture,
@@ -39,7 +36,6 @@ export class SignInWithYouVersionResult {
     this.accessToken = accessToken;
     this.expiryDate = expiresIn ? new Date(Date.now() + expiresIn * 1000) : new Date();
     this.refreshToken = refreshToken;
-    this.idToken = idToken;
     this.yvpUserId = yvpUserId;
     this.name = name;
     this.profilePicture = profilePicture;

--- a/packages/core/src/Users.ts
+++ b/packages/core/src/Users.ts
@@ -117,13 +117,22 @@ export class YouVersionAPIUsers {
       // Extract user info from ID token
       const result = this.extractSignInResult(tokens);
 
-      // Store tokens in configuration
+      // Store tokens in configuration. The ID token is intentionally not
+      // persisted — it is only used here to derive the user profile below.
       YouVersionPlatformConfiguration.saveAuthData(
         result.accessToken || null,
         result.refreshToken || null,
-        result.idToken || null,
         result.expiryDate || null,
       );
+
+      // Persist the decoded user profile so it survives reloads without
+      // retaining the ID token itself.
+      YouVersionPlatformConfiguration.saveUserInfo({
+        id: result.yvpUserId,
+        name: result.name,
+        email: result.email,
+        avatar_url: result.profilePicture,
+      });
 
       // Clean up localStorage
       localStorage.removeItem('youversion-auth-code-verifier');
@@ -284,6 +293,18 @@ export class YouVersionAPIUsers {
   }
 
   /**
+   * Returns the user profile that was persisted at sign-in, or `null` if the
+   * user is not signed in (or the stored profile is missing/invalid).
+   *
+   * This reads the decoded profile from storage rather than re-decoding the ID
+   * token, which is never persisted.
+   */
+  static getStoredUserInfo(): YouVersionUserInfo | null {
+    const stored = YouVersionPlatformConfiguration.storedUserInfo;
+    return stored ? new YouVersionUserInfo(stored) : null;
+  }
+
+  /**
    * Refreshes the access token using the stored refresh token.
    *
    * @returns Promise<SignInWithYouVersionResult | null> - New tokens if refresh succeeds, null otherwise
@@ -292,10 +313,9 @@ export class YouVersionAPIUsers {
   static async refreshTokens(): Promise<SignInWithYouVersionResult | null> {
     const refreshToken = YouVersionPlatformConfiguration.refreshToken;
     const appKey = YouVersionPlatformConfiguration.appKey;
-    const existingIdToken = YouVersionPlatformConfiguration.idToken;
 
-    if (!refreshToken || !existingIdToken) {
-      throw new Error('No refresh token or id token available');
+    if (!refreshToken) {
+      throw new Error('No refresh token available');
     }
 
     if (!appKey) {
@@ -335,19 +355,18 @@ export class YouVersionAPIUsers {
         token_type: string;
       };
 
-      // Create result with new tokens but preserve user info
+      // Create result with new tokens. The persisted user profile is left
+      // untouched — refreshing only rotates the access/refresh tokens.
       const result = new SignInWithYouVersionResult({
         accessToken: tokens.access_token,
         expiresIn: tokens.expires_in,
         refreshToken: tokens.refresh_token,
-        idToken: existingIdToken,
       });
 
       // Store updated tokens
       YouVersionPlatformConfiguration.saveAuthData(
         result.accessToken || null,
         result.refreshToken || null,
-        result.idToken || null,
         result.expiryDate || null,
       );
 

--- a/packages/core/src/Users.ts
+++ b/packages/core/src/Users.ts
@@ -146,7 +146,7 @@ export class YouVersionAPIUsers {
 
       return result;
     } catch (error) {
-      // Clean up on error
+      YouVersionPlatformConfiguration.clearAuthTokens();
       localStorage.removeItem('youversion-auth-code-verifier');
       localStorage.removeItem('youversion-auth-redirect-uri');
       localStorage.removeItem('youversion-auth-state');
@@ -193,7 +193,6 @@ export class YouVersionAPIUsers {
       accessToken: tokens.access_token,
       expiresIn: tokens.expires_in,
       refreshToken: tokens.refresh_token,
-      idToken: tokens.id_token,
       yvpUserId: idClaims.sub as string,
       name: idClaims.name as string,
       profilePicture: idClaims.profile_picture as string,
@@ -301,7 +300,10 @@ export class YouVersionAPIUsers {
    */
   static getStoredUserInfo(): YouVersionUserInfo | null {
     const stored = YouVersionPlatformConfiguration.storedUserInfo;
-    return stored ? new YouVersionUserInfo(stored) : null;
+    if (!stored?.id) {
+      return null;
+    }
+    return new YouVersionUserInfo(stored);
   }
 
   /**

--- a/packages/core/src/YouVersionPlatformConfiguration.ts
+++ b/packages/core/src/YouVersionPlatformConfiguration.ts
@@ -1,5 +1,9 @@
+import { YouVersionUserInfoJSONSchema, type YouVersionUserInfoJSON } from './schemas/user-info';
+
 /**
- * Security Note: Tokens are stored in localStorage for persistence.
+ * Security Note: Tokens and the decoded user profile are stored in localStorage
+ * for persistence. The ID token itself is never persisted — it is decoded once at
+ * sign-in to derive the user profile and then discarded.
  * Ensure your application follows XSS prevention best practices:
  * - Sanitize user input
  * - Use Content Security Policy headers
@@ -33,7 +37,6 @@ export class YouVersionPlatformConfiguration {
   public static saveAuthData(
     accessToken: string | null,
     refreshToken: string | null,
-    idToken: string | null,
     expiryDate: Date | null,
   ): void {
     if (accessToken !== null) {
@@ -48,12 +51,6 @@ export class YouVersionPlatformConfiguration {
       localStorage.removeItem('refreshToken');
     }
 
-    if (idToken !== null) {
-      localStorage.setItem('idToken', idToken);
-    } else {
-      localStorage.removeItem('idToken');
-    }
-
     if (expiryDate !== null) {
       localStorage.setItem('expiryDate', expiryDate.toISOString());
     } else {
@@ -61,8 +58,21 @@ export class YouVersionPlatformConfiguration {
     }
   }
 
+  /**
+   * Persists the decoded user profile derived from the ID token at sign-in.
+   * Pass `null` to remove any stored profile.
+   */
+  public static saveUserInfo(userInfo: YouVersionUserInfoJSON | null): void {
+    if (userInfo !== null) {
+      localStorage.setItem('userInfo', JSON.stringify(userInfo));
+    } else {
+      localStorage.removeItem('userInfo');
+    }
+  }
+
   public static clearAuthTokens(): void {
-    this.saveAuthData(null, null, null, null);
+    this.saveAuthData(null, null, null);
+    this.saveUserInfo(null);
   }
 
   public static get accessToken(): string | null {
@@ -73,8 +83,23 @@ export class YouVersionPlatformConfiguration {
     return localStorage.getItem('refreshToken');
   }
 
-  public static get idToken(): string | null {
-    return localStorage.getItem('idToken');
+  /**
+   * Returns the persisted user profile, validated against the expected schema.
+   * Returns `null` when nothing is stored or the stored value is malformed.
+   */
+  public static get storedUserInfo(): YouVersionUserInfoJSON | null {
+    const raw = localStorage.getItem('userInfo');
+    if (!raw) {
+      return null;
+    }
+
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      const result = YouVersionUserInfoJSONSchema.safeParse(parsed);
+      return result.success ? result.data : null;
+    } catch {
+      return null;
+    }
   }
 
   public static get tokenExpiryDate(): Date | null {

--- a/packages/core/src/YouVersionUserInfo.ts
+++ b/packages/core/src/YouVersionUserInfo.ts
@@ -1,9 +1,6 @@
-export interface YouVersionUserInfoJSON {
-  name?: string;
-  id?: string;
-  avatar_url?: string;
-  email?: string;
-}
+import type { YouVersionUserInfoJSON } from './schemas/user-info';
+
+export type { YouVersionUserInfoJSON };
 
 export class YouVersionUserInfo {
   readonly name?: string;

--- a/packages/core/src/__tests__/Users.test.ts
+++ b/packages/core/src/__tests__/Users.test.ts
@@ -192,8 +192,9 @@ describe('YouVersionAPIUsers', () => {
         }),
       );
 
-      // Mock YouVersionPlatformConfiguration.saveAuthData
+      // Mock YouVersionPlatformConfiguration persistence
       const saveAuthDataSpy = vi.spyOn(YouVersionPlatformConfiguration, 'saveAuthData');
+      const saveUserInfoSpy = vi.spyOn(YouVersionPlatformConfiguration, 'saveUserInfo');
 
       const result = await YouVersionAPIUsers.handleAuthCallback();
 
@@ -204,8 +205,22 @@ describe('YouVersionAPIUsers', () => {
       expect(result?.name).toBe('John Doe');
       expect(result?.email).toBe('john@example.com');
 
-      // Verify saveAuthData was called
-      expect(saveAuthDataSpy).toHaveBeenCalled();
+      // Verify saveAuthData was called with tokens only (no id token persisted)
+      expect(saveAuthDataSpy).toHaveBeenCalledWith(
+        'access-token-123',
+        'refresh-token-456',
+        expect.any(Date),
+      );
+
+      // Verify the decoded profile was persisted instead of the id token
+      expect(saveUserInfoSpy).toHaveBeenCalledWith({
+        id: '1234567890',
+        name: 'John Doe',
+        email: 'john@example.com',
+        avatar_url: 'https://example.com/avatar.jpg',
+      });
+
+      saveUserInfoSpy.mockRestore();
 
       // Verify cleanup
       expect(mocks.localStorage.removeItem).toHaveBeenCalledWith('youversion-auth-code-verifier');
@@ -463,24 +478,11 @@ describe('YouVersionAPIUsers', () => {
     it('should throw error when no refresh token available', async () => {
       mocks.localStorage.getItem.mockImplementation((key: string) => {
         if (key === 'refreshToken') return null;
-        if (key === 'idToken') return 'id-token-123';
         return null;
       });
 
       await expect(YouVersionAPIUsers.refreshTokens()).rejects.toThrow(
-        'No refresh token or id token available',
-      );
-    });
-
-    it('should throw error when no id token available', async () => {
-      mocks.localStorage.getItem.mockImplementation((key: string) => {
-        if (key === 'refreshToken') return 'refresh-token-123';
-        if (key === 'idToken') return null;
-        return null;
-      });
-
-      await expect(YouVersionAPIUsers.refreshTokens()).rejects.toThrow(
-        'No refresh token or id token available',
+        'No refresh token available',
       );
     });
 
@@ -489,7 +491,6 @@ describe('YouVersionAPIUsers', () => {
 
       mocks.localStorage.getItem.mockImplementation((key: string) => {
         if (key === 'refreshToken') return 'refresh-token-123';
-        if (key === 'idToken') return 'id-token-123';
         return null;
       });
 
@@ -498,10 +499,9 @@ describe('YouVersionAPIUsers', () => {
       );
     });
 
-    it('should successfully refresh tokens and preserve existing id_token', async () => {
+    it('should successfully rotate the access and refresh tokens', async () => {
       const originalAccessToken = 'old-access-token';
       const originalRefreshToken = 'old-refresh-token';
-      const existingIdToken = 'existing-id-token';
 
       const mockRefreshResponse = {
         access_token: 'new-access-token',
@@ -520,7 +520,6 @@ describe('YouVersionAPIUsers', () => {
 
       mocks.localStorage.getItem.mockImplementation((key: string) => {
         if (key === 'refreshToken') return originalRefreshToken;
-        if (key === 'idToken') return existingIdToken;
         if (key === 'accessToken') return originalAccessToken;
         return null;
       });
@@ -528,6 +527,7 @@ describe('YouVersionAPIUsers', () => {
       mockFetch.mockResolvedValue(mockResponse);
 
       const saveAuthDataSpy = vi.spyOn(YouVersionPlatformConfiguration, 'saveAuthData');
+      const saveUserInfoSpy = vi.spyOn(YouVersionPlatformConfiguration, 'saveUserInfo');
 
       const result = await YouVersionAPIUsers.refreshTokens();
 
@@ -539,8 +539,8 @@ describe('YouVersionAPIUsers', () => {
       expect(result?.refreshToken).toBe('new-refresh-token');
       expect(result?.refreshToken).not.toBe(originalRefreshToken);
 
-      // Assert that id_token is preserved (same as original)
-      expect(result?.idToken).toBe(existingIdToken);
+      // The id token is never carried through a refresh
+      expect(result?.idToken).toBeUndefined();
 
       // Verify the refresh token request was made correctly
       expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -560,15 +560,18 @@ describe('YouVersionAPIUsers', () => {
       const body = new URLSearchParams(bodyText);
       expect(body.get('grant_type')).toBe('refresh_token');
 
-      // Verify saveAuthData was called with new tokens but existing id_token
+      // Verify saveAuthData was called with the rotated tokens only
       expect(saveAuthDataSpy).toHaveBeenCalledWith(
         'new-access-token',
         'new-refresh-token',
-        existingIdToken,
         expect.any(Date),
       );
 
+      // The stored profile is left untouched by a refresh
+      expect(saveUserInfoSpy).not.toHaveBeenCalled();
+
       saveAuthDataSpy.mockRestore();
+      saveUserInfoSpy.mockRestore();
     });
 
     it('should handle refresh token request failure', async () => {

--- a/packages/core/src/__tests__/Users.test.ts
+++ b/packages/core/src/__tests__/Users.test.ts
@@ -539,9 +539,6 @@ describe('YouVersionAPIUsers', () => {
       expect(result?.refreshToken).toBe('new-refresh-token');
       expect(result?.refreshToken).not.toBe(originalRefreshToken);
 
-      // The id token is never carried through a refresh
-      expect(result?.idToken).toBeUndefined();
-
       // Verify the refresh token request was made correctly
       expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockFetch).toHaveBeenCalledWith(

--- a/packages/core/src/__tests__/YouVersionPlatformConfiguration.test.ts
+++ b/packages/core/src/__tests__/YouVersionPlatformConfiguration.test.ts
@@ -47,7 +47,7 @@ describe('YouVersionPlatformConfiguration', () => {
     // Reset all static properties
     YouVersionPlatformConfiguration.appKey = null;
     YouVersionPlatformConfiguration.installationId = null;
-    YouVersionPlatformConfiguration.saveAuthData(null, null, null, null);
+    YouVersionPlatformConfiguration.clearAuthTokens();
     YouVersionPlatformConfiguration.apiHost = envApiHost;
   });
 
@@ -115,10 +115,10 @@ describe('YouVersionPlatformConfiguration', () => {
       expect(YouVersionPlatformConfiguration.accessToken).toBeNull();
 
       const token = 'test-access-token';
-      YouVersionPlatformConfiguration.saveAuthData(token, null, null, null);
+      YouVersionPlatformConfiguration.saveAuthData(token, null, null);
       expect(YouVersionPlatformConfiguration.accessToken).toBe(token);
 
-      YouVersionPlatformConfiguration.saveAuthData(null, null, null, null);
+      YouVersionPlatformConfiguration.saveAuthData(null, null, null);
       expect(YouVersionPlatformConfiguration.accessToken).toBeNull();
     });
 
@@ -126,10 +126,10 @@ describe('YouVersionPlatformConfiguration', () => {
       expect(YouVersionPlatformConfiguration.refreshToken).toBeNull();
 
       const refreshToken = 'test-refresh-token';
-      YouVersionPlatformConfiguration.saveAuthData(null, refreshToken, null, null);
+      YouVersionPlatformConfiguration.saveAuthData(null, refreshToken, null);
       expect(YouVersionPlatformConfiguration.refreshToken).toBe(refreshToken);
 
-      YouVersionPlatformConfiguration.saveAuthData(null, null, null, null);
+      YouVersionPlatformConfiguration.saveAuthData(null, null, null);
       expect(YouVersionPlatformConfiguration.refreshToken).toBeNull();
     });
 
@@ -137,53 +137,46 @@ describe('YouVersionPlatformConfiguration', () => {
       expect(YouVersionPlatformConfiguration.tokenExpiryDate).toBeNull();
 
       const expiryDate = new Date('2024-12-31T23:59:59Z');
-      YouVersionPlatformConfiguration.saveAuthData(null, null, null, expiryDate);
+      YouVersionPlatformConfiguration.saveAuthData(null, null, expiryDate);
       expect(YouVersionPlatformConfiguration.tokenExpiryDate).toEqual(expiryDate);
 
-      YouVersionPlatformConfiguration.saveAuthData(null, null, null, null);
+      YouVersionPlatformConfiguration.saveAuthData(null, null, null);
       expect(YouVersionPlatformConfiguration.tokenExpiryDate).toBeNull();
     });
 
-    it('should save all auth data together', () => {
+    it('should never persist the id token', () => {
       const accessToken = 'test-access-token';
       const refreshToken = 'test-refresh-token';
-      const idToken = 'test-id-token';
       const expiryDate = new Date('2024-12-31T23:59:59Z');
 
-      YouVersionPlatformConfiguration.saveAuthData(accessToken, refreshToken, idToken, expiryDate);
+      YouVersionPlatformConfiguration.saveAuthData(accessToken, refreshToken, expiryDate);
 
       expect(YouVersionPlatformConfiguration.accessToken).toBe(accessToken);
       expect(YouVersionPlatformConfiguration.refreshToken).toBe(refreshToken);
-      expect(YouVersionPlatformConfiguration.idToken).toBe(idToken);
       expect(YouVersionPlatformConfiguration.tokenExpiryDate).toEqual(expiryDate);
+      expect(mockSetItem).not.toHaveBeenCalledWith('idToken', expect.anything());
+      expect(mockStorage.idToken).toBeUndefined();
     });
 
     it('should handle partial updates without affecting other tokens', () => {
       // Set up initial state
       const initialAccess = 'initial-access';
       const initialRefresh = 'initial-refresh';
-      const initialIdToken = 'initial-id-token';
       const initialExpiry = new Date('2024-01-01T00:00:00Z');
-      YouVersionPlatformConfiguration.saveAuthData(
-        initialAccess,
-        initialRefresh,
-        initialIdToken,
-        initialExpiry,
-      );
+      YouVersionPlatformConfiguration.saveAuthData(initialAccess, initialRefresh, initialExpiry);
 
       // Update only access token
       const newAccess = 'new-access-token';
-      YouVersionPlatformConfiguration.saveAuthData(newAccess, null, null, null);
+      YouVersionPlatformConfiguration.saveAuthData(newAccess, null, null);
 
       expect(YouVersionPlatformConfiguration.accessToken).toBe(newAccess);
       expect(YouVersionPlatformConfiguration.refreshToken).toBeNull();
-      expect(YouVersionPlatformConfiguration.idToken).toBeNull();
       expect(YouVersionPlatformConfiguration.tokenExpiryDate).toBeNull();
     });
 
     it('should properly serialize and deserialize dates', () => {
       const originalDate = new Date('2024-06-15T14:30:45.123Z');
-      YouVersionPlatformConfiguration.saveAuthData(null, null, null, originalDate);
+      YouVersionPlatformConfiguration.saveAuthData(null, null, originalDate);
 
       const retrievedDate = YouVersionPlatformConfiguration.tokenExpiryDate;
       expect(retrievedDate).toEqual(originalDate);
@@ -193,62 +186,95 @@ describe('YouVersionPlatformConfiguration', () => {
     it('should call localStorage methods correctly', () => {
       const accessToken = 'test-access';
       const refreshToken = 'test-refresh';
-      const idToken = 'test-id';
       const expiryDate = new Date('2024-12-31T23:59:59Z');
 
-      YouVersionPlatformConfiguration.saveAuthData(accessToken, refreshToken, idToken, expiryDate);
+      YouVersionPlatformConfiguration.saveAuthData(accessToken, refreshToken, expiryDate);
 
       expect(mockSetItem).toHaveBeenCalledWith('accessToken', accessToken);
       expect(mockSetItem).toHaveBeenCalledWith('refreshToken', refreshToken);
-      expect(mockSetItem).toHaveBeenCalledWith('idToken', idToken);
       expect(mockSetItem).toHaveBeenCalledWith('expiryDate', expiryDate.toISOString());
     });
 
     it('should call removeItem when tokens are null', () => {
       // First set some values
-      YouVersionPlatformConfiguration.saveAuthData('access', 'refresh', 'id-token', new Date());
+      YouVersionPlatformConfiguration.saveAuthData('access', 'refresh', new Date());
 
       // Clear the mock calls
       mockRemoveItem.mockClear();
 
       // Now set to null
-      YouVersionPlatformConfiguration.saveAuthData(null, null, null, null);
+      YouVersionPlatformConfiguration.saveAuthData(null, null, null);
 
       expect(mockRemoveItem).toHaveBeenCalledWith('accessToken');
       expect(mockRemoveItem).toHaveBeenCalledWith('refreshToken');
-      expect(mockRemoveItem).toHaveBeenCalledWith('idToken');
       expect(mockRemoveItem).toHaveBeenCalledWith('expiryDate');
     });
   });
 
+  describe('user info persistence', () => {
+    it('should save and retrieve the decoded user profile', () => {
+      expect(YouVersionPlatformConfiguration.storedUserInfo).toBeNull();
+
+      const userInfo = {
+        id: 'user-123',
+        name: 'John Doe',
+        email: 'john@example.com',
+        avatar_url: 'https://example.com/avatar.jpg',
+      };
+      YouVersionPlatformConfiguration.saveUserInfo(userInfo);
+
+      expect(mockSetItem).toHaveBeenCalledWith('userInfo', JSON.stringify(userInfo));
+      expect(YouVersionPlatformConfiguration.storedUserInfo).toEqual(userInfo);
+    });
+
+    it('should remove the stored profile when passed null', () => {
+      YouVersionPlatformConfiguration.saveUserInfo({ id: 'user-123', name: 'John Doe' });
+      YouVersionPlatformConfiguration.saveUserInfo(null);
+
+      expect(mockRemoveItem).toHaveBeenCalledWith('userInfo');
+      expect(YouVersionPlatformConfiguration.storedUserInfo).toBeNull();
+    });
+
+    it('should return null when the stored profile is malformed JSON', () => {
+      mockStorage.userInfo = 'not-json{';
+      expect(YouVersionPlatformConfiguration.storedUserInfo).toBeNull();
+    });
+
+    it('should return null when the stored profile fails schema validation', () => {
+      mockStorage.userInfo = JSON.stringify({ id: 42 });
+      expect(YouVersionPlatformConfiguration.storedUserInfo).toBeNull();
+    });
+  });
+
   describe('clearAuthTokens', () => {
-    it('should clear all auth tokens', () => {
+    it('should clear all auth tokens and the stored profile', () => {
       // Set up initial auth data
       const accessToken = 'test-access-token';
       const refreshToken = 'test-refresh-token';
-      const idToken = 'test-id-token';
       const expiryDate = new Date('2024-12-31T23:59:59Z');
-      YouVersionPlatformConfiguration.saveAuthData(accessToken, refreshToken, idToken, expiryDate);
+      YouVersionPlatformConfiguration.saveAuthData(accessToken, refreshToken, expiryDate);
+      YouVersionPlatformConfiguration.saveUserInfo({ id: 'user-123', name: 'John Doe' });
 
       // Verify data is set
       expect(YouVersionPlatformConfiguration.accessToken).toBe(accessToken);
       expect(YouVersionPlatformConfiguration.refreshToken).toBe(refreshToken);
-      expect(YouVersionPlatformConfiguration.idToken).toBe(idToken);
       expect(YouVersionPlatformConfiguration.tokenExpiryDate).toEqual(expiryDate);
+      expect(YouVersionPlatformConfiguration.storedUserInfo).not.toBeNull();
 
       // Clear all tokens
       YouVersionPlatformConfiguration.clearAuthTokens();
 
-      // Verify all tokens are null
+      // Verify all tokens and the profile are null
       expect(YouVersionPlatformConfiguration.accessToken).toBeNull();
       expect(YouVersionPlatformConfiguration.refreshToken).toBeNull();
-      expect(YouVersionPlatformConfiguration.idToken).toBeNull();
       expect(YouVersionPlatformConfiguration.tokenExpiryDate).toBeNull();
+      expect(YouVersionPlatformConfiguration.storedUserInfo).toBeNull();
     });
 
-    it('should call removeItem for all token types', () => {
+    it('should call removeItem for all token types and the profile', () => {
       // Set up some auth data first
-      YouVersionPlatformConfiguration.saveAuthData('access', 'refresh', 'id-token', new Date());
+      YouVersionPlatformConfiguration.saveAuthData('access', 'refresh', new Date());
+      YouVersionPlatformConfiguration.saveUserInfo({ id: 'user-123' });
 
       // Clear mock calls
       mockRemoveItem.mockClear();
@@ -256,18 +282,18 @@ describe('YouVersionPlatformConfiguration', () => {
       // Clear auth tokens
       YouVersionPlatformConfiguration.clearAuthTokens();
 
-      // Verify removeItem was called for each token type
+      // Verify removeItem was called for each token type and the profile
       expect(mockRemoveItem).toHaveBeenCalledWith('accessToken');
       expect(mockRemoveItem).toHaveBeenCalledWith('refreshToken');
-      expect(mockRemoveItem).toHaveBeenCalledWith('idToken');
       expect(mockRemoveItem).toHaveBeenCalledWith('expiryDate');
+      expect(mockRemoveItem).toHaveBeenCalledWith('userInfo');
     });
 
     it('should work when no tokens are previously set', () => {
       // Ensure clean state
       expect(YouVersionPlatformConfiguration.accessToken).toBeNull();
       expect(YouVersionPlatformConfiguration.refreshToken).toBeNull();
-      expect(YouVersionPlatformConfiguration.idToken).toBeNull();
+      expect(YouVersionPlatformConfiguration.storedUserInfo).toBeNull();
       expect(YouVersionPlatformConfiguration.tokenExpiryDate).toBeNull();
 
       // Should not throw when clearing empty state
@@ -278,7 +304,7 @@ describe('YouVersionPlatformConfiguration', () => {
       // State should remain null
       expect(YouVersionPlatformConfiguration.accessToken).toBeNull();
       expect(YouVersionPlatformConfiguration.refreshToken).toBeNull();
-      expect(YouVersionPlatformConfiguration.idToken).toBeNull();
+      expect(YouVersionPlatformConfiguration.storedUserInfo).toBeNull();
       expect(YouVersionPlatformConfiguration.tokenExpiryDate).toBeNull();
     });
   });

--- a/packages/core/src/__tests__/highlights.test.ts
+++ b/packages/core/src/__tests__/highlights.test.ts
@@ -15,12 +15,12 @@ describe.skip('HighlightsClient', () => {
     });
     highlightsClient = new HighlightsClient(apiClient);
     // Set a default token for tests that don't explicitly pass one
-    YouVersionPlatformConfiguration.saveAuthData('test-token', null, null, null);
+    YouVersionPlatformConfiguration.saveAuthData('test-token', null, null);
   });
 
   afterEach(() => {
     // Clean up token after each test
-    YouVersionPlatformConfiguration.saveAuthData(null, null, null, null);
+    YouVersionPlatformConfiguration.saveAuthData(null, null, null);
     vi.clearAllMocks(); // Reset all mocked calls between tests
   });
 
@@ -96,7 +96,7 @@ describe.skip('HighlightsClient', () => {
     });
 
     it('should include lat parameter when token auto-retrieved from config', async () => {
-      YouVersionPlatformConfiguration.saveAuthData('config-token', null, null, null);
+      YouVersionPlatformConfiguration.saveAuthData('config-token', null, null);
       const fetchSpy = vi.spyOn(global, 'fetch');
 
       const highlights = await highlightsClient.getHighlights({ version_id: 1 });
@@ -112,7 +112,7 @@ describe.skip('HighlightsClient', () => {
     });
 
     it('should throw an error when no token is available', async () => {
-      YouVersionPlatformConfiguration.saveAuthData(null, null, null, null);
+      YouVersionPlatformConfiguration.saveAuthData(null, null, null);
 
       await expect(highlightsClient.getHighlights({ version_id: 1 })).rejects.toThrow(
         'Authentication required. Please provide a token or sign in before accessing highlights.',
@@ -120,7 +120,7 @@ describe.skip('HighlightsClient', () => {
     });
 
     it('should use explicit token over config token', async () => {
-      YouVersionPlatformConfiguration.saveAuthData('config-token', null, null, null);
+      YouVersionPlatformConfiguration.saveAuthData('config-token', null, null);
       const fetchSpy = vi.spyOn(global, 'fetch');
       const highlights = await highlightsClient.getHighlights({ version_id: 1 }, 'explicit-token');
 
@@ -269,7 +269,7 @@ describe.skip('HighlightsClient', () => {
     });
 
     it('should include lat parameter when token auto-retrieved from config', async () => {
-      YouVersionPlatformConfiguration.saveAuthData('config-token', null, null, null);
+      YouVersionPlatformConfiguration.saveAuthData('config-token', null, null);
       const fetchSpy = vi.spyOn(global, 'fetch');
       const highlight = await highlightsClient.createHighlight({
         version_id: 111,
@@ -291,7 +291,7 @@ describe.skip('HighlightsClient', () => {
     });
 
     it('should throw an error when no token is available', async () => {
-      YouVersionPlatformConfiguration.saveAuthData(null, null, null, null);
+      YouVersionPlatformConfiguration.saveAuthData(null, null, null);
 
       await expect(
         highlightsClient.createHighlight({
@@ -305,7 +305,7 @@ describe.skip('HighlightsClient', () => {
     });
 
     it('should use explicit token over config token', async () => {
-      YouVersionPlatformConfiguration.saveAuthData('config-token', null, null, null);
+      YouVersionPlatformConfiguration.saveAuthData('config-token', null, null);
       const fetchSpy = vi.spyOn(global, 'fetch');
       const highlight = await highlightsClient.createHighlight(
         {
@@ -432,7 +432,7 @@ describe.skip('HighlightsClient', () => {
     });
 
     it('should include lat parameter when token auto-retrieved from config', async () => {
-      YouVersionPlatformConfiguration.saveAuthData('config-token', null, null, null);
+      YouVersionPlatformConfiguration.saveAuthData('config-token', null, null);
       let capturedStatus: number | undefined;
       const originalFetch = global.fetch;
       const fetchSpy = vi.spyOn(global, 'fetch').mockImplementation(async (...args) => {
@@ -453,7 +453,7 @@ describe.skip('HighlightsClient', () => {
     });
 
     it('should throw an error when no token is available', async () => {
-      YouVersionPlatformConfiguration.saveAuthData(null, null, null, null);
+      YouVersionPlatformConfiguration.saveAuthData(null, null, null);
 
       await expect(highlightsClient.deleteHighlight('MAT.1.1')).rejects.toThrow(
         'Authentication required. Please provide a token or sign in before accessing highlights.',
@@ -461,7 +461,7 @@ describe.skip('HighlightsClient', () => {
     });
 
     it('should use explicit token over config token', async () => {
-      YouVersionPlatformConfiguration.saveAuthData('config-token', null, null, null);
+      YouVersionPlatformConfiguration.saveAuthData('config-token', null, null);
       let capturedStatus: number | undefined;
       const originalFetch = global.fetch;
       const fetchSpy = vi.spyOn(global, 'fetch').mockImplementation(async (...args) => {

--- a/packages/core/src/schemas/index.ts
+++ b/packages/core/src/schemas/index.ts
@@ -14,3 +14,4 @@ export * from './verse';
 export * from './video';
 export * from './votd';
 export * from './user';
+export * from './user-info';

--- a/packages/core/src/schemas/user-info.ts
+++ b/packages/core/src/schemas/user-info.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+/**
+ * Shape of the decoded user profile that is persisted at sign-in.
+ *
+ * The ID token is decoded once to produce this profile and then discarded — the
+ * token itself is never persisted. This schema validates the profile when it is
+ * rehydrated from storage so a tampered or malformed entry is rejected rather
+ * than trusted blindly.
+ */
+export const YouVersionUserInfoJSONSchema = z.object({
+  name: z.string().optional(),
+  id: z.string().optional(),
+  avatar_url: z.string().optional(),
+  email: z.string().optional(),
+});
+
+export type YouVersionUserInfoJSON = z.infer<typeof YouVersionUserInfoJSONSchema>;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -49,7 +49,6 @@ export interface AuthenticationState {
   readonly isAuthenticated: boolean;
   readonly isLoading: boolean;
   readonly accessToken: string | null;
-  readonly idToken: string | null;
   readonly result: SignInWithYouVersionResult | null;
   readonly error: Error | null;
 }

--- a/packages/hooks/src/__tests__/mocks/auth.ts
+++ b/packages/hooks/src/__tests__/mocks/auth.ts
@@ -37,7 +37,6 @@ export const createMockAuthResult = (
   return new SignInWithYouVersionResult({
     ...mockUserInfo,
     accessToken: 'access-token',
-    idToken: 'id-token',
     refreshToken: 'refresh-token',
     expiresIn: 3600,
     yvpUserId: 'test-yvp-user-id',

--- a/packages/hooks/src/__tests__/mocks/core-mock-factory.ts
+++ b/packages/hooks/src/__tests__/mocks/core-mock-factory.ts
@@ -12,7 +12,6 @@ interface MockAuthResultProps {
   accessToken?: string;
   expiresIn?: number;
   refreshToken?: string;
-  idToken?: string;
   yvpUserId?: string;
   name?: string;
   profilePicture?: string;
@@ -58,7 +57,6 @@ class MockSignInWithYouVersionResult {
   readonly accessToken: string | undefined;
   readonly expiryDate: Date | undefined;
   readonly refreshToken: string | undefined;
-  readonly idToken: string | undefined;
   readonly yvpUserId: string | undefined;
   readonly name: string | undefined;
   readonly profilePicture: string | undefined;
@@ -68,7 +66,6 @@ class MockSignInWithYouVersionResult {
     this.accessToken = props.accessToken;
     this.expiryDate = props.expiresIn ? new Date(Date.now() + props.expiresIn * 1000) : new Date();
     this.refreshToken = props.refreshToken;
-    this.idToken = props.idToken;
     this.yvpUserId = props.yvpUserId;
     this.name = props.name;
     this.profilePicture = props.profilePicture;

--- a/packages/hooks/src/__tests__/mocks/core-mock-factory.ts
+++ b/packages/hooks/src/__tests__/mocks/core-mock-factory.ts
@@ -78,20 +78,16 @@ class MockSignInWithYouVersionResult {
 
 interface MockConfiguration {
   accessToken: string | null;
-  idToken: string | null;
   refreshToken: string | null;
+  storedUserInfo: MockUserInfoData | null;
   appKey: string;
   apiHost: string;
   installationId: string | null;
   clearAuthTokens: MockedFunction<() => void>;
   saveAuthData: MockedFunction<
-    (
-      accessToken: string | null,
-      refreshToken: string | null,
-      idToken: string | null,
-      installationId: string | null,
-    ) => void
+    (accessToken: string | null, refreshToken: string | null, expiryDate: Date | null) => void
   >;
+  saveUserInfo: MockedFunction<(userInfo: MockUserInfoData | null) => void>;
 }
 
 interface SimpleCoreMockFactory {
@@ -99,6 +95,7 @@ interface SimpleCoreMockFactory {
     signIn: MockedFunction<typeof YouVersionAPIUsers.signIn>;
     handleAuthCallback: MockedFunction<typeof YouVersionAPIUsers.handleAuthCallback>;
     userInfo: MockedFunction<typeof YouVersionAPIUsers.userInfo>;
+    getStoredUserInfo: MockedFunction<typeof YouVersionAPIUsers.getStoredUserInfo>;
     refreshTokenIfNeeded: MockedFunction<typeof YouVersionAPIUsers.refreshTokenIfNeeded>;
   };
   YouVersionPlatformConfiguration: MockConfiguration;
@@ -111,19 +108,21 @@ interface GetterCoreMockFactory {
   YouVersionAPIUsers: {
     handleAuthCallback: MockedFunction<typeof YouVersionAPIUsers.handleAuthCallback>;
     userInfo: MockedFunction<typeof YouVersionAPIUsers.userInfo>;
+    getStoredUserInfo: MockedFunction<typeof YouVersionAPIUsers.getStoredUserInfo>;
     refreshTokenIfNeeded: MockedFunction<typeof YouVersionAPIUsers.refreshTokenIfNeeded>;
   };
   YouVersionPlatformConfiguration: {
     appKey: string;
     installationId: string;
     apiHost: string;
-    readonly idToken: string | null;
     readonly refreshToken: string | null;
     readonly accessToken: string | null;
+    readonly storedUserInfo: MockUserInfoData | null;
     clearAuthTokens: MockedFunction<() => void>;
     saveAuthData: MockedFunction<
-      (accessToken: string | null, refreshToken: string | null, idToken: string | null) => void
+      (accessToken: string | null, refreshToken: string | null, expiryDate: Date | null) => void
     >;
+    saveUserInfo: MockedFunction<(userInfo: MockUserInfoData | null) => void>;
   };
   YouVersionUserInfo: typeof MockYouVersionUserInfo;
   SignInWithYouVersionResult: typeof MockSignInWithYouVersionResult;
@@ -132,29 +131,25 @@ interface GetterCoreMockFactory {
 export function createSimpleCoreMockFactory(): SimpleCoreMockFactory {
   const mockConfiguration: MockConfiguration = {
     accessToken: null,
-    idToken: null,
     refreshToken: null,
+    storedUserInfo: null,
     appKey: '',
     apiHost: 'test-api.example.com',
     installationId: null,
     clearAuthTokens: vi.fn(() => {
       mockConfiguration.accessToken = null;
-      mockConfiguration.idToken = null;
       mockConfiguration.refreshToken = null;
+      mockConfiguration.storedUserInfo = null;
     }),
     saveAuthData: vi.fn(
-      (
-        accessToken: string | null,
-        refreshToken: string | null,
-        idToken: string | null,
-        installationId: string | null,
-      ) => {
+      (accessToken: string | null, refreshToken: string | null, _expiryDate: Date | null) => {
         mockConfiguration.accessToken = accessToken;
         mockConfiguration.refreshToken = refreshToken;
-        mockConfiguration.idToken = idToken;
-        mockConfiguration.installationId = installationId;
       },
     ),
+    saveUserInfo: vi.fn((userInfo: MockUserInfoData | null) => {
+      mockConfiguration.storedUserInfo = userInfo;
+    }),
   };
 
   return {
@@ -162,6 +157,7 @@ export function createSimpleCoreMockFactory(): SimpleCoreMockFactory {
       signIn: vi.fn(),
       handleAuthCallback: vi.fn(),
       userInfo: vi.fn(),
+      getStoredUserInfo: vi.fn(),
       refreshTokenIfNeeded: vi.fn(),
     },
     YouVersionPlatformConfiguration: mockConfiguration,
@@ -179,14 +175,17 @@ export function createSimpleCoreMockFactory(): SimpleCoreMockFactory {
 
 export function createGetterCoreMockFactory(): GetterCoreMockFactory {
   let mockInstallationId = 'auto-generated-installation-id';
-  let mockIdToken: string | null = null;
   let mockRefreshToken: string | null = null;
   let mockAccessToken: string | null = null;
+  let mockStoredUserInfo: MockUserInfoData | null = null;
 
   return {
     YouVersionAPIUsers: {
       handleAuthCallback: vi.fn(),
       userInfo: vi.fn(),
+      getStoredUserInfo: vi.fn(() =>
+        mockStoredUserInfo ? new MockYouVersionUserInfo(mockStoredUserInfo) : null,
+      ),
       refreshTokenIfNeeded: vi.fn(),
     },
     YouVersionPlatformConfiguration: {
@@ -198,27 +197,29 @@ export function createGetterCoreMockFactory(): GetterCoreMockFactory {
         if (value) mockInstallationId = value;
       },
       apiHost: 'test-api.example.com',
-      get idToken() {
-        return mockIdToken;
-      },
       get refreshToken() {
         return mockRefreshToken;
       },
       get accessToken() {
         return mockAccessToken;
       },
+      get storedUserInfo() {
+        return mockStoredUserInfo;
+      },
       clearAuthTokens: vi.fn(() => {
-        mockIdToken = null;
         mockRefreshToken = null;
         mockAccessToken = null;
+        mockStoredUserInfo = null;
       }),
       saveAuthData: vi.fn(
-        (accessToken: string | null, refreshToken: string | null, idToken: string | null) => {
+        (accessToken: string | null, refreshToken: string | null, _expiryDate: Date | null) => {
           mockAccessToken = accessToken;
           mockRefreshToken = refreshToken;
-          mockIdToken = idToken;
         },
       ),
+      saveUserInfo: vi.fn((userInfo: MockUserInfoData | null) => {
+        mockStoredUserInfo = userInfo;
+      }),
     },
     YouVersionUserInfo: MockYouVersionUserInfo,
     SignInWithYouVersionResult: MockSignInWithYouVersionResult,

--- a/packages/hooks/src/context/YouVersionAuthProvider.test.tsx
+++ b/packages/hooks/src/context/YouVersionAuthProvider.test.tsx
@@ -109,13 +109,8 @@ describe('YouVersionAuthProvider', () => {
   describe('OAuth callback handling', () => {
     it('should detect OAuth callback with state parameter', async () => {
       mockWindow.location.search = '?state=test-state&code=auth-code';
-      vi.spyOn(YouVersionAPIUsers, 'userInfo').mockReturnValue(mockUserInfo);
-
-      // Mock the configuration to return the id token after handleAuthCallback
-      vi.spyOn(YouVersionAPIUsers, 'handleAuthCallback').mockImplementation(() => {
-        YouVersionPlatformConfiguration.saveAuthData(null, null, 'test-id-token', null);
-        return Promise.resolve(mockAuthResult as any);
-      });
+      vi.spyOn(YouVersionAPIUsers, 'getStoredUserInfo').mockReturnValue(mockUserInfo);
+      vi.spyOn(YouVersionAPIUsers, 'handleAuthCallback').mockResolvedValue(mockAuthResult);
 
       const { getByTestId } = render(
         <YouVersionAuthProvider config={mockConfig}>
@@ -128,7 +123,7 @@ describe('YouVersionAuthProvider', () => {
       });
 
       expect(vi.mocked(YouVersionAPIUsers).handleAuthCallback).toHaveBeenCalled();
-      expect(vi.mocked(YouVersionAPIUsers).userInfo).toHaveBeenCalledWith('test-id-token');
+      expect(vi.mocked(YouVersionAPIUsers).getStoredUserInfo).toHaveBeenCalled();
       expect(getByTestId('user-info')).toHaveTextContent(JSON.stringify(mockUserInfo));
     });
 
@@ -167,10 +162,10 @@ describe('YouVersionAuthProvider', () => {
       });
     });
 
-    it('should handle callback with no idToken', async () => {
+    it('should leave user null when no profile was stored during callback', async () => {
       mockWindow.location.search = '?state=test-state&code=auth-code';
       vi.spyOn(YouVersionAPIUsers, 'handleAuthCallback').mockResolvedValue(mockAuthResult);
-      YouVersionPlatformConfiguration.saveAuthData(null, null, null, null);
+      vi.spyOn(YouVersionAPIUsers, 'getStoredUserInfo').mockReturnValue(null);
 
       const { getByTestId } = render(
         <YouVersionAuthProvider config={mockConfig}>
@@ -182,22 +177,18 @@ describe('YouVersionAuthProvider', () => {
         expect(getByTestId('is-loading')).toHaveTextContent('false');
       });
 
-      expect(vi.mocked(YouVersionAPIUsers).userInfo).not.toHaveBeenCalled();
+      expect(vi.mocked(YouVersionAPIUsers).getStoredUserInfo).toHaveBeenCalled();
       expect(getByTestId('user-info')).toHaveTextContent('null');
     });
   });
 
   describe('existing token handling', () => {
-    it('should refresh token when refresh token exists', async () => {
+    it('should rehydrate stored user when refresh succeeds', async () => {
       // Set up refresh token before mounting component
-      YouVersionPlatformConfiguration.saveAuthData(null, 'existing-refresh-token', null, null);
+      YouVersionPlatformConfiguration.saveAuthData(null, 'existing-refresh-token', null);
 
-      // Mock refreshTokenIfNeeded to set the id token after successful refresh
-      vi.spyOn(YouVersionAPIUsers, 'refreshTokenIfNeeded').mockImplementation(() => {
-        YouVersionPlatformConfiguration.saveAuthData(null, null, 'refreshed-id-token', null);
-        return Promise.resolve(true);
-      });
-      vi.spyOn(YouVersionAPIUsers, 'userInfo').mockReturnValue(mockUserInfo);
+      vi.spyOn(YouVersionAPIUsers, 'refreshTokenIfNeeded').mockResolvedValue(true);
+      vi.spyOn(YouVersionAPIUsers, 'getStoredUserInfo').mockReturnValue(mockUserInfo);
 
       const { getByTestId } = render(
         <YouVersionAuthProvider config={mockConfig}>
@@ -210,12 +201,12 @@ describe('YouVersionAuthProvider', () => {
       });
 
       expect(vi.mocked(YouVersionAPIUsers).refreshTokenIfNeeded).toHaveBeenCalled();
-      expect(vi.mocked(YouVersionAPIUsers).userInfo).toHaveBeenCalledWith('refreshed-id-token');
+      expect(vi.mocked(YouVersionAPIUsers).getStoredUserInfo).toHaveBeenCalled();
       expect(getByTestId('user-info')).toHaveTextContent(JSON.stringify(mockUserInfo));
     });
 
     it('should handle refresh token failure', async () => {
-      YouVersionPlatformConfiguration.saveAuthData(null, 'existing-refresh-token', null, null);
+      YouVersionPlatformConfiguration.saveAuthData(null, 'existing-refresh-token', null);
       vi.spyOn(YouVersionAPIUsers, 'refreshTokenIfNeeded').mockRejectedValue(
         new Error('Refresh failed'),
       );
@@ -233,9 +224,10 @@ describe('YouVersionAuthProvider', () => {
       expect(getByTestId('user-info')).toHaveTextContent('null');
     });
 
-    it('should clear user when refresh token exists but no idToken after refresh', async () => {
-      YouVersionPlatformConfiguration.saveAuthData(null, 'existing-refresh-token', null, null);
+    it('should clear user when the session expires and cannot be refreshed', async () => {
+      YouVersionPlatformConfiguration.saveAuthData(null, 'existing-refresh-token', null);
       vi.spyOn(YouVersionAPIUsers, 'refreshTokenIfNeeded').mockResolvedValue(false);
+      const getStoredUserInfoSpy = vi.spyOn(YouVersionAPIUsers, 'getStoredUserInfo');
 
       const { getByTestId } = render(
         <YouVersionAuthProvider config={mockConfig}>
@@ -247,6 +239,7 @@ describe('YouVersionAuthProvider', () => {
         expect(getByTestId('is-loading')).toHaveTextContent('false');
       });
 
+      expect(getStoredUserInfoSpy).not.toHaveBeenCalled();
       expect(getByTestId('user-info')).toHaveTextContent('null');
     });
   });

--- a/packages/hooks/src/context/YouVersionAuthProvider.tsx
+++ b/packages/hooks/src/context/YouVersionAuthProvider.tsx
@@ -1,28 +1,46 @@
 'use client';
 
-import React, { useEffect, useState, type ReactNode } from 'react';
 import {
   YouVersionAPIUsers,
   YouVersionPlatformConfiguration,
-  type YouVersionUserInfo,
+  YouVersionUserInfo,
+  type YouVersionUserInfoJSON,
 } from '@youversion/platform-core';
-import { YouVersionAuthContext } from './YouVersionAuthContext';
+import React, { useEffect, useState, type ReactNode } from 'react';
 import type { AuthConfig, AuthContextValue } from '../types/auth';
+import { YouVersionAuthContext } from './YouVersionAuthContext';
 
 interface YouVersionAuthProviderProps {
   config: AuthConfig;
+  /**
+   * Host-controlled auth state. When provided (including `null`), the host owns
+   * sign-in (e.g. the React Native Expo SDK signs in natively and passes the
+   * resulting profile down). In that mode the web token/OAuth init is skipped and
+   * this value drives `userInfo`/`isAuthenticated`. Leave `undefined` for the
+   * default web-managed flow.
+   */
+  userInfo?: YouVersionUserInfoJSON | null;
   children: ReactNode;
 }
 
 export default function YouVersionAuthProvider({
   config,
+  userInfo: controlledUserInfo,
   children,
 }: YouVersionAuthProviderProps): React.ReactElement {
+  const isHostControlled = controlledUserInfo !== undefined;
   const [userInfo, setUserInfo] = useState<YouVersionUserInfo | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
+    if (!isHostControlled) return;
+    setUserInfo(controlledUserInfo ? new YouVersionUserInfo(controlledUserInfo) : null);
+    setIsLoading(false);
+  }, [isHostControlled, controlledUserInfo]);
+
+  useEffect(() => {
+    if (isHostControlled) return;
     let mounted = true;
     const initAuth = async () => {
       // Set configuration

--- a/packages/hooks/src/context/YouVersionAuthProvider.tsx
+++ b/packages/hooks/src/context/YouVersionAuthProvider.tsx
@@ -37,10 +37,10 @@ export default function YouVersionAuthProvider({
         if (isOAuthCallback) {
           try {
             const result = await YouVersionAPIUsers.handleAuthCallback();
-            if (result && YouVersionPlatformConfiguration.idToken) {
-              const info = YouVersionAPIUsers.userInfo(YouVersionPlatformConfiguration.idToken);
+            if (result) {
+              // handleAuthCallback persists the decoded profile; read it back.
               if (!mounted) return;
-              setUserInfo(info);
+              setUserInfo(YouVersionAPIUsers.getStoredUserInfo());
             }
           } catch (err) {
             if (!mounted) return;
@@ -51,16 +51,11 @@ export default function YouVersionAuthProvider({
           const refreshToken = YouVersionPlatformConfiguration.refreshToken;
           if (refreshToken) {
             try {
-              await YouVersionAPIUsers.refreshTokenIfNeeded();
-              const idToken = YouVersionPlatformConfiguration.idToken;
-              if (idToken) {
-                const info = YouVersionAPIUsers.userInfo(idToken);
-                if (!mounted) return;
-                setUserInfo(info);
-              } else {
-                if (!mounted) return;
-                setUserInfo(null);
-              }
+              // refreshTokenIfNeeded clears tokens (and the stored profile)
+              // when the session has expired and cannot be refreshed.
+              const refreshed = await YouVersionAPIUsers.refreshTokenIfNeeded();
+              if (!mounted) return;
+              setUserInfo(refreshed ? YouVersionAPIUsers.getStoredUserInfo() : null);
             } catch {
               if (!mounted) return;
               setUserInfo(null);

--- a/packages/hooks/src/context/YouVersionProvider.tsx
+++ b/packages/hooks/src/context/YouVersionProvider.tsx
@@ -3,7 +3,10 @@
 import type { PropsWithChildren, ReactNode } from 'react';
 import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
 import { YouVersionContext } from './YouVersionContext';
-import { YouVersionPlatformConfiguration } from '@youversion/platform-core';
+import {
+  YouVersionPlatformConfiguration,
+  type YouVersionUserInfoJSON,
+} from '@youversion/platform-core';
 
 interface YouVersionProviderPropsBase {
   children: ReactNode;
@@ -22,6 +25,12 @@ interface YouVersionProviderPropsBase {
 interface YouVersionProviderPropsWithAuth extends YouVersionProviderPropsBase {
   authRedirectUrl: string;
   includeAuth: true;
+  /**
+   * Host-controlled auth state. When provided (including `null`), the host owns
+   * sign-in and this profile drives the in-app auth UI instead of the web
+   * token/OAuth flow. Used by the React Native Expo SDK to surface native sign-in.
+   */
+  userInfo?: YouVersionUserInfoJSON | null;
 }
 
 interface YouVersionProviderPropsWithoutAuth extends YouVersionProviderPropsBase {
@@ -107,7 +116,10 @@ export function YouVersionProvider(
     return (
       <YouVersionContext.Provider value={contextValue}>
         <Suspense>
-          <AuthProvider config={{ appKey, apiHost, redirectUri: props.authRedirectUrl }}>
+          <AuthProvider
+            config={{ appKey, apiHost, redirectUri: props.authRedirectUrl }}
+            userInfo={props.userInfo}
+          >
             {children}
           </AuthProvider>
         </Suspense>

--- a/packages/hooks/src/useYVAuth.test.tsx
+++ b/packages/hooks/src/useYVAuth.test.tsx
@@ -63,7 +63,6 @@ describe('useYVAuth', () => {
       expect(result.current).not.toBeNull();
       expect(result.current.auth.isAuthenticated).toBe(false);
       expect(result.current.auth.accessToken).toBe(null);
-      expect(result.current.auth.idToken).toBe(null);
       expect(result.current.userInfo).toBe(null);
     });
 
@@ -219,11 +218,10 @@ describe('useYVAuth', () => {
 
   describe('auth state', () => {
     it('should derive correct auth state from configuration', async () => {
-      YouVersionPlatformConfiguration.saveAuthData('access-token', null, 'id-token', null);
+      YouVersionPlatformConfiguration.saveAuthData('access-token', null, null);
       const { result } = await renderAuthHook();
 
       expect(result.current.auth.accessToken).toBe('access-token');
-      expect(result.current.auth.idToken).toBe('id-token');
     });
   });
 

--- a/packages/hooks/src/useYVAuth.ts
+++ b/packages/hooks/src/useYVAuth.ts
@@ -122,10 +122,9 @@ export function useYVAuth(): UseYVAuthReturn {
     if (typeof window !== 'undefined') {
       return {
         accessToken: YouVersionPlatformConfiguration.accessToken,
-        idToken: YouVersionPlatformConfiguration.idToken,
       };
     }
-    return { accessToken: null, idToken: null };
+    return { accessToken: null };
   }, []);
 
   // Sign in function
@@ -159,11 +158,10 @@ export function useYVAuth(): UseYVAuthReturn {
       isAuthenticated,
       isLoading,
       accessToken: authTokens.accessToken,
-      idToken: authTokens.idToken,
       result: null,
       error,
     }),
-    [isAuthenticated, isLoading, authTokens.accessToken, authTokens.idToken, error],
+    [isAuthenticated, isLoading, authTokens.accessToken, error],
   );
 
   // Sign out function

--- a/packages/ui/src/components/bible-reader.tsx
+++ b/packages/ui/src/components/bible-reader.tsx
@@ -55,6 +55,8 @@ type BibleReaderContextType = {
   onFootnotePress?: (data: FootnoteData) => void;
   onChapterPickerPress?: (data: BibleChapterPickerPressData) => void;
   onVersionPickerPress?: (data: BibleVersionPickerPressData) => void;
+  onSignInPress?: () => void;
+  onSignOutPress?: () => void;
 };
 
 const BibleReaderContext = createContext<BibleReaderContextType | null>(null);
@@ -89,6 +91,8 @@ export type RootProps = {
   onFootnotePress?: (data: FootnoteData) => void;
   onChapterPickerPress?: (data: BibleChapterPickerPressData) => void;
   onVersionPickerPress?: (data: BibleVersionPickerPressData) => void;
+  onSignInPress?: () => void;
+  onSignOutPress?: () => void;
   children?: ReactNode;
 };
 
@@ -189,6 +193,8 @@ function Root({
   onFootnotePress,
   onChapterPickerPress,
   onVersionPickerPress,
+  onSignInPress,
+  onSignOutPress,
   children,
 }: RootProps) {
   const [book, setBook] = useControllableState({
@@ -296,6 +302,8 @@ function Root({
     onFootnotePress,
     onChapterPickerPress,
     onVersionPickerPress,
+    onSignInPress,
+    onSignOutPress,
   };
 
   return (
@@ -408,6 +416,24 @@ function UserMenu() {
   const { t } = useTranslation(undefined, { i18n });
   const { auth, signIn, signOut, userInfo } = useYVAuth();
   const yvContext = useContext(YouVersionContext);
+  const { onSignInPress, onSignOutPress } = useBibleReaderContext();
+
+  // Prefer host-supplied native actions (e.g. the Expo DOM wrapper bridges these to
+  // native PKCE sign-in). Fall back to the Web SDK's own auth for pure-web usage.
+  const handleSignIn = () => {
+    if (onSignInPress) {
+      onSignInPress();
+    } else {
+      void signIn({ scopes: ['profile'] });
+    }
+  };
+  const handleSignOut = () => {
+    if (onSignOutPress) {
+      onSignOutPress();
+    } else {
+      void signOut();
+    }
+  };
 
   return (
     <Popover>
@@ -435,14 +461,18 @@ function UserMenu() {
       >
         <PopoverClose asChild>
           {auth.isAuthenticated ? (
-            <Button variant="secondary" className="yv:card yv:text-foreground" onClick={signOut}>
+            <Button
+              variant="secondary"
+              className="yv:card yv:text-foreground"
+              onClick={handleSignOut}
+            >
               {t('signOut')}
             </Button>
           ) : (
             <Button
               variant="secondary"
               className="yv:card yv:text-foreground"
-              onClick={() => void signIn({ scopes: ['profile'] })}
+              onClick={handleSignIn}
             >
               {t('signIn')}
             </Button>

--- a/packages/ui/src/test/utils.ts
+++ b/packages/ui/src/test/utils.ts
@@ -15,12 +15,14 @@ export async function setupAuthenticatedUser(
     '@youversion/platform-core'
   );
 
-  YouVersionPlatformConfiguration.saveAuthData(
-    'mock-access-token',
-    'mock-refresh-token',
-    'mock-id-token',
-    null,
-  );
+  YouVersionPlatformConfiguration.saveAuthData('mock-access-token', 'mock-refresh-token', null);
+
+  YouVersionPlatformConfiguration.saveUserInfo({
+    id: options.id ?? 'mock-user-id',
+    name: options.name ?? 'Test User',
+    email: options.email ?? 'test@example.com',
+    avatar_url: options.avatarUrl ?? undefined,
+  });
 
   const mockUserInfo = new YouVersionUserInfo({
     id: options.id ?? 'mock-user-id',
@@ -29,8 +31,8 @@ export async function setupAuthenticatedUser(
     avatar_url: options.avatarUrl ?? undefined,
   });
 
-  spyOn(YouVersionAPIUsers, 'refreshTokenIfNeeded').mockResolvedValue(false);
-  spyOn(YouVersionAPIUsers, 'userInfo').mockReturnValue(mockUserInfo);
+  spyOn(YouVersionAPIUsers, 'refreshTokenIfNeeded').mockResolvedValue(true);
+  spyOn(YouVersionAPIUsers, 'getStoredUserInfo').mockReturnValue(mockUserInfo);
 
   return mockUserInfo;
 }


### PR DESCRIPTION
- Decode ID token once at sign-in to derive userInfo, then discard it
  - Persist the decoded profile (Zod-validated on read) so it survives reloads
  - Clear stored profile on sign-out and on unrecoverable session expiry
  - core: drop idToken from saveAuthData; add saveUserInfo/storedUserInfo and getStoredUserInfo()
  - hooks: remove AuthenticationState.idToken; provider rehydrates from stored profile
  - ui: update authenticated-user test helper

  BREAKING CHANGE: the ID token is no longer exposed or persisted.
  - Removed AuthenticationState.idToken (use userInfo for profile data)
  - Removed the YouVersionPlatformConfiguration.idToken getter
  - saveAuthData(accessToken, refreshToken, expiryDate) no longer accepts an idToken arg

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the raw ID token from the auth persistence layer: the token is now decoded once at sign-in to produce a Zod-validated user profile, which is persisted in place of the token itself. Token refresh no longer requires a stored ID token, sign-out clears the profile alongside the OAuth tokens, and a new host-controlled mode lets native Expo wrappers pass an externally-obtained profile directly into the provider.

- **`YouVersionPlatformConfiguration`**: `saveAuthData` drops the `idToken` parameter; new `saveUserInfo`/`storedUserInfo` handle the decoded profile; `clearAuthTokens` now wipes the profile as well as the OAuth tokens.
- **`YouVersionAPIUsers`**: `handleAuthCallback` persists the decoded profile after exchange and clears everything (tokens + profile) if an error is thrown; `getStoredUserInfo()` reads the validated profile from storage; `refreshTokens` no longer needs or preserves a stored ID token.
- **`YouVersionAuthProvider`**: rehydrates `userInfo` via `getStoredUserInfo()` instead of re-decoding the token; adds a `userInfo` prop for host-controlled (native) auth flows.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the legacy idToken cleanup gap; all new auth paths are well-tested and logically sound.

The clearAuthTokens method no longer removes the idToken localStorage key. Existing users who signed in with the previous SDK version carry a raw ID token in storage; after upgrading and signing out, that key persists indefinitely because nothing in the new code touches it. The stated security goal of never keeping the signed token in storage is not met for this population until they uninstall or manually clear storage.

packages/core/src/YouVersionPlatformConfiguration.ts — the clearAuthTokens method needs a one-line migration to remove the legacy idToken key.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/core/src/YouVersionPlatformConfiguration.ts | Replaces idToken getter/storage with saveUserInfo/storedUserInfo (Zod-validated); clearAuthTokens no longer removes the legacy idToken localStorage key, leaving it in storage for existing users after upgrade |
| packages/core/src/Users.ts | handleAuthCallback now persists decoded profile instead of idToken; catch block correctly calls clearAuthTokens() before re-throwing; getStoredUserInfo() guards on id presence; refreshTokens() leaves the stored profile untouched |
| packages/core/src/schemas/user-info.ts | New Zod schema for the persisted profile; all fields optional (empty object passes), but getStoredUserInfo() adds an id-presence guard to prevent empty stubs from counting as authenticated |
| packages/hooks/src/context/YouVersionAuthProvider.tsx | Provider now rehydrates userInfo via getStoredUserInfo() instead of re-decoding idToken; adds host-controlled mode (userInfo prop) for Expo native sign-in bridging; two useEffects cleanly separated by isHostControlled guard |
| packages/hooks/src/useYVAuth.ts | Removes idToken from authTokens memo and AuthenticationState; isAuthenticated still derives from userInfo presence; no functional regressions |
| packages/ui/src/components/bible-reader.tsx | Adds onSignInPress/onSignOutPress props to BibleReader.Root, bridged to native handlers in UserMenu; falls back to web SDK auth when callbacks are absent |
| packages/ui/src/test/utils.ts | Updated setupAuthenticatedUser to use saveUserInfo + getStoredUserInfo mock instead of idToken; refreshTokenIfNeeded now returns true (matching the new refreshed=true to getStoredUserInfo path) |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/core/src/Users.ts`, line 192-201 ([link](https://github.com/youversion/platform-sdk-react/blob/abcf0b603e980228ecc64e23240a94b6745a8bc2/packages/core/src/Users.ts#L192-L201)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`extractSignInResult` still attaches `idToken` to the result — partial removal of the exposure path**

   `handleAuthCallback` no longer persists the ID token, but it still returns a `SignInWithYouVersionResult` whose `idToken` field is set (via `extractSignInResult`). `processCallback()` in `useYVAuth` returns this object directly, so any consumer calling `result.idToken` can still read the raw token from memory. If the intent is to fully remove the exposure vector, `idToken` should be omitted from the result constructed inside `extractSignInResult`.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/core/src/Users.ts
   Line: 192-201

   Comment:
   **`extractSignInResult` still attaches `idToken` to the result — partial removal of the exposure path**

   `handleAuthCallback` no longer persists the ID token, but it still returns a `SignInWithYouVersionResult` whose `idToken` field is set (via `extractSignInResult`). `processCallback()` in `useYVAuth` returns this object directly, so any consumer calling `result.idToken` can still read the raw token from memory. If the intent is to fully remove the exposure vector, `idToken` should be omitted from the result constructed inside `extractSignInResult`.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcore%2Fsrc%2FUsers.ts%0ALine%3A%20192-201%0A%0AComment%3A%0A**%60extractSignInResult%60%20still%20attaches%20%60idToken%60%20to%20the%20result%20%E2%80%94%20partial%20removal%20of%20the%20exposure%20path**%0A%0A%60handleAuthCallback%60%20no%20longer%20persists%20the%20ID%20token%2C%20but%20it%20still%20returns%20a%20%60SignInWithYouVersionResult%60%20whose%20%60idToken%60%20field%20is%20set%20%28via%20%60extractSignInResult%60%29.%20%60processCallback%28%29%60%20in%20%60useYVAuth%60%20returns%20this%20object%20directly%2C%20so%20any%20consumer%20calling%20%60result.idToken%60%20can%20still%20read%20the%20raw%20token%20from%20memory.%20If%20the%20intent%20is%20to%20fully%20remove%20the%20exposure%20vector%2C%20%60idToken%60%20should%20be%20omitted%20from%20the%20result%20constructed%20inside%20%60extractSignInResult%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20resultData%20%3D%20%7B%0A%20%20%20%20%20%20accessToken%3A%20tokens.access_token%2C%0A%20%20%20%20%20%20expiresIn%3A%20tokens.expires_in%2C%0A%20%20%20%20%20%20refreshToken%3A%20tokens.refresh_token%2C%0A%20%20%20%20%20%20%2F%2F%20idToken%20is%20intentionally%20omitted%20%E2%80%94%20decoded%20once%20above%20and%20discarded.%0A%20%20%20%20%20%20yvpUserId%3A%20idClaims.sub%20as%20string%2C%0A%20%20%20%20%20%20name%3A%20idClaims.name%20as%20string%2C%0A%20%20%20%20%20%20profilePicture%3A%20idClaims.profile_picture%20as%20string%2C%0A%20%20%20%20%20%20email%3A%20idClaims.email%20as%20string%2C%0A%20%20%20%20%7D%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-react&pr=248&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcore%2Fsrc%2FUsers.ts%0ALine%3A%20192-201%0A%0AComment%3A%0A**%60extractSignInResult%60%20still%20attaches%20%60idToken%60%20to%20the%20result%20%E2%80%94%20partial%20removal%20of%20the%20exposure%20path**%0A%0A%60handleAuthCallback%60%20no%20longer%20persists%20the%20ID%20token%2C%20but%20it%20still%20returns%20a%20%60SignInWithYouVersionResult%60%20whose%20%60idToken%60%20field%20is%20set%20%28via%20%60extractSignInResult%60%29.%20%60processCallback%28%29%60%20in%20%60useYVAuth%60%20returns%20this%20object%20directly%2C%20so%20any%20consumer%20calling%20%60result.idToken%60%20can%20still%20read%20the%20raw%20token%20from%20memory.%20If%20the%20intent%20is%20to%20fully%20remove%20the%20exposure%20vector%2C%20%60idToken%60%20should%20be%20omitted%20from%20the%20result%20constructed%20inside%20%60extractSignInResult%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20resultData%20%3D%20%7B%0A%20%20%20%20%20%20accessToken%3A%20tokens.access_token%2C%0A%20%20%20%20%20%20expiresIn%3A%20tokens.expires_in%2C%0A%20%20%20%20%20%20refreshToken%3A%20tokens.refresh_token%2C%0A%20%20%20%20%20%20%2F%2F%20idToken%20is%20intentionally%20omitted%20%E2%80%94%20decoded%20once%20above%20and%20discarded.%0A%20%20%20%20%20%20yvpUserId%3A%20idClaims.sub%20as%20string%2C%0A%20%20%20%20%20%20name%3A%20idClaims.name%20as%20string%2C%0A%20%20%20%20%20%20profilePicture%3A%20idClaims.profile_picture%20as%20string%2C%0A%20%20%20%20%20%20email%3A%20idClaims.email%20as%20string%2C%0A%20%20%20%20%7D%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=248&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-react%22%20on%20the%20existing%20branch%20%22bm%2Frefactor-auth%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22bm%2Frefactor-auth%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcore%2Fsrc%2FUsers.ts%0ALine%3A%20192-201%0A%0AComment%3A%0A**%60extractSignInResult%60%20still%20attaches%20%60idToken%60%20to%20the%20result%20%E2%80%94%20partial%20removal%20of%20the%20exposure%20path**%0A%0A%60handleAuthCallback%60%20no%20longer%20persists%20the%20ID%20token%2C%20but%20it%20still%20returns%20a%20%60SignInWithYouVersionResult%60%20whose%20%60idToken%60%20field%20is%20set%20%28via%20%60extractSignInResult%60%29.%20%60processCallback%28%29%60%20in%20%60useYVAuth%60%20returns%20this%20object%20directly%2C%20so%20any%20consumer%20calling%20%60result.idToken%60%20can%20still%20read%20the%20raw%20token%20from%20memory.%20If%20the%20intent%20is%20to%20fully%20remove%20the%20exposure%20vector%2C%20%60idToken%60%20should%20be%20omitted%20from%20the%20result%20constructed%20inside%20%60extractSignInResult%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20resultData%20%3D%20%7B%0A%20%20%20%20%20%20accessToken%3A%20tokens.access_token%2C%0A%20%20%20%20%20%20expiresIn%3A%20tokens.expires_in%2C%0A%20%20%20%20%20%20refreshToken%3A%20tokens.refresh_token%2C%0A%20%20%20%20%20%20%2F%2F%20idToken%20is%20intentionally%20omitted%20%E2%80%94%20decoded%20once%20above%20and%20discarded.%0A%20%20%20%20%20%20yvpUserId%3A%20idClaims.sub%20as%20string%2C%0A%20%20%20%20%20%20name%3A%20idClaims.name%20as%20string%2C%0A%20%20%20%20%20%20profilePicture%3A%20idClaims.profile_picture%20as%20string%2C%0A%20%20%20%20%20%20email%3A%20idClaims.email%20as%20string%2C%0A%20%20%20%20%7D%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

2. `packages/core/src/Users.ts`, line 148-154 ([link](https://github.com/youversion/platform-sdk-react/blob/abcf0b603e980228ecc64e23240a94b6745a8bc2/packages/core/src/Users.ts#L148-L154)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Catch block doesn't clean up `saveAuthData` / `saveUserInfo` on error**

   If an exception is raised after `saveAuthData` and `saveUserInfo` have already written to localStorage (e.g. `window.history.replaceState` throwing in a restrictive browser environment), the catch block removes the PKCE/OAuth temporary keys but leaves the persisted tokens and user profile intact. On the next page load the user would be treated as authenticated, while the provider also exposes the error that was thrown. Adding `YouVersionPlatformConfiguration.clearAuthTokens()` at the top of the catch block would make the failure path consistent with sign-out semantics.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/core/src/Users.ts
   Line: 148-154

   Comment:
   **Catch block doesn't clean up `saveAuthData` / `saveUserInfo` on error**

   If an exception is raised after `saveAuthData` and `saveUserInfo` have already written to localStorage (e.g. `window.history.replaceState` throwing in a restrictive browser environment), the catch block removes the PKCE/OAuth temporary keys but leaves the persisted tokens and user profile intact. On the next page load the user would be treated as authenticated, while the provider also exposes the error that was thrown. Adding `YouVersionPlatformConfiguration.clearAuthTokens()` at the top of the catch block would make the failure path consistent with sign-out semantics.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcore%2Fsrc%2FUsers.ts%0ALine%3A%20148-154%0A%0AComment%3A%0A**Catch%20block%20doesn't%20clean%20up%20%60saveAuthData%60%20%2F%20%60saveUserInfo%60%20on%20error**%0A%0AIf%20an%20exception%20is%20raised%20after%20%60saveAuthData%60%20and%20%60saveUserInfo%60%20have%20already%20written%20to%20localStorage%20%28e.g.%20%60window.history.replaceState%60%20throwing%20in%20a%20restrictive%20browser%20environment%29%2C%20the%20catch%20block%20removes%20the%20PKCE%2FOAuth%20temporary%20keys%20but%20leaves%20the%20persisted%20tokens%20and%20user%20profile%20intact.%20On%20the%20next%20page%20load%20the%20user%20would%20be%20treated%20as%20authenticated%2C%20while%20the%20provider%20also%20exposes%20the%20error%20that%20was%20thrown.%20Adding%20%60YouVersionPlatformConfiguration.clearAuthTokens%28%29%60%20at%20the%20top%20of%20the%20catch%20block%20would%20make%20the%20failure%20path%20consistent%20with%20sign-out%20semantics.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-react&pr=248&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcore%2Fsrc%2FUsers.ts%0ALine%3A%20148-154%0A%0AComment%3A%0A**Catch%20block%20doesn't%20clean%20up%20%60saveAuthData%60%20%2F%20%60saveUserInfo%60%20on%20error**%0A%0AIf%20an%20exception%20is%20raised%20after%20%60saveAuthData%60%20and%20%60saveUserInfo%60%20have%20already%20written%20to%20localStorage%20%28e.g.%20%60window.history.replaceState%60%20throwing%20in%20a%20restrictive%20browser%20environment%29%2C%20the%20catch%20block%20removes%20the%20PKCE%2FOAuth%20temporary%20keys%20but%20leaves%20the%20persisted%20tokens%20and%20user%20profile%20intact.%20On%20the%20next%20page%20load%20the%20user%20would%20be%20treated%20as%20authenticated%2C%20while%20the%20provider%20also%20exposes%20the%20error%20that%20was%20thrown.%20Adding%20%60YouVersionPlatformConfiguration.clearAuthTokens%28%29%60%20at%20the%20top%20of%20the%20catch%20block%20would%20make%20the%20failure%20path%20consistent%20with%20sign-out%20semantics.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=248&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-react%22%20on%20the%20existing%20branch%20%22bm%2Frefactor-auth%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22bm%2Frefactor-auth%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcore%2Fsrc%2FUsers.ts%0ALine%3A%20148-154%0A%0AComment%3A%0A**Catch%20block%20doesn't%20clean%20up%20%60saveAuthData%60%20%2F%20%60saveUserInfo%60%20on%20error**%0A%0AIf%20an%20exception%20is%20raised%20after%20%60saveAuthData%60%20and%20%60saveUserInfo%60%20have%20already%20written%20to%20localStorage%20%28e.g.%20%60window.history.replaceState%60%20throwing%20in%20a%20restrictive%20browser%20environment%29%2C%20the%20catch%20block%20removes%20the%20PKCE%2FOAuth%20temporary%20keys%20but%20leaves%20the%20persisted%20tokens%20and%20user%20profile%20intact.%20On%20the%20next%20page%20load%20the%20user%20would%20be%20treated%20as%20authenticated%2C%20while%20the%20provider%20also%20exposes%20the%20error%20that%20was%20thrown.%20Adding%20%60YouVersionPlatformConfiguration.clearAuthTokens%28%29%60%20at%20the%20top%20of%20the%20catch%20block%20would%20make%20the%20failure%20path%20consistent%20with%20sign-out%20semantics.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fcore%2Fsrc%2FYouVersionPlatformConfiguration.ts%3A73-76%0ALegacy%20%60idToken%60%20localStorage%20key%20is%20never%20removed%20after%20upgrading.%20The%20old%20%60saveAuthData%60%20always%20removed%20%60idToken%60%20%28passing%20null%20set%20%60removeItem%60%29%2C%20but%20the%20new%20signature%20dropped%20that%20branch%20entirely.%20Users%20who%20signed%20in%20with%20the%20previous%20version%20have%20a%20raw%20ID%20token%20sitting%20in%20%60localStorage%60%3B%20after%20upgrading%20they%20sign%20out%2C%20%60clearAuthTokens%60%20removes%20%60accessToken%60%2C%20%60refreshToken%60%2C%20%60expiryDate%60%2C%20and%20%60userInfo%60%20%E2%80%94%20but%20the%20%60idToken%60%20key%20is%20silently%20left%20behind.%20That%20directly%20contradicts%20this%20PR's%20stated%20goal%20of%20never%20keeping%20the%20signed%20token%20in%20storage.%0A%0A%60%60%60suggestion%0A%20%20public%20static%20clearAuthTokens%28%29%3A%20void%20%7B%0A%20%20%20%20this.saveAuthData%28null%2C%20null%2C%20null%29%3B%0A%20%20%20%20this.saveUserInfo%28null%29%3B%0A%20%20%20%20%2F%2F%20Migration%3A%20remove%20the%20legacy%20idToken%20key%20written%20by%20older%20versions%20of%20this%20SDK.%0A%20%20%20%20%2F%2F%20saveAuthData%20no%20longer%20touches%20this%20key%2C%20so%20it%20must%20be%20cleaned%20up%20explicitly.%0A%20%20%20%20localStorage.removeItem%28'idToken'%29%3B%0A%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fbible-reader.tsx%3A423-436%0AUnnecessary%20%60else%60%20blocks%20after%20a%20return-like%20branch.%20Per%20the%20project%20style%20guide%2C%20prefer%20early%20returns%20to%20reduce%20nesting.%20Both%20handlers%20can%20be%20flattened%20by%20calling%20the%20host%20callback%20and%20returning%20early.%0A%0A%60%60%60suggestion%0A%20%20const%20handleSignIn%20%3D%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20if%20%28onSignInPress%29%20%7B%0A%20%20%20%20%20%20onSignInPress%28%29%3B%0A%20%20%20%20%20%20return%3B%0A%20%20%20%20%7D%0A%20%20%20%20void%20signIn%28%7B%20scopes%3A%20%5B'profile'%5D%20%7D%29%3B%0A%20%20%7D%3B%0A%20%20const%20handleSignOut%20%3D%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20if%20%28onSignOutPress%29%20%7B%0A%20%20%20%20%20%20onSignOutPress%28%29%3B%0A%20%20%20%20%20%20return%3B%0A%20%20%20%20%7D%0A%20%20%20%20void%20signOut%28%29%3B%0A%20%20%7D%3B%0A%60%60%60%0A%0A&repo=youversion%2Fplatform-sdk-react&pr=248&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fcore%2Fsrc%2FYouVersionPlatformConfiguration.ts%3A73-76%0ALegacy%20%60idToken%60%20localStorage%20key%20is%20never%20removed%20after%20upgrading.%20The%20old%20%60saveAuthData%60%20always%20removed%20%60idToken%60%20%28passing%20null%20set%20%60removeItem%60%29%2C%20but%20the%20new%20signature%20dropped%20that%20branch%20entirely.%20Users%20who%20signed%20in%20with%20the%20previous%20version%20have%20a%20raw%20ID%20token%20sitting%20in%20%60localStorage%60%3B%20after%20upgrading%20they%20sign%20out%2C%20%60clearAuthTokens%60%20removes%20%60accessToken%60%2C%20%60refreshToken%60%2C%20%60expiryDate%60%2C%20and%20%60userInfo%60%20%E2%80%94%20but%20the%20%60idToken%60%20key%20is%20silently%20left%20behind.%20That%20directly%20contradicts%20this%20PR's%20stated%20goal%20of%20never%20keeping%20the%20signed%20token%20in%20storage.%0A%0A%60%60%60suggestion%0A%20%20public%20static%20clearAuthTokens%28%29%3A%20void%20%7B%0A%20%20%20%20this.saveAuthData%28null%2C%20null%2C%20null%29%3B%0A%20%20%20%20this.saveUserInfo%28null%29%3B%0A%20%20%20%20%2F%2F%20Migration%3A%20remove%20the%20legacy%20idToken%20key%20written%20by%20older%20versions%20of%20this%20SDK.%0A%20%20%20%20%2F%2F%20saveAuthData%20no%20longer%20touches%20this%20key%2C%20so%20it%20must%20be%20cleaned%20up%20explicitly.%0A%20%20%20%20localStorage.removeItem%28'idToken'%29%3B%0A%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fbible-reader.tsx%3A423-436%0AUnnecessary%20%60else%60%20blocks%20after%20a%20return-like%20branch.%20Per%20the%20project%20style%20guide%2C%20prefer%20early%20returns%20to%20reduce%20nesting.%20Both%20handlers%20can%20be%20flattened%20by%20calling%20the%20host%20callback%20and%20returning%20early.%0A%0A%60%60%60suggestion%0A%20%20const%20handleSignIn%20%3D%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20if%20%28onSignInPress%29%20%7B%0A%20%20%20%20%20%20onSignInPress%28%29%3B%0A%20%20%20%20%20%20return%3B%0A%20%20%20%20%7D%0A%20%20%20%20void%20signIn%28%7B%20scopes%3A%20%5B'profile'%5D%20%7D%29%3B%0A%20%20%7D%3B%0A%20%20const%20handleSignOut%20%3D%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20if%20%28onSignOutPress%29%20%7B%0A%20%20%20%20%20%20onSignOutPress%28%29%3B%0A%20%20%20%20%20%20return%3B%0A%20%20%20%20%7D%0A%20%20%20%20void%20signOut%28%29%3B%0A%20%20%7D%3B%0A%60%60%60%0A%0A&pr=248&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-react%22%20on%20the%20existing%20branch%20%22bm%2Frefactor-auth%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22bm%2Frefactor-auth%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fcore%2Fsrc%2FYouVersionPlatformConfiguration.ts%3A73-76%0ALegacy%20%60idToken%60%20localStorage%20key%20is%20never%20removed%20after%20upgrading.%20The%20old%20%60saveAuthData%60%20always%20removed%20%60idToken%60%20%28passing%20null%20set%20%60removeItem%60%29%2C%20but%20the%20new%20signature%20dropped%20that%20branch%20entirely.%20Users%20who%20signed%20in%20with%20the%20previous%20version%20have%20a%20raw%20ID%20token%20sitting%20in%20%60localStorage%60%3B%20after%20upgrading%20they%20sign%20out%2C%20%60clearAuthTokens%60%20removes%20%60accessToken%60%2C%20%60refreshToken%60%2C%20%60expiryDate%60%2C%20and%20%60userInfo%60%20%E2%80%94%20but%20the%20%60idToken%60%20key%20is%20silently%20left%20behind.%20That%20directly%20contradicts%20this%20PR's%20stated%20goal%20of%20never%20keeping%20the%20signed%20token%20in%20storage.%0A%0A%60%60%60suggestion%0A%20%20public%20static%20clearAuthTokens%28%29%3A%20void%20%7B%0A%20%20%20%20this.saveAuthData%28null%2C%20null%2C%20null%29%3B%0A%20%20%20%20this.saveUserInfo%28null%29%3B%0A%20%20%20%20%2F%2F%20Migration%3A%20remove%20the%20legacy%20idToken%20key%20written%20by%20older%20versions%20of%20this%20SDK.%0A%20%20%20%20%2F%2F%20saveAuthData%20no%20longer%20touches%20this%20key%2C%20so%20it%20must%20be%20cleaned%20up%20explicitly.%0A%20%20%20%20localStorage.removeItem%28'idToken'%29%3B%0A%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fbible-reader.tsx%3A423-436%0AUnnecessary%20%60else%60%20blocks%20after%20a%20return-like%20branch.%20Per%20the%20project%20style%20guide%2C%20prefer%20early%20returns%20to%20reduce%20nesting.%20Both%20handlers%20can%20be%20flattened%20by%20calling%20the%20host%20callback%20and%20returning%20early.%0A%0A%60%60%60suggestion%0A%20%20const%20handleSignIn%20%3D%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20if%20%28onSignInPress%29%20%7B%0A%20%20%20%20%20%20onSignInPress%28%29%3B%0A%20%20%20%20%20%20return%3B%0A%20%20%20%20%7D%0A%20%20%20%20void%20signIn%28%7B%20scopes%3A%20%5B'profile'%5D%20%7D%29%3B%0A%20%20%7D%3B%0A%20%20const%20handleSignOut%20%3D%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20if%20%28onSignOutPress%29%20%7B%0A%20%20%20%20%20%20onSignOutPress%28%29%3B%0A%20%20%20%20%20%20return%3B%0A%20%20%20%20%7D%0A%20%20%20%20void%20signOut%28%29%3B%0A%20%20%7D%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/core/src/YouVersionPlatformConfiguration.ts:73-76
Legacy `idToken` localStorage key is never removed after upgrading. The old `saveAuthData` always removed `idToken` (passing null set `removeItem`), but the new signature dropped that branch entirely. Users who signed in with the previous version have a raw ID token sitting in `localStorage`; after upgrading they sign out, `clearAuthTokens` removes `accessToken`, `refreshToken`, `expiryDate`, and `userInfo` — but the `idToken` key is silently left behind. That directly contradicts this PR's stated goal of never keeping the signed token in storage.

```suggestion
  public static clearAuthTokens(): void {
    this.saveAuthData(null, null, null);
    this.saveUserInfo(null);
    // Migration: remove the legacy idToken key written by older versions of this SDK.
    // saveAuthData no longer touches this key, so it must be cleaned up explicitly.
    localStorage.removeItem('idToken');
  }
```

### Issue 2 of 2
packages/ui/src/components/bible-reader.tsx:423-436
Unnecessary `else` blocks after a return-like branch. Per the project style guide, prefer early returns to reduce nesting. Both handlers can be flattened by calling the host callback and returning early.

```suggestion
  const handleSignIn = () => {
    if (onSignInPress) {
      onSignInPress();
      return;
    }
    void signIn({ scopes: ['profile'] });
  };
  const handleSignOut = () => {
    if (onSignOutPress) {
      onSignOutPress();
      return;
    }
    void signOut();
  };
```


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(auth): harden sign-in result and cal..."](https://github.com/youversion/platform-sdk-react/commit/d2e7621cde79046aadd776192e628767be9c0ef9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35061203)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->