### PR TITLE
YPE-2776 - Make it clear BibleReader is loading when changing chapters

### DIFF
--- a/.changeset/bible-reader-chapter-loading-overlay.md
+++ b/.changeset/bible-reader-chapter-loading-overlay.md
@@ -1,0 +1,5 @@
+---
+'@youversion/platform-react-ui': patch
+---
+
+Improve the chapter-change loading experience in `BibleReader`/`BibleTextView`. Instead of pulsing the previous chapter's text while the next chapter loads, the outgoing text now fades to a low opacity in place (no layout shift) with a spinner overlaid and centered in the visible reading area. This avoids both the confusing stale-but-active text and the flash-of-empty-content a bare spinner would cause, and the opacity transition doubles as a smooth fade-in for the incoming chapter.

--- a/packages/ui/src/components/verse.test.tsx
+++ b/packages/ui/src/components/verse.test.tsx
@@ -668,7 +668,7 @@ describe('BibleTextView - Refetch loading behavior', () => {
     );
 
     await waitFor(() => {
-      const wrapper = container.querySelector('[data-yv-sdk]');
+      const wrapper = container.querySelector('[aria-busy="true"]');
       expect(wrapper).not.toBeNull();
       expect((wrapper as HTMLElement).style.pointerEvents).toBe('none');
     });

--- a/packages/ui/src/components/verse.tsx
+++ b/packages/ui/src/components/verse.tsx
@@ -544,29 +544,47 @@ export const BibleTextView = forwardRef<HTMLDivElement, BibleTextViewProps>(
       );
     }
 
+    // While the next chapter loads, usePassage keeps returning the previous
+    // passage. Fade it in place behind a spinner rather than clearing it (which
+    // would flash the layout). The spinner is sticky so it stays centered in view
+    // on long chapters.
     return (
-      <div
-        data-yv-sdk
-        data-yv-theme={currentTheme}
-        className={cn(fetchedLoading || currentLoading ? 'yv:animate-pulse' : '')}
-        aria-busy={currentLoading || undefined}
-        style={currentLoading ? { pointerEvents: 'none' } : undefined}
-      >
-        <Verse.Html
-          ref={ref}
-          html={currentPassage?.content || ''}
-          fontFamily={fontFamily}
-          fontSize={fontSize}
-          lineHeight={lineHeight}
-          showVerseNumbers={showVerseNumbers}
-          renderNotes={renderNotes}
-          reference={currentPassage?.reference}
-          theme={currentTheme}
-          selectedVerses={selectedVerses}
-          onVerseSelect={onVerseSelect}
-          highlightedVerses={highlightedVerses}
-          onFootnotePress={onFootnotePress}
-        />
+      <div data-yv-sdk data-yv-theme={currentTheme} className="yv:relative">
+        <div
+          className={cn('yv:transition-opacity yv:duration-300', currentLoading && 'yv:opacity-40')}
+          aria-busy={currentLoading || undefined}
+          style={currentLoading ? { pointerEvents: 'none' } : undefined}
+        >
+          <Verse.Html
+            ref={ref}
+            html={currentPassage?.content || ''}
+            fontFamily={fontFamily}
+            fontSize={fontSize}
+            lineHeight={lineHeight}
+            showVerseNumbers={showVerseNumbers}
+            renderNotes={renderNotes}
+            reference={currentPassage?.reference}
+            theme={currentTheme}
+            selectedVerses={selectedVerses}
+            onVerseSelect={onVerseSelect}
+            highlightedVerses={highlightedVerses}
+            onFootnotePress={onFootnotePress}
+          />
+        </div>
+        {currentLoading && (
+          <div
+            role="status"
+            aria-label={t('loadingPassageAriaLabel')}
+            className="yv:pointer-events-none yv:absolute yv:inset-0"
+          >
+            <div className="yv:sticky yv:top-1/2 yv:flex yv:-translate-y-1/2 yv:justify-center">
+              <LoaderIcon
+                className="yv:size-8 yv:animate-spin yv:text-muted-foreground"
+                aria-hidden="true"
+              />
+            </div>
+          </div>
+        )}
       </div>
     );
   },


### PR DESCRIPTION
[PLEASE WATCH VIDEO DEMO](https://cap.so/s/8hdh9q045hdjzdd)

<img width="1100" height="1204" alt="image" src="https://github.com/user-attachments/assets/8044f8ce-f781-4439-b015-53b605524246" />


Reworked the chapter-change loading state in `BibleTextView` (`packages/ui/src/components/verse.tsx`). While the next chapter is fetching, the outgoing chapter's text now fades to 40% opacity in place behind a sticky, viewport-centered spinner, instead of pulsing the stale text. The opacity transition doubles as a fade-in for the incoming chapter.

This avoids the two bad alternatives: a bare spinner (flashes the layout empty then back) and the previous pulsing stale text (reads as active/confusing while the heading already shows the new chapter).

Touched areas: stale-while-revalidate render path, loading overlay, `pointer-events`/`aria-busy` placement, updated refetch loading test selector, changeset.

All 70 UI tests pass; typecheck and lint clean.

Completes YPE-2776

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the `animate-pulse` stale-text loading indicator in `BibleTextView` with a fade-to-40%-opacity overlay and a sticky viewport-centered spinner, avoiding both the confusing active-stale-text appearance and the flash-of-empty-content a bare spinner would cause.

- **`verse.tsx`**: The stale-while-revalidate render branch wraps the passage content in a transitioning opacity div (`aria-busy`, `pointerEvents: none`) and conditionally renders an `absolute inset-0` overlay with a sticky spinner; the initial-load-with-no-content path is unchanged.
- **`verse.test.tsx`**: The pointer-events test selector is updated from `[data-yv-sdk]` to `[aria-busy=\"true\"]` to match the new DOM structure.
- **`.changeset/\u2026`**: Patch changeset added for `@youversion/platform-react-ui`.

<h3>Confidence Score: 3/5</h3>

The sticky spinner is invisible for any chapter taller than the viewport, defeating the overlay's main purpose on the chapters where it matters most.

The loading UX approach is well-structured, but `top-1/2` resolves against the absolute overlay height (= full chapter text height) rather than the viewport. For long chapters like Psalm 119, this pins the spinner off-screen immediately, leaving users with only faded text and no visible loading indicator.

packages/ui/src/components/verse.tsx — the sticky spinner positioning at line 580

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/verse.tsx | Replaces animate-pulse stale-text with fade-to-40%-opacity + sticky spinner overlay; sticky top-1/2 is resolved against the absolute overlay height rather than the viewport, making the spinner invisible for chapters taller than the viewport |
| packages/ui/src/components/verse.test.tsx | Selector in the pointer-events test updated from [data-yv-sdk] to [aria-busy="true"] to match the new DOM structure where aria-busy lives on the inner content wrapper |
| .changeset/bible-reader-chapter-loading-overlay.md | Patch changeset added for @youversion/platform-react-ui with accurate description of the loading UX change |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[BibleTextView render] --> B{currentLoading AND no passage?}
    B -- Yes --> C[Initial load spinner\nfull-screen centered]
    B -- No --> D{currentError?}
    D -- Yes --> E[Error message]
    D -- No --> F[Outer div data-yv-sdk relative]
    F --> G[Inner content div aria-busy transition-opacity]
    G --> H{currentLoading?}
    H -- Yes --> I[opacity-40 pointerEvents none]
    H -- No --> J[opacity-100 normal]
    F --> K{currentLoading?}
    K -- Yes --> L[Overlay div absolute inset-0 pointer-events-none]
    L --> M[Sticky spinner div sticky top-1/2]
    M --> N[LoaderIcon size-8 animate-spin]
    K -- No --> O[null no overlay]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fverse.tsx%3A580-582%0A**Sticky%20spinner%20invisible%20on%20long%20chapters**%0A%0A%60yv%3Atop-1%2F2%60%20resolves%20%60top%3A%2050%25%60%20against%20the%20sticky%20element's%20*containing%20block*%20%E2%80%94%20the%20%60absolute%20inset-0%60%20overlay%20div%20%E2%80%94%20whose%20height%20equals%20the%20entire%20chapter%20text%20height.%20For%20any%20chapter%20taller%20than%20the%20viewport%20%28e.g.%20Psalm%20119%2C%20long%20Gospels%29%2C%20that%20threshold%20exceeds%20the%20viewport%20height%2C%20so%20%60position%3A%20sticky%60%20pins%20the%20spinner%20below%20the%20visible%20area%20immediately.%20Users%20see%20only%20the%20faded%20text%20with%20no%20visible%20loading%20indicator%20throughout%20the%20scroll.%0A%0A%60yv%3Atop-%5B50vh%5D%60%20fixes%20this%20%E2%80%94%20it%20resolves%20against%20the%20viewport%20height%20rather%20than%20the%20chapter%20height%2C%20keeping%20the%20spinner%20at%20the%20vertical%20midpoint%20of%20the%20visible%20area%20on%20chapters%20of%20any%20length.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cdiv%20className%3D%22yv%3Asticky%20yv%3Atop-%5B50vh%5D%20yv%3Aflex%20yv%3A-translate-y-1%2F2%20yv%3Ajustify-center%22%3E%0A%60%60%60%0A%0A&repo=youversion%2Fplatform-sdk-react&pr=258&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fverse.tsx%3A580-582%0A**Sticky%20spinner%20invisible%20on%20long%20chapters**%0A%0A%60yv%3Atop-1%2F2%60%20resolves%20%60top%3A%2050%25%60%20against%20the%20sticky%20element's%20*containing%20block*%20%E2%80%94%20the%20%60absolute%20inset-0%60%20overlay%20div%20%E2%80%94%20whose%20height%20equals%20the%20entire%20chapter%20text%20height.%20For%20any%20chapter%20taller%20than%20the%20viewport%20%28e.g.%20Psalm%20119%2C%20long%20Gospels%29%2C%20that%20threshold%20exceeds%20the%20viewport%20height%2C%20so%20%60position%3A%20sticky%60%20pins%20the%20spinner%20below%20the%20visible%20area%20immediately.%20Users%20see%20only%20the%20faded%20text%20with%20no%20visible%20loading%20indicator%20throughout%20the%20scroll.%0A%0A%60yv%3Atop-%5B50vh%5D%60%20fixes%20this%20%E2%80%94%20it%20resolves%20against%20the%20viewport%20height%20rather%20than%20the%20chapter%20height%2C%20keeping%20the%20spinner%20at%20the%20vertical%20midpoint%20of%20the%20visible%20area%20on%20chapters%20of%20any%20length.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cdiv%20className%3D%22yv%3Asticky%20yv%3Atop-%5B50vh%5D%20yv%3Aflex%20yv%3A-translate-y-1%2F2%20yv%3Ajustify-center%22%3E%0A%60%60%60%0A%0A&pr=258&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-react%22%20on%20the%20existing%20branch%20%22YPE-2776-react-sdk-components-bible-reader-show-loading-spinner-when-changing-chapters%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22YPE-2776-react-sdk-components-bible-reader-show-loading-spinner-when-changing-chapters%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fverse.tsx%3A580-582%0A**Sticky%20spinner%20invisible%20on%20long%20chapters**%0A%0A%60yv%3Atop-1%2F2%60%20resolves%20%60top%3A%2050%25%60%20against%20the%20sticky%20element's%20*containing%20block*%20%E2%80%94%20the%20%60absolute%20inset-0%60%20overlay%20div%20%E2%80%94%20whose%20height%20equals%20the%20entire%20chapter%20text%20height.%20For%20any%20chapter%20taller%20than%20the%20viewport%20%28e.g.%20Psalm%20119%2C%20long%20Gospels%29%2C%20that%20threshold%20exceeds%20the%20viewport%20height%2C%20so%20%60position%3A%20sticky%60%20pins%20the%20spinner%20below%20the%20visible%20area%20immediately.%20Users%20see%20only%20the%20faded%20text%20with%20no%20visible%20loading%20indicator%20throughout%20the%20scroll.%0A%0A%60yv%3Atop-%5B50vh%5D%60%20fixes%20this%20%E2%80%94%20it%20resolves%20against%20the%20viewport%20height%20rather%20than%20the%20chapter%20height%2C%20keeping%20the%20spinner%20at%20the%20vertical%20midpoint%20of%20the%20visible%20area%20on%20chapters%20of%20any%20length.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cdiv%20className%3D%22yv%3Asticky%20yv%3Atop-%5B50vh%5D%20yv%3Aflex%20yv%3A-translate-y-1%2F2%20yv%3Ajustify-center%22%3E%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/ui/src/components/verse.tsx:580-582
**Sticky spinner invisible on long chapters**

`yv:top-1/2` resolves `top: 50%` against the sticky element's *containing block* — the `absolute inset-0` overlay div — whose height equals the entire chapter text height. For any chapter taller than the viewport (e.g. Psalm 119, long Gospels), that threshold exceeds the viewport height, so `position: sticky` pins the spinner below the visible area immediately. Users see only the faded text with no visible loading indicator throughout the scroll.

`yv:top-[50vh]` fixes this — it resolves against the viewport height rather than the chapter height, keeping the spinner at the vertical midpoint of the visible area on chapters of any length.

```suggestion
            <div className="yv:sticky yv:top-[50vh] yv:flex yv:-translate-y-1/2 yv:justify-center">
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["YPE-2776 - feat(ui): clarify BibleReader..."](https://github.com/youversion/platform-sdk-react/commit/e0881e5ae33e222b12bd4cb2cbe8310fefd51b3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35675624)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->