### PR TITLE
YPE-2834 - feat(ui): add onShare callback to VerseOfTheDay

### DIFF
--- a/.changeset/votd-on-share.md
+++ b/.changeset/votd-on-share.md
@@ -1,0 +1,5 @@
+---
+"@youversion/platform-react-ui": minor
+---
+
+Add optional `onShare` and `VerseOfTheDayShareData` to `VerseOfTheDay` for native host share flows.

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -33,7 +33,11 @@ export {
   type BibleVersionPickerLanguageTriggerProps,
 } from './bible-version-picker';
 export { YouVersionAuthButton, type YouVersionAuthButtonProps } from './YouVersionAuthButton';
-export { VerseOfTheDay, type VerseOfTheDayProps } from './verse-of-the-day';
+export {
+  VerseOfTheDay,
+  type VerseOfTheDayProps,
+  type VerseOfTheDayShareData,
+} from './verse-of-the-day';
 export {
   BibleTextView,
   type BibleTextViewProps,

--- a/packages/ui/src/components/verse-of-the-day.test.tsx
+++ b/packages/ui/src/components/verse-of-the-day.test.tsx
@@ -151,6 +151,27 @@ describe('VerseOfTheDay - share', () => {
     });
   });
 
+  it('does not surface unhandled rejection when onShare rejects', async () => {
+    const user = userEvent.setup();
+    const onShare = vi.fn().mockRejectedValue(new Error('User dismissed'));
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (event: PromiseRejectionEvent): void => {
+      unhandledRejections.push(event.reason);
+    };
+    window.addEventListener('unhandledrejection', onUnhandledRejection);
+
+    try {
+      render(<VerseOfTheDay onShare={onShare} />);
+      await user.click(screen.getByRole('button', { name: en.shareAriaLabel }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(onShare).toHaveBeenCalledTimes(1);
+      expect(unhandledRejections).toHaveLength(0);
+    } finally {
+      window.removeEventListener('unhandledrejection', onUnhandledRejection);
+    }
+  });
+
   it('does not call navigator.share or clipboard when onShare is provided', async () => {
     const user = userEvent.setup();
     const onShare = vi.fn();

--- a/packages/ui/src/components/verse-of-the-day.test.tsx
+++ b/packages/ui/src/components/verse-of-the-day.test.tsx
@@ -4,6 +4,7 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type * as PlatformHooks from '@youversion/platform-react-hooks';
 
 // ResizeObserver is used by downstream components (BibleTextView, AnimatedHeight).
@@ -15,6 +16,7 @@ class ResizeObserverMock {
 globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
 
 import { VerseOfTheDay } from './verse-of-the-day';
+import type { VerseOfTheDayShareData } from './verse-of-the-day';
 import en from '@/i18n/locales/en.json';
 import {
   getDayOfYear,
@@ -36,18 +38,32 @@ vi.mock('@youversion/platform-react-hooks', async (importActual) => {
   };
 });
 
-function stubHooks(): void {
+const MOCK_VERSE_HTML = '<p class="yv-p">For God so loved the world</p>';
+const MOCK_VERSE_TEXT = 'For God so loved the world';
+const MOCK_REFERENCE = 'John 3:16 NIV';
+
+function stubHooks(
+  overrides: {
+    passageContent?: string;
+    passageError?: Error | null;
+    votdError?: Error | null;
+  } = {},
+): void {
+  const { passageContent = MOCK_VERSE_HTML, passageError = null, votdError = null } = overrides;
+
   vi.mocked(getDayOfYear).mockReturnValue(1);
   vi.mocked(useVerseOfTheDay).mockReturnValue({
     data: { day: 1, passage_id: 'JHN.3.16' },
     loading: false,
-    error: null,
+    error: votdError,
     refetch: vi.fn(),
   });
   vi.mocked(usePassage).mockReturnValue({
-    passage: { id: 'JHN.3.16', reference: 'John 3:16', content: '' },
+    passage: passageError
+      ? null
+      : { id: 'JHN.3.16', reference: 'John 3:16', content: passageContent },
     loading: false,
-    error: null,
+    error: passageError,
     refetch: vi.fn(),
   });
   // useVersion returns a full BibleVersion shape; keep the cast to avoid reproducing
@@ -61,6 +77,14 @@ function stubHooks(): void {
   vi.mocked(useTheme).mockReturnValue('light');
 }
 
+function expectedShareData(verseText: string = MOCK_VERSE_TEXT): VerseOfTheDayShareData {
+  return {
+    text: `${verseText}\n\n${MOCK_REFERENCE}`,
+    reference: MOCK_REFERENCE,
+    verseText,
+  };
+}
+
 describe('VerseOfTheDay i18n integration', () => {
   beforeEach(() => {
     stubHooks();
@@ -69,5 +93,98 @@ describe('VerseOfTheDay i18n integration', () => {
   it('renders the translated label from the i18n instance', () => {
     render(<VerseOfTheDay />);
     expect(screen.getByText(en.verseOfTheDay)).toBeInTheDocument();
+  });
+});
+
+describe('VerseOfTheDay - share', () => {
+  let shareSpy: ReturnType<typeof vi.fn>;
+  let clipboardWriteTextSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    stubHooks();
+
+    // jsdom does not implement innerText; mirror textContent for share payload tests.
+    Object.defineProperty(HTMLElement.prototype, 'innerText', {
+      configurable: true,
+      get(this: HTMLElement): string {
+        return this.textContent ?? '';
+      },
+    });
+
+    shareSpy = vi.fn().mockResolvedValue(undefined);
+    clipboardWriteTextSpy = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal(
+      'navigator',
+      Object.assign({}, navigator, {
+        share: shareSpy,
+        clipboard: {
+          writeText: clipboardWriteTextSpy,
+        },
+      }),
+    );
+  });
+
+  it('calls onShare with expected payload when provided', async () => {
+    const user = userEvent.setup();
+    const onShare = vi.fn();
+
+    render(<VerseOfTheDay onShare={onShare} />);
+
+    await user.click(screen.getByRole('button', { name: en.shareAriaLabel }));
+
+    expect(onShare).toHaveBeenCalledTimes(1);
+    expect(onShare).toHaveBeenCalledWith(expectedShareData());
+  });
+
+  it('uses navigator.share with built text when onShare is omitted', async () => {
+    const user = userEvent.setup();
+
+    render(<VerseOfTheDay />);
+
+    await user.click(screen.getByRole('button', { name: en.shareAriaLabel }));
+
+    expect(shareSpy).toHaveBeenCalledTimes(1);
+    expect(shareSpy).toHaveBeenCalledWith({
+      text: expectedShareData().text,
+      title: undefined,
+      url: undefined,
+    });
+  });
+
+  it('does not call navigator.share or clipboard when onShare is provided', async () => {
+    const user = userEvent.setup();
+    const onShare = vi.fn();
+
+    render(<VerseOfTheDay onShare={onShare} />);
+
+    await user.click(screen.getByRole('button', { name: en.shareAriaLabel }));
+
+    expect(onShare).toHaveBeenCalledTimes(1);
+    expect(shareSpy).not.toHaveBeenCalled();
+    expect(clipboardWriteTextSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not render share button or call onShare when showShareButton is false', () => {
+    const onShare = vi.fn();
+
+    render(<VerseOfTheDay showShareButton={false} onShare={onShare} />);
+
+    expect(screen.queryByRole('button', { name: en.shareAriaLabel })).not.toBeInTheDocument();
+    expect(onShare).not.toHaveBeenCalled();
+  });
+
+  it('does not call onShare when passage has an error', async () => {
+    const user = userEvent.setup();
+    const onShare = vi.fn();
+    stubHooks({ passageError: new Error('Passage failed') });
+
+    render(<VerseOfTheDay onShare={onShare} />);
+
+    const shareButton = screen.getByRole('button', { name: en.shareAriaLabel });
+    expect(shareButton).toBeDisabled();
+
+    await user.click(shareButton);
+
+    expect(onShare).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/verse-of-the-day.tsx
+++ b/packages/ui/src/components/verse-of-the-day.tsx
@@ -160,15 +160,12 @@ export function VerseOfTheDay({
     if (!verseRef.current) {
       return;
     }
-    const { text, reference, verseText } = buildVerseOfTheDayShareData(
-      verseRef.current,
-      referenceText,
-    );
+    const shareData = buildVerseOfTheDayShareData(verseRef.current, referenceText);
     if (onShare) {
-      await onShare({ text, reference, verseText });
+      await onShare(shareData);
       return;
     }
-    await share({ text, errorMessage: t('unableToShare') });
+    await share({ text: shareData.text, errorMessage: t('unableToShare') });
   };
 
   return (

--- a/packages/ui/src/components/verse-of-the-day.tsx
+++ b/packages/ui/src/components/verse-of-the-day.tsx
@@ -162,7 +162,11 @@ export function VerseOfTheDay({
     }
     const shareData = buildVerseOfTheDayShareData(verseRef.current, referenceText);
     if (onShare) {
-      await onShare(shareData);
+      try {
+        await onShare(shareData);
+      } catch {
+        // Silently fail — mirror navigator.share dismiss/cancel in share()
+      }
       return;
     }
     await share({ text: shareData.text, errorMessage: t('unableToShare') });

--- a/packages/ui/src/components/verse-of-the-day.tsx
+++ b/packages/ui/src/components/verse-of-the-day.tsx
@@ -18,6 +18,17 @@ import { BibleTextView } from '@/components/verse';
 import { DEFAULT_LICENSE_FREE_BIBLE_VERSION } from '@youversion/platform-core';
 import { cn } from '@/lib/utils';
 
+export type VerseOfTheDayShareData = {
+  /** Full share body: verse text, blank line, then reference (same as Web Share `text`). */
+  text: string;
+  /** Human-readable reference line, e.g. "John 3:16 NIV". */
+  reference: string;
+  /** Verse body only (DOM `innerText`), without the reference line. */
+  verseText: string;
+  /** Optional deep link; not populated today. */
+  url?: string;
+};
+
 export type VerseOfTheDayProps = {
   /**
    * Sets the background color of the Verse Of the Day component.
@@ -44,11 +55,26 @@ export type VerseOfTheDayProps = {
    */
   showShareButton?: boolean;
   /**
+   * When provided, called on share button click with serializable share data.
+   * Suppresses the default Web Share API / clipboard flow. Use for React Native
+   * or Expo DOM hosts that forward the payload across the native bridge.
+   */
+  onShare?: (data: VerseOfTheDayShareData) => void | Promise<void>;
+  /**
    * The size of the card. Changing this will change the
    * size of the card and the font size of the text.
    */
   size?: 'default' | 'lg';
 };
+
+function buildVerseOfTheDayShareData(
+  verseEl: HTMLElement,
+  referenceText: string,
+): VerseOfTheDayShareData {
+  const verseText = verseEl.innerText;
+  const text = referenceText ? `${verseText}\n\n${referenceText}` : verseText;
+  return { text, reference: referenceText, verseText };
+}
 
 async function share({
   title,
@@ -99,6 +125,7 @@ export function VerseOfTheDay({
   showSunIcon = true,
   showShareButton = true,
   showBibleAppAttribution = true,
+  onShare,
   size = 'default',
 }: VerseOfTheDayProps): React.ReactElement {
   const { t } = useTranslation(undefined, { i18n });
@@ -130,10 +157,18 @@ export function VerseOfTheDay({
   }
 
   const handleShareVerse = async () => {
-    if (verseRef.current) {
-      const text = verseRef.current.innerText + '\n\n' + referenceText;
-      await share({ text, errorMessage: t('unableToShare') });
+    if (!verseRef.current) {
+      return;
     }
+    const { text, reference, verseText } = buildVerseOfTheDayShareData(
+      verseRef.current,
+      referenceText,
+    );
+    if (onShare) {
+      await onShare({ text, reference, verseText });
+      return;
+    }
+    await share({ text, errorMessage: t('unableToShare') });
   };
 
   return (


### PR DESCRIPTION
## Summary

Adds an optional `onShare` escape hatch to `VerseOfTheDay` so hosts (Expo DOM, React Native wrappers) can run native share flows with a serializable payload, while default web behavior (`navigator.share` → clipboard) is unchanged when the prop is omitted.

## Changes

- Export `VerseOfTheDayShareData` (`text`, `reference`, `verseText`, optional `url`) from `@youversion/platform-react-ui`
- Add `onShare?: (data: VerseOfTheDayShareData) => void | Promise<void>` to `VerseOfTheDayProps`
- Build share payload from the same DOM `innerText` + reference formatting as today; custom handler skips Web Share / clipboard
- Preserve existing share button visibility, disabled-on-error rules, and DOM guard when `verseRef` is missing
- Unit tests for custom handler, default fallback, override, and guardrails
- Minor changeset for unified package release

## Expo / RN consumption

```tsx
<VerseOfTheDay onShare={(data) => Share.share({ message: data.text })} />
```

## Test plan

- [x] `pnpm --filter @youversion/platform-react-ui test -- verse-of-the-day.test.tsx`
- [x] `pnpm --filter @youversion/platform-react-ui typecheck`
- [x] `pnpm --filter @youversion/platform-react-ui lint`

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an `onShare` escape hatch to `VerseOfTheDay`, letting Expo DOM / React Native hosts intercept the share button and run a native share flow with a typed `VerseOfTheDayShareData` payload, while the existing Web Share API / clipboard path remains the default when the prop is omitted.

- `VerseOfTheDayShareData` is exported from the package index, `buildVerseOfTheDayShareData` centralises payload construction, and `handleShareVerse` dispatches between the custom and built-in paths with matching error-swallow semantics.
- Previous review findings (unhandled rejection from `onShare`, payload destructuring) are both addressed in this revision.
- Test coverage is thorough: six new cases cover the custom path, default fallback, rejection guardrail, mutual exclusivity, and the disabled/error-state guards.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is purely additive and all existing share behavior is preserved when `onShare` is omitted.

The logic is straightforward, the two code paths are well-tested, previous review concerns are resolved, and the only open item is a minor forward-compatibility gap where the fallback web-share call does not yet forward the `url` field from the share payload.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/verse-of-the-day.tsx | Adds `VerseOfTheDayShareData` type, `buildVerseOfTheDayShareData` helper, and `onShare` prop; refactors `handleShareVerse` to dispatch between custom and built-in share flows with proper error handling. |
| packages/ui/src/components/verse-of-the-day.test.tsx | Adds thorough share-related test suite covering custom handler, default fallback, unhandled-rejection guardrail, mutual exclusivity, disabled state, and error state; stubs `innerText` for jsdom compatibility. |
| packages/ui/src/components/index.ts | Re-exports `VerseOfTheDayShareData` type alongside existing `VerseOfTheDay` and `VerseOfTheDayProps`; clean additive change. |
| .changeset/votd-on-share.md | Minor changeset entry for `@youversion/platform-react-ui`; bump type is correct for a backward-compatible new prop. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant VerseOfTheDay
    participant buildShareData as buildVerseOfTheDayShareData
    participant onShare as onShare (host)
    participant share as share() (web)
    participant Navigator as navigator.share / clipboard

    User->>VerseOfTheDay: click share button
    VerseOfTheDay->>VerseOfTheDay: guard: verseRef.current?
    VerseOfTheDay->>buildShareData: (verseEl, referenceText)
    buildShareData-->>VerseOfTheDay: "VerseOfTheDayShareData {text, reference, verseText, url?}"

    alt onShare prop provided
        VerseOfTheDay->>onShare: onShare(shareData)
        onShare-->>VerseOfTheDay: "void / Promise<void>"
        Note over VerseOfTheDay,onShare: errors silently caught
    else default web flow
        VerseOfTheDay->>share: "share({ text, errorMessage })"
        share->>Navigator: "navigator.share({ text, url, title }) or clipboard.writeText"
        Navigator-->>share: resolved / dismissed
        Note over share,Navigator: navigator.share errors silently caught
    end
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fverse-of-the-day.tsx%3A172%0AThe%20fallback%20%60share%28%29%60%20call%20only%20forwards%20%60shareData.text%60%2C%20silently%20dropping%20the%20%60url%60%20field.%20The%20custom%20%60onShare%60%20path%20receives%20the%20full%20%60VerseOfTheDayShareData%60%20payload%20%28including%20%60url%60%29%2C%20so%20the%20two%20paths%20are%20already%20asymmetric.%20When%20%60url%60%20is%20eventually%20populated%20in%20%60buildVerseOfTheDayShareData%60%2C%20the%20built-in%20Web%20Share%20flow%20will%20silently%20omit%20the%20deep%20link%20while%20the%20escape%20hatch%20correctly%20includes%20it.%0A%0A%60%60%60suggestion%0A%20%20%20%20await%20share%28%7B%20text%3A%20shareData.text%2C%20url%3A%20shareData.url%2C%20errorMessage%3A%20t%28'unableToShare'%29%20%7D%29%3B%0A%60%60%60%0A%0A&repo=youversion%2Fplatform-sdk-react&pr=249&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fverse-of-the-day.tsx%3A172%0AThe%20fallback%20%60share%28%29%60%20call%20only%20forwards%20%60shareData.text%60%2C%20silently%20dropping%20the%20%60url%60%20field.%20The%20custom%20%60onShare%60%20path%20receives%20the%20full%20%60VerseOfTheDayShareData%60%20payload%20%28including%20%60url%60%29%2C%20so%20the%20two%20paths%20are%20already%20asymmetric.%20When%20%60url%60%20is%20eventually%20populated%20in%20%60buildVerseOfTheDayShareData%60%2C%20the%20built-in%20Web%20Share%20flow%20will%20silently%20omit%20the%20deep%20link%20while%20the%20escape%20hatch%20correctly%20includes%20it.%0A%0A%60%60%60suggestion%0A%20%20%20%20await%20share%28%7B%20text%3A%20shareData.text%2C%20url%3A%20shareData.url%2C%20errorMessage%3A%20t%28'unableToShare'%29%20%7D%29%3B%0A%60%60%60%0A%0A&pr=249&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-react%22%20on%20the%20existing%20branch%20%22YPE-2834-add-optional-share-callback-to-verse-of-the-day-in-react-web-sdk%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22YPE-2834-add-optional-share-callback-to-verse-of-the-day-in-react-web-sdk%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fverse-of-the-day.tsx%3A172%0AThe%20fallback%20%60share%28%29%60%20call%20only%20forwards%20%60shareData.text%60%2C%20silently%20dropping%20the%20%60url%60%20field.%20The%20custom%20%60onShare%60%20path%20receives%20the%20full%20%60VerseOfTheDayShareData%60%20payload%20%28including%20%60url%60%29%2C%20so%20the%20two%20paths%20are%20already%20asymmetric.%20When%20%60url%60%20is%20eventually%20populated%20in%20%60buildVerseOfTheDayShareData%60%2C%20the%20built-in%20Web%20Share%20flow%20will%20silently%20omit%20the%20deep%20link%20while%20the%20escape%20hatch%20correctly%20includes%20it.%0A%0A%60%60%60suggestion%0A%20%20%20%20await%20share%28%7B%20text%3A%20shareData.text%2C%20url%3A%20shareData.url%2C%20errorMessage%3A%20t%28'unableToShare'%29%20%7D%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/ui/src/components/verse-of-the-day.tsx:172
The fallback `share()` call only forwards `shareData.text`, silently dropping the `url` field. The custom `onShare` path receives the full `VerseOfTheDayShareData` payload (including `url`), so the two paths are already asymmetric. When `url` is eventually populated in `buildVerseOfTheDayShareData`, the built-in Web Share flow will silently omit the deep link while the escape hatch correctly includes it.

```suggestion
    await share({ text: shareData.text, url: shareData.url, errorMessage: t('unableToShare') });
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into YPE-2834-add-op..."](https://github.com/youversion/platform-sdk-react/commit/f5d658a587b295bb92459d7925c4801e643533d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35178258)</sub>

<!-- /greptile_comment -->