### PR TITLE
fix(ui): show loading spinner when Bible Reader chapter changes

### DIFF
--- a/.changeset/reader-chapter-loading-spinner.md
+++ b/.changeset/reader-chapter-loading-spinner.md
@@ -1,0 +1,5 @@
+---
+"@youversion/platform-react-ui": patch
+---
+
+Show a loading spinner in Bible Reader when changing chapters instead of displaying stale passage text under the updated header.

--- a/packages/ui/src/components/bible-reader.stories.tsx
+++ b/packages/ui/src/components/bible-reader.stories.tsx
@@ -703,6 +703,70 @@ export const VersionButtonLoadingStates: Story = {
 };
 
 /**
+ * Tests that navigating to the next chapter shows a content spinner instead of stale
+ * chapter text while the new passage loads.
+ */
+export const ChapterChangeLoadingSpinner: Story = {
+  tags: ['integration'],
+  args: {
+    defaultVersionId: 111,
+    book: 'JHN',
+    chapter: '1',
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('*/v1/bibles/111/passages/JHN.2', async () => {
+          await delay(1000);
+          return HttpResponse.json({
+            id: 'JHN.2',
+            content:
+              '<div><div class="p"><span class="yv-v" v="1"></span><span class="yv-vlbl">1</span>On the third day a wedding took place at Cana in Galilee.</div></div>',
+            reference: 'John 2',
+          });
+        }),
+      ],
+    },
+  },
+  render: (args) => (
+    <div data-yv-sdk className="yv:h-screen">
+      <BibleReader.Root {...args}>
+        <BibleReader.Content />
+        <BibleReader.Toolbar />
+      </BibleReader.Root>
+    </div>
+  ),
+  play: async () => {
+    await waitFor(
+      async () => {
+        await expect(screen.getByText(/In the beginning was the Word/i)).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    const nextChapterButton = screen.getByRole('button', { name: /next chapter/i });
+    await expect(nextChapterButton).toBeEnabled();
+    await userEvent.click(nextChapterButton);
+
+    await waitFor(async () => {
+      await expect(screen.getByRole('status', { name: /loading passage/i })).toBeInTheDocument();
+    });
+    await expect(screen.queryByText(/In the beginning was the Word/i)).not.toBeInTheDocument();
+
+    await waitFor(
+      async () => {
+        await expect(
+          screen.getByText(/On the third day a wedding took place at Cana in Galilee/i),
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    await expect(nextChapterButton).toBeEnabled();
+  },
+};
+
+/**
  * Tests that a rich intro chapter (Joshua) renders correctly with real-world content
  * including structured sections (At a Glance, Purpose, Major Themes), italic spans,
  * bold-italic spans, and special formatting classes (imt1, imt2, is, ili, ip, etc.).

--- a/packages/ui/src/components/bible-reader.stories.tsx
+++ b/packages/ui/src/components/bible-reader.stories.tsx
@@ -1,10 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { expect, fn, screen, spyOn, userEvent, waitFor } from 'storybook/test';
+import { expect, fn, screen, spyOn, userEvent, waitFor, within } from 'storybook/test';
 import { http, HttpResponse, delay } from 'msw';
 import { BibleReader } from './bible-reader';
 import { setupAuthenticatedUser } from '../test/utils';
 import { INTER_FONT, SOURCE_SERIF_FONT } from '@/lib/verse-html-utils';
 import mockBibles from '../test/mock-data/bibles.json';
+import mockPassages from '../test/mock-data/passages.json';
+import { globalHandlers } from '../test/mocks/handlers';
 
 let signInMock: ReturnType<typeof fn>;
 
@@ -710,21 +712,18 @@ export const ChapterChangeLoadingSpinner: Story = {
   tags: ['integration'],
   args: {
     defaultVersionId: 111,
-    book: 'JHN',
-    chapter: '1',
+    defaultBook: 'JHN',
+    defaultChapter: '1',
   },
   parameters: {
     msw: {
+      // Story-level handlers replace preview defaults; keep globals and override JHN.2 with a delay.
       handlers: [
         http.get('*/v1/bibles/111/passages/JHN.2', async () => {
           await delay(1000);
-          return HttpResponse.json({
-            id: 'JHN.2',
-            content:
-              '<div><div class="p"><span class="yv-v" v="1"></span><span class="yv-vlbl">1</span>On the third day a wedding took place at Cana in Galilee.</div></div>',
-            reference: 'John 2',
-          });
+          return HttpResponse.json(mockPassages['JHN.2']);
         }),
+        ...globalHandlers,
       ],
     },
   },
@@ -736,27 +735,37 @@ export const ChapterChangeLoadingSpinner: Story = {
       </BibleReader.Root>
     </div>
   ),
-  play: async () => {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     await waitFor(
       async () => {
-        await expect(screen.getByText(/In the beginning was the Word/i)).toBeInTheDocument();
+        await expect(canvas.getByText(/In the beginning was the Word/i)).toBeInTheDocument();
       },
       { timeout: 5000 },
     );
 
-    const nextChapterButton = screen.getByRole('button', { name: /next chapter/i });
-    await expect(nextChapterButton).toBeEnabled();
+    const nextChapterButton = canvas.getByRole('button', { name: /next chapter/i });
+    await waitFor(
+      async () => {
+        await expect(nextChapterButton).toBeEnabled();
+      },
+      { timeout: 5000 },
+    );
     await userEvent.click(nextChapterButton);
 
-    await waitFor(async () => {
-      await expect(screen.getByRole('status', { name: /loading passage/i })).toBeInTheDocument();
-    });
-    await expect(screen.queryByText(/In the beginning was the Word/i)).not.toBeInTheDocument();
+    await waitFor(
+      async () => {
+        await expect(canvas.getByRole('status', { name: /loading passage/i })).toBeInTheDocument();
+        await expect(canvas.queryByText(/In the beginning was the Word/i)).not.toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
 
     await waitFor(
       async () => {
         await expect(
-          screen.getByText(/On the third day a wedding took place at Cana in Galilee/i),
+          canvas.getByText(/On the third day a wedding took place at Cana in Galilee/i),
         ).toBeInTheDocument();
       },
       { timeout: 5000 },

--- a/packages/ui/src/components/bible-reader.test.tsx
+++ b/packages/ui/src/components/bible-reader.test.tsx
@@ -7,12 +7,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
-import type { BibleBook, BibleVersion, Language } from '@youversion/platform-core';
+import type { BibleBook, BiblePassage, BibleVersion, Language } from '@youversion/platform-core';
 import {
   useBooks,
   useFilteredVersions,
   useLanguage,
   useLanguages,
+  usePassage,
   useTheme,
   useVersion,
   useVersions,
@@ -34,6 +35,27 @@ class ResizeObserverMock {
 }
 globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
 
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(globalThis, 'localStorage', {
+  value: localStorageMock,
+  writable: true,
+});
+
 vi.mock('@youversion/platform-react-hooks', async () => {
   const actual = await vi.importActual('@youversion/platform-react-hooks');
   return {
@@ -45,8 +67,21 @@ vi.mock('@youversion/platform-react-hooks', async () => {
     useTheme: vi.fn(),
     useVersion: vi.fn(),
     useVersions: vi.fn(),
+    usePassage: vi.fn(),
   };
 });
+
+const mockPassageChapter1: BiblePassage = {
+  id: 'JHN.1',
+  content: '<p class="yv-p">Chapter one opening words</p>',
+  reference: 'John 1',
+};
+
+const mockPassageChapter2: BiblePassage = {
+  id: 'JHN.2',
+  content: '<p class="yv-p">Chapter two opening words</p>',
+  reference: 'John 2',
+};
 
 const mockBooks: BibleBook[] = [
   {
@@ -71,6 +106,13 @@ const mockVersion = {
 } as BibleVersion;
 
 function setupDefaultMocks() {
+  localStorage.clear();
+  vi.mocked(usePassage).mockReturnValue({
+    passage: null,
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  });
   vi.mocked(useTheme).mockReturnValue('light');
   vi.mocked(useBooks).mockReturnValue({
     books: { data: [...mockBooks], next_page_token: null },
@@ -152,7 +194,6 @@ describe('createBibleThemeSettingsContentHandlers', () => {
 describe('BibleReader theme settings', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    localStorage.clear();
     setupDefaultMocks();
   });
 
@@ -297,5 +338,84 @@ describe('BibleReader Toolbar - onChapterPickerPress', () => {
     });
 
     expect(screen.queryByPlaceholderText('Search')).not.toBeInTheDocument();
+  });
+});
+
+describe('BibleReader Content - chapter loading', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDefaultMocks();
+  });
+
+  function renderContent(chapter: string) {
+    return render(
+      <BibleReader.Root defaultVersionId={3034} defaultBook="JHN" defaultChapter={chapter}>
+        <BibleReader.Content />
+      </BibleReader.Root>,
+    );
+  }
+
+  it('shows a spinner on initial load when passage is null', () => {
+    vi.mocked(usePassage).mockReturnValue({
+      passage: null,
+      loading: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    renderContent('1');
+
+    expect(screen.getByRole('status', { name: /loading passage/i })).toBeInTheDocument();
+    expect(screen.queryByText('Chapter one opening words')).not.toBeInTheDocument();
+  });
+
+  it('shows a spinner instead of stale text during chapter change', () => {
+    vi.mocked(usePassage).mockReturnValue({
+      passage: mockPassageChapter1,
+      loading: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    renderContent('2');
+
+    expect(screen.getByRole('status', { name: /loading passage/i })).toBeInTheDocument();
+    expect(screen.queryByText('Chapter one opening words')).not.toBeInTheDocument();
+    expect(screen.queryByText('Chapter two opening words')).not.toBeInTheDocument();
+  });
+
+  it('renders passage text when the loaded passage matches the requested chapter', async () => {
+    vi.mocked(usePassage).mockReturnValue({
+      passage: mockPassageChapter2,
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    renderContent('2');
+
+    await waitFor(() => {
+      expect(screen.getByText('Chapter two opening words')).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('status', { name: /loading passage/i })).not.toBeInTheDocument();
+  });
+
+  it('shows chapter unavailable message without passage content or spinner', () => {
+    vi.mocked(usePassage).mockReturnValue({
+      passage: null,
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    renderContent('99');
+
+    expect(screen.getByText(/this chapter is not available in this version/i)).toBeInTheDocument();
+    expect(screen.queryByRole('status', { name: /loading passage/i })).not.toBeInTheDocument();
+    expect(usePassage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: { enabled: false },
+      }),
+    );
   });
 });

--- a/packages/ui/src/components/bible-reader.tsx
+++ b/packages/ui/src/components/bible-reader.tsx
@@ -5,6 +5,7 @@ import i18n from '@/i18n';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import {
   useBooks,
+  usePassage,
   useTheme,
   useVersion,
   useYVAuth,
@@ -346,6 +347,25 @@ function Content() {
     chapterLabel = bookData.intro.title;
   }
 
+  const {
+    passage,
+    loading: passageLoading,
+    error: passageError,
+  } = usePassage({
+    versionId,
+    usfm: usfmReference,
+    include_headings: true,
+    include_notes: true,
+    options: { enabled: !chapterUnavailable },
+  });
+
+  const isPassageCurrent = !passageLoading && passage?.id === usfmReference;
+  const passageState = {
+    passage: isPassageCurrent ? passage : null,
+    loading: !isPassageCurrent && !passageError && (passageLoading || passage !== null),
+    error: passageError,
+  };
+
   return (
     <main className="yv:*:max-w-lg yv:flex yv:flex-col yv:items-center yv:gap-6 yv:overflow-y-auto yv:px-6 yv:max-sm:px-4 yv:py-12 yv:h-full">
       <h1 className="yv:flex yv:gap-2 yv:flex-col yv:justify-center yv:items-center yv:text-muted-foreground yv:font-medium">
@@ -376,6 +396,7 @@ function Content() {
           lineHeight={lineHeight}
           showVerseNumbers={showVerseNumbers}
           theme={background}
+          passageState={passageState}
           onFootnotePress={onFootnotePress}
         />
       )}

--- a/packages/ui/src/test/mock-data/passages.json
+++ b/packages/ui/src/test/mock-data/passages.json
@@ -63,5 +63,11 @@
     "content": "<div><div class=\"p\"><span class=\"yv-v\" v=\"51\"></span><span class=\"yv-vlbl\">51</span>He then added, <span class=\"wj\">\"Very truly I tell you,</span><span class=\"yv-n f\"><span class=\"fr\">1:51 </span><span class=\"ft\">The Greek is plural.</span></span> <span class=\"wj\">you</span><span class=\"yv-n f\"><span class=\"fr\">1:51 </span><span class=\"ft\">The Greek is plural.</span></span> <span class=\"wj\">will see 'heaven open, and the angels of God ascending and descending on'</span><span class=\"yv-n f\"><span class=\"fr\">1:51 </span><span class=\"ft\"><span class=\"ref\" usfm=\"GEN.28.12\">Gen. 28:12</span></span></span> <span class=\"wj\">the Son of Man.\"</span></div></div>",
     "bible_id": 111,
     "reference": "John 1:51"
+  },
+  "JHN.2": {
+    "id": "JHN.2",
+    "content": "<div><div class=\"p\"><span class=\"yv-v\" v=\"1\"></span><span class=\"yv-vlbl\">1</span>On the third day a wedding took place at Cana in Galilee.</div></div>",
+    "bible_id": 111,
+    "reference": "John 2"
   }
 }

--- a/packages/ui/src/test/mocks/handlers.ts
+++ b/packages/ui/src/test/mocks/handlers.ts
@@ -42,6 +42,10 @@ export const globalHandlers = [
     return HttpResponse.json(mockPassages['JHN.1']);
   }),
 
+  http.get('*/v1/bibles/111/passages/JHN.2', () => {
+    return HttpResponse.json(mockPassages['JHN.2']);
+  }),
+
   http.get('*/v1/bibles/111/passages/JHN.1.51', () => {
     return HttpResponse.json(mockPassages['JHN.1.51']);
   }),


### PR DESCRIPTION
## Summary

- Gate Bible Reader passage display until the fetched passage matches the requested chapter USFM, so stale chapter text is not shown under an updated header during slow loads.
- Lift `usePassage` into `BibleReader.Content` and pass controlled `passageState` into `BibleTextView` without changing default refetch behavior used by `BibleCard`.
- Increase the passage loading spinner size and add unit tests plus Storybook/MSW coverage for chapter navigation.


https://github.com/user-attachments/assets/45a409d3-14be-4e3f-8439-39677686647c


## Test plan

- [ ] Open Bible Reader, navigate next/previous chapter on a slow network and confirm content shows a spinner until the new chapter loads
- [ ] Confirm initial load, error, and unavailable-chapter states still behave correctly
- [ ] Run `pnpm --filter @youversion/platform-react-ui test`
- [ ] Run Storybook integration test `ChapterChangeLoadingSpinner` (requires Playwright browsers)


Made with [Cursor](https://cursor.com)