### PR TITLE
feat(ui): add cycling line spacing setting to BibleReader

### DIFF
--- a/.changeset/nine-gifts-check.md
+++ b/.changeset/nine-gifts-check.md
@@ -1,0 +1,14 @@
+---
+'@youversion/platform-react-ui': minor
+---
+
+Add a cycling line spacing setting to BibleReader
+
+The Bible theme settings panel now includes a line spacing control that cycles
+through three presets (small `1.45`, default `1.7`, large `2.0`) on each press.
+The selection persists to `localStorage` when uncontrolled.
+
+`BibleReader.Root` gains `lineSpacing`, `defaultLineSpacing`, and
+`onChangeLineSpacing` props for controlled/uncontrolled usage. The existing
+`lineHeight` prop is deprecated but still honored as the initial line spacing,
+so this change is backward compatible; it will be removed in the next major.

--- a/packages/ui/src/components/bible-reader.stories.tsx
+++ b/packages/ui/src/components/bible-reader.stories.tsx
@@ -42,10 +42,10 @@ const meta: Meta<typeof BibleReader.Root> = {
       control: { type: 'range', min: 8, max: 24, step: 1 },
       description: 'Font size in pixels',
     },
-    lineHeight: {
+    lineSpacing: {
       control: 'select',
-      options: [1.4, 1.6, 1.8, 2.0],
-      description: 'Line height multiplier',
+      options: [1.45, 1.7, 2.0],
+      description: 'Line spacing (line-height multiplier)',
     },
     fontFamily: {
       control: 'select',
@@ -72,7 +72,7 @@ export const Default: Story = {
   tags: ['integration'],
   args: {
     defaultVersionId: 111,
-    lineHeight: 1.6,
+    lineSpacing: 1.7,
     fontFamily: "'Inter', sans-serif",
     showVerseNumbers: true,
   },
@@ -146,7 +146,7 @@ export const DarkTheme: Story = {
   args: {
     defaultVersionId: 111,
     fontSize: 16,
-    lineHeight: 1.6,
+    lineSpacing: 1.7,
     fontFamily: "'Inter', sans-serif",
     showVerseNumbers: true,
   },
@@ -171,7 +171,7 @@ export const CustomStyling: Story = {
   args: {
     defaultVersionId: 111,
     fontSize: 18,
-    lineHeight: 2.0,
+    lineSpacing: 2.0,
     fontFamily: "'Nunito Sans', sans-serif",
     showVerseNumbers: false,
   },
@@ -201,7 +201,7 @@ export const FontSizeOutOfRange: Story = {
   args: {
     defaultVersionId: 111,
     fontSize: 28,
-    lineHeight: 2.0,
+    lineSpacing: 2.0,
     fontFamily: "'Nunito Sans', sans-serif",
     showVerseNumbers: false,
   },

--- a/packages/ui/src/components/bible-reader.stories.tsx
+++ b/packages/ui/src/components/bible-reader.stories.tsx
@@ -1,11 +1,11 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
-import { expect, fn, screen, spyOn, userEvent, waitFor } from 'storybook/test';
-import { http, HttpResponse, delay } from 'msw';
-import { BibleReader } from './bible-reader';
-import { setupAuthenticatedUser } from '../test/utils';
 import { INTER_FONT, SOURCE_SERIF_FONT } from '@/lib/verse-html-utils';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { delay, http, HttpResponse } from 'msw';
+import { expect, fn, screen, spyOn, userEvent, waitFor } from 'storybook/test';
 import mockBibles from '../test/mock-data/bibles.json';
 import { globalHandlers } from '../test/mocks/handlers';
+import { setupAuthenticatedUser } from '../test/utils';
+import { BibleReader } from './bible-reader';
 
 let signInMock: ReturnType<typeof fn>;
 
@@ -107,7 +107,7 @@ export const Default: Story = {
     });
 
     const fontButtons = screen.getAllByRole('button', { name: /font/i });
-    await expect(fontButtons.length).toBe(2);
+    await expect(fontButtons.length).toBe(4);
 
     const decreaseFontButton = screen.getByTestId('decrease-font-size');
     const increaseFontButton = screen.getByTestId('increase-font-size');

--- a/packages/ui/src/components/bible-reader.test.tsx
+++ b/packages/ui/src/components/bible-reader.test.tsx
@@ -18,7 +18,9 @@ import {
   useVersions,
 } from '@youversion/platform-react-hooks';
 import {
+  BIBLE_READER_SPACING,
   BibleReader,
+  changeBibleReaderLineSpacing,
   clampBibleReaderFontSize,
   createBibleThemeSettingsContentHandlers,
   nextBibleReaderFontSizeDown,
@@ -118,17 +120,34 @@ describe('BibleReader font helpers', () => {
     expect(nextBibleReaderFontSizeDown(18)).toBe(16);
     expect(nextBibleReaderFontSizeDown(12)).toBe(12);
   });
+
+  it('cycles line spacing DEFAULT -> LG -> SM -> DEFAULT', () => {
+    expect(changeBibleReaderLineSpacing(BIBLE_READER_SPACING.DEFAULT)).toBe(
+      BIBLE_READER_SPACING.LG,
+    );
+    expect(changeBibleReaderLineSpacing(BIBLE_READER_SPACING.LG)).toBe(BIBLE_READER_SPACING.SM);
+    expect(changeBibleReaderLineSpacing(BIBLE_READER_SPACING.SM)).toBe(
+      BIBLE_READER_SPACING.DEFAULT,
+    );
+    // Any unknown value falls back to DEFAULT
+    expect(changeBibleReaderLineSpacing(99)).toBe(BIBLE_READER_SPACING.DEFAULT);
+  });
 });
 
 describe('createBibleThemeSettingsContentHandlers', () => {
-  it('updates font size and family via host-owned setters', () => {
+  it('updates font size, family, and line spacing via host-owned setters', () => {
     let fontSize = 16;
     let fontFamily: FontFamily = SOURCE_SERIF_FONT;
+    let lineSpacing = BIBLE_READER_SPACING.DEFAULT;
     const setFontSize = vi.fn((n: number) => {
       fontSize = n;
     });
     const setFontFamily = vi.fn((f: FontFamily) => {
       fontFamily = f;
+    });
+    const setLineSpacing = vi.fn((n: number) => {
+      lineSpacing = n;
+      return n;
     });
 
     const handlers = createBibleThemeSettingsContentHandlers({
@@ -136,6 +155,8 @@ describe('createBibleThemeSettingsContentHandlers', () => {
       getFontFamily: () => fontFamily,
       setFontSize,
       setFontFamily,
+      getLineSpacing: () => lineSpacing,
+      setLineSpacing,
     });
 
     handlers.onFontIncreased();
@@ -146,6 +167,14 @@ describe('createBibleThemeSettingsContentHandlers', () => {
 
     handlers.onFontSelected(INTER_FONT);
     expect(setFontFamily).toHaveBeenCalledWith(INTER_FONT);
+
+    // Cycles DEFAULT -> LG -> SM -> DEFAULT
+    handlers.onChangeLineSpacing();
+    expect(setLineSpacing).toHaveBeenLastCalledWith(BIBLE_READER_SPACING.LG);
+    handlers.onChangeLineSpacing();
+    expect(setLineSpacing).toHaveBeenLastCalledWith(BIBLE_READER_SPACING.SM);
+    handlers.onChangeLineSpacing();
+    expect(setLineSpacing).toHaveBeenLastCalledWith(BIBLE_READER_SPACING.DEFAULT);
   });
 });
 
@@ -180,6 +209,50 @@ describe('BibleReader theme settings', () => {
     });
   });
 
+  it('cycles line spacing and resizes the line-spacing button icon gap on click', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <BibleReader.Root defaultVersionId={3034} defaultBook="JHN" defaultChapter="1">
+        <BibleReader.Toolbar />
+      </BibleReader.Root>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Settings' }));
+    expect(await screen.findByText('Reader Settings')).toBeInTheDocument();
+
+    // The icon's gap container is the only <div> inside the line-spacing button.
+    const gapClasses = () =>
+      (screen.getByTestId('line-spacing').querySelector('div')?.className ?? '').split(/\s+/);
+
+    // Starts at DEFAULT spacing (1.7) -> medium gap.
+    await waitFor(() => {
+      expect(localStorage.getItem('youversion-platform:reader:line-spacing')).toBe('1.7');
+    });
+    expect(gapClasses()).toContain('yv:gap-1.5');
+
+    // DEFAULT -> LG (2.0) -> widest gap.
+    await user.click(screen.getByTestId('line-spacing'));
+    await waitFor(() => {
+      expect(localStorage.getItem('youversion-platform:reader:line-spacing')).toBe('2');
+    });
+    expect(gapClasses()).toContain('yv:gap-2');
+
+    // LG -> SM (1.45) -> tightest gap.
+    await user.click(screen.getByTestId('line-spacing'));
+    await waitFor(() => {
+      expect(localStorage.getItem('youversion-platform:reader:line-spacing')).toBe('1.45');
+    });
+    expect(gapClasses()).toContain('yv:gap-1');
+
+    // SM -> DEFAULT (1.7) -> back to medium gap.
+    await user.click(screen.getByTestId('line-spacing'));
+    await waitFor(() => {
+      expect(localStorage.getItem('youversion-platform:reader:line-spacing')).toBe('1.7');
+    });
+    expect(gapClasses()).toContain('yv:gap-1.5');
+  });
+
   it('calls onOpenBibleThemeSettings with a serializable snapshot and skips popover content', async () => {
     const user = userEvent.setup();
     const onOpenBibleThemeSettings = vi.fn();
@@ -205,6 +278,7 @@ describe('BibleReader theme settings', () => {
     expect(snapshot).toEqual({
       fontSize: 18,
       fontFamily: INTER_FONT,
+      lineSpacing: BIBLE_READER_SPACING.DEFAULT,
       minFontSize: 12,
       maxFontSize: 20,
     });

--- a/packages/ui/src/components/bible-reader.test.tsx
+++ b/packages/ui/src/components/bible-reader.test.tsx
@@ -138,7 +138,7 @@ describe('createBibleThemeSettingsContentHandlers', () => {
   it('updates font size, family, and line spacing via host-owned setters', () => {
     let fontSize = 16;
     let fontFamily: FontFamily = SOURCE_SERIF_FONT;
-    let lineSpacing = BIBLE_READER_SPACING.DEFAULT;
+    let lineSpacing: number = BIBLE_READER_SPACING.DEFAULT;
     const setFontSize = vi.fn((n: number) => {
       fontSize = n;
     });

--- a/packages/ui/src/components/bible-reader.tsx
+++ b/packages/ui/src/components/bible-reader.tsx
@@ -1,8 +1,12 @@
 'use client';
 
-import { useTranslation } from 'react-i18next';
 import i18n from '@/i18n';
+import { useDelayedLoading } from '@/lib/use-delayed-loading';
+import { cn } from '@/lib/utils';
+import { INTER_FONT, SOURCE_SERIF_FONT, type FontFamily } from '@/lib/verse-html-utils';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
+import type { BibleBook } from '@youversion/platform-core';
+import { DEFAULT_LICENSE_FREE_BIBLE_VERSION, getAdjacentChapter } from '@youversion/platform-core';
 import {
   useBooks,
   usePassage,
@@ -11,32 +15,28 @@ import {
   useYVAuth,
   YouVersionContext,
 } from '@youversion/platform-react-hooks';
-import type { BibleBook } from '@youversion/platform-core';
-import {
+import React, {
   createContext,
-  type ReactNode,
   useContext,
   useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
   type ReactElement,
+  type ReactNode,
 } from 'react';
-import { cn } from '@/lib/utils';
-import { useDelayedLoading } from '@/lib/use-delayed-loading';
-import { DEFAULT_LICENSE_FREE_BIBLE_VERSION, getAdjacentChapter } from '@youversion/platform-core';
+import { useTranslation } from 'react-i18next';
 import { BibleChapterPicker, type BibleChapterPickerPressData } from './bible-chapter-picker';
 import { BibleVersionPicker, type BibleVersionPickerPressData } from './bible-version-picker';
+import { ChevronLeftIcon } from './icons/chevron-left';
+import { ChevronRightIcon } from './icons/chevron-right';
 import { GearIcon } from './icons/gear';
 import { InfoIcon } from './icons/info';
 import { LoaderIcon } from './icons/loader';
 import { PersonIcon } from './icons/person';
 import { Button } from './ui/button';
-import { Popover, PopoverContent, PopoverTrigger, PopoverClose } from './ui/popover';
+import { Popover, PopoverClose, PopoverContent, PopoverTrigger } from './ui/popover';
 import { BibleTextView, type FootnoteData } from './verse';
-import { INTER_FONT, SOURCE_SERIF_FONT, type FontFamily } from '@/lib/verse-html-utils';
-import { ChevronLeftIcon } from './icons/chevron-left';
-import { ChevronRightIcon } from './icons/chevron-right';
 
 type BibleReaderContextType = {
   book: string;
@@ -51,7 +51,8 @@ type BibleReaderContextType = {
   setCurrentFontFamily: React.Dispatch<React.SetStateAction<FontFamily>>;
   currentFontSize: number;
   setCurrentFontSize: React.Dispatch<React.SetStateAction<number>>;
-  lineHeight?: number;
+  currentLineSpacing: number;
+  setCurrentLineSpacing: React.Dispatch<React.SetStateAction<number>>;
   showVerseNumbers: boolean;
   background: 'light' | 'dark';
   onFootnotePress?: (data: FootnoteData) => void;
@@ -87,7 +88,9 @@ export type RootProps = {
   fontFamily?: FontFamily;
   defaultFontFamily?: FontFamily;
   onFontFamilyChange?: (fontFamily: FontFamily) => void;
-  lineHeight?: number;
+  lineSpacing?: number;
+  defaultLineSpacing?: number;
+  onChangeLineSpacing?: (size: number) => void;
   showVerseNumbers?: boolean;
   background?: 'light' | 'dark';
   onFootnotePress?: (data: FootnoteData) => void;
@@ -105,6 +108,12 @@ export const BIBLE_READER_FONT = {
   STEP: 2,
 } as const;
 
+export const BIBLE_READER_SPACING = {
+  SM: 1.45,
+  DEFAULT: 1.7,
+  LG: 2.0,
+} as const;
+
 const MIN_FONT_SIZE = BIBLE_READER_FONT.MIN;
 const MAX_FONT_SIZE = BIBLE_READER_FONT.MAX;
 const DEFAULT_FONT_SIZE = BIBLE_READER_FONT.DEFAULT;
@@ -113,6 +122,7 @@ const FONT_SIZE_STEP = BIBLE_READER_FONT.STEP;
 export type BibleThemeSettingsValues = {
   fontSize: number;
   fontFamily: FontFamily;
+  lineSpacing: number;
 };
 
 export type BibleThemeSettingsSnapshot = BibleThemeSettingsValues & {
@@ -124,9 +134,11 @@ export type BibleThemeSettingsContentProps = {
   theme: 'light' | 'dark';
   fontSize: number;
   fontFamily: FontFamily;
+  lineSpacing: number;
   onFontSelected: (fontFamily: FontFamily) => void;
   onFontIncreased: () => void;
   onFontDecreased: () => void;
+  onChangeLineSpacing: () => void;
 };
 
 export function clampBibleReaderFontSize(fontSize: number): number {
@@ -148,6 +160,28 @@ export function nextBibleReaderFontSizeDown(current: number): number {
   return clampBibleReaderFontSize(current - FONT_SIZE_STEP);
 }
 
+export function changeBibleReaderLineSpacing(current: number): number {
+  switch (current) {
+    case BIBLE_READER_SPACING.DEFAULT:
+      return BIBLE_READER_SPACING.LG;
+    case BIBLE_READER_SPACING.LG:
+      return BIBLE_READER_SPACING.SM;
+    default:
+      return BIBLE_READER_SPACING.DEFAULT;
+  }
+}
+
+function lineSpacingButtonGapClass(lineSpacing: number): string {
+  switch (lineSpacing) {
+    case BIBLE_READER_SPACING.SM:
+      return 'yv:gap-1';
+    case BIBLE_READER_SPACING.LG:
+      return 'yv:gap-2';
+    default:
+      return 'yv:gap-1.5';
+  }
+}
+
 /**
  * Builds the three handler props for {@link BibleThemeSettingsContent} from host-owned font state.
  * Use this on the same side as `setFontSize` / `setFontFamily` (e.g. React Native before passing
@@ -159,7 +193,12 @@ export function createBibleThemeSettingsContentHandlers(options: {
   getFontFamily: () => FontFamily;
   setFontSize: (size: number) => void;
   setFontFamily: (fontFamily: FontFamily) => void;
-}): Pick<BibleThemeSettingsContentProps, 'onFontIncreased' | 'onFontDecreased' | 'onFontSelected'> {
+  getLineSpacing: () => number;
+  setLineSpacing: (size: number) => void;
+}): Pick<
+  BibleThemeSettingsContentProps,
+  'onFontIncreased' | 'onFontDecreased' | 'onFontSelected' | 'onChangeLineSpacing'
+> {
   return {
     onFontIncreased: () => {
       options.setFontSize(nextBibleReaderFontSizeUp(options.getFontSize()));
@@ -169,6 +208,9 @@ export function createBibleThemeSettingsContentHandlers(options: {
     },
     onFontSelected: (fontFamily) => {
       options.setFontFamily(fontFamily);
+    },
+    onChangeLineSpacing: () => {
+      options.setLineSpacing(changeBibleReaderLineSpacing(options.getLineSpacing()));
     },
   };
 }
@@ -189,7 +231,9 @@ function Root({
   fontFamily: fontFamilyProp,
   defaultFontFamily = SOURCE_SERIF_FONT,
   onFontFamilyChange,
-  lineHeight,
+  lineSpacing: lineSpacingProp,
+  defaultLineSpacing = BIBLE_READER_SPACING.DEFAULT,
+  onChangeLineSpacing,
   showVerseNumbers = true,
   background,
   onFootnotePress,
@@ -224,6 +268,7 @@ function Root({
 
   const isFontSizeControlled = onFontSizeChange !== undefined;
   const isFontFamilyControlled = onFontFamilyChange !== undefined;
+  const isLineSpacingControlled = onChangeLineSpacing !== undefined;
 
   const defaultPropFontSize = normalizeReaderFontSizeForInitialization(
     fontSizeProp ?? validatedDefaultFontSize,
@@ -241,6 +286,12 @@ function Root({
     prop: isFontFamilyControlled ? fontFamilyProp : undefined,
     defaultProp: defaultPropFontFamily,
     onChange: onFontFamilyChange,
+  });
+
+  const [currentLineSpacing, setCurrentLineSpacing] = useControllableState({
+    prop: isLineSpacingControlled ? lineSpacingProp : undefined,
+    defaultProp: defaultLineSpacing,
+    onChange: onChangeLineSpacing,
   });
 
   const didHydrateThemeSettingsRef = useRef(false);
@@ -265,7 +316,24 @@ function Root({
         setCurrentFontFamily(savedFontFamily);
       }
     }
-  }, [isFontFamilyControlled, isFontSizeControlled, setCurrentFontFamily, setCurrentFontSize]);
+
+    if (!isLineSpacingControlled) {
+      const savedLineSpacing = localStorage.getItem('youversion-platform:reader:line-spacing');
+      if (savedLineSpacing) {
+        const parsed = parseFloat(savedLineSpacing);
+        if (Object.values(BIBLE_READER_SPACING).some((spacing) => spacing === parsed)) {
+          setCurrentLineSpacing(parsed);
+        }
+      }
+    }
+  }, [
+    isFontFamilyControlled,
+    isFontSizeControlled,
+    setCurrentFontFamily,
+    setCurrentFontSize,
+    isLineSpacingControlled,
+    setCurrentLineSpacing,
+  ]);
 
   useEffect(() => {
     if (!isFontSizeControlled) {
@@ -278,6 +346,15 @@ function Root({
       localStorage.setItem('youversion-platform:reader:font-family', currentFontFamily);
     }
   }, [currentFontFamily, isFontFamilyControlled]);
+
+  useEffect(() => {
+    if (!isLineSpacingControlled) {
+      localStorage.setItem(
+        'youversion-platform:reader:line-spacing',
+        currentLineSpacing.toString(),
+      );
+    }
+  }, [currentLineSpacing, isLineSpacingControlled]);
 
   const providerTheme = useTheme();
   const theme = background || providerTheme;
@@ -298,7 +375,8 @@ function Root({
     setCurrentFontFamily,
     currentFontSize,
     setCurrentFontSize,
-    lineHeight,
+    currentLineSpacing,
+    setCurrentLineSpacing,
     showVerseNumbers,
     background: theme,
     onFootnotePress,
@@ -331,7 +409,7 @@ function Content() {
     booksData,
     currentFontSize,
     currentFontFamily,
-    lineHeight,
+    currentLineSpacing,
     showVerseNumbers,
     onFootnotePress,
   } = useBibleReaderContext();
@@ -416,7 +494,7 @@ function Content() {
               versionId={versionId}
               fontFamily={currentFontFamily}
               fontSize={currentFontSize}
-              lineHeight={lineHeight}
+              lineHeight={currentLineSpacing}
               showVerseNumbers={showVerseNumbers}
               theme={background}
               onFootnotePress={onFootnotePress}
@@ -545,35 +623,54 @@ export function BibleThemeSettingsContent({
   theme,
   fontSize,
   fontFamily,
+  lineSpacing,
   onFontSelected,
   onFontIncreased,
   onFontDecreased,
+  onChangeLineSpacing,
 }: BibleThemeSettingsContentProps): ReactElement {
   const { t } = useTranslation(undefined, { i18n });
   return (
     <div data-yv-sdk data-yv-theme={theme} className="yv:flex yv:flex-col yv:gap-4 yv:p-4">
-      <div className="yv:grid yv:grid-cols-2">
+      <div className="yv:flex yv:justify-between yv:items-stretch yv:gap-4">
+        <div className="yv:flex yv:flex-1">
+          <Button
+            className="yv:flex-1 yv:text-xs yv:text-black yv:dark:text-muted-foreground yv:rounded-l-[8px] yv:rounded-r-none yv:border yv:border-white yv:dark:border-border yv:h-auto yv:py-2"
+            onClick={onFontDecreased}
+            size="lg"
+            variant="secondary"
+            data-testid="decrease-font-size"
+            disabled={fontSize <= MIN_FONT_SIZE}
+            aria-disabled={fontSize <= MIN_FONT_SIZE}
+            aria-label="Decrease font size"
+          >
+            A
+          </Button>
+          <Button
+            className="yv:flex-1 yv:text-3xl yv:text-black yv:dark:text-muted-foreground yv:rounded-r-[8px] yv:rounded-l-none yv:border yv:border-white yv:dark:border-border yv:h-auto yv:py-2"
+            onClick={onFontIncreased}
+            size="lg"
+            variant="secondary"
+            data-testid="increase-font-size"
+            disabled={fontSize >= MAX_FONT_SIZE}
+            aria-disabled={fontSize >= MAX_FONT_SIZE}
+            aria-label="Increase font size"
+          >
+            A
+          </Button>
+        </div>
         <Button
-          className="yv:text-xs yv:text-black yv:dark:text-muted-foreground yv:rounded-l-[8px] yv:rounded-r-none yv:border yv:border-white yv:dark:border-border yv:h-auto yv:py-2"
-          onClick={onFontDecreased}
-          size="lg"
+          className="yv:h-auto yv:border yv:border-white yv:dark:border-border yv:rounded-[8px]"
           variant="secondary"
-          data-testid="decrease-font-size"
-          disabled={fontSize <= MIN_FONT_SIZE}
-          aria-disabled={fontSize <= MIN_FONT_SIZE}
+          data-testid="line-spacing"
+          onClick={onChangeLineSpacing}
+          aria-label="Change line spacing"
         >
-          A
-        </Button>
-        <Button
-          className="yv:text-3xl yv:text-black yv:dark:text-muted-foreground yv:rounded-r-[8px] yv:rounded-l-none yv:border yv:border-white yv:dark:border-border yv:h-auto yv:py-2"
-          onClick={onFontIncreased}
-          size="lg"
-          variant="secondary"
-          data-testid="increase-font-size"
-          disabled={fontSize >= MAX_FONT_SIZE}
-          aria-disabled={fontSize >= MAX_FONT_SIZE}
-        >
-          A
+          <div className={cn('yv:flex yv:flex-col', lineSpacingButtonGapClass(lineSpacing))}>
+            <span className="yv:h-0.5 yv:w-8 yv:bg-current"></span>
+            <span className="yv:h-0.5 yv:w-8 yv:bg-current"></span>
+            <span className="yv:h-0.5 yv:w-8 yv:bg-current"></span>
+          </div>
         </Button>
       </div>
 
@@ -653,6 +750,8 @@ function Toolbar({ border = 'top', onOpenBibleThemeSettings }: BibleReaderToolba
     setCurrentFontFamily,
     currentFontSize,
     setCurrentFontSize,
+    currentLineSpacing,
+    setCurrentLineSpacing,
     background,
     onChapterPickerPress,
     onVersionPickerPress,
@@ -661,11 +760,13 @@ function Toolbar({ border = 'top', onOpenBibleThemeSettings }: BibleReaderToolba
   const themesSettingsValuesRef = useRef<BibleThemeSettingsValues>({
     fontSize: currentFontSize,
     fontFamily: currentFontFamily,
+    lineSpacing: currentLineSpacing,
   });
 
   themesSettingsValuesRef.current = {
     fontSize: currentFontSize,
     fontFamily: currentFontFamily,
+    lineSpacing: currentLineSpacing,
   };
 
   const applyThemeSettings = (
@@ -674,11 +775,13 @@ function Toolbar({ border = 'top', onOpenBibleThemeSettings }: BibleReaderToolba
     const nextThemeSettings = {
       fontSize: clampBibleReaderFontSize(themeSettings.fontSize),
       fontFamily: themeSettings.fontFamily,
+      lineSpacing: themeSettings.lineSpacing,
     };
 
     themesSettingsValuesRef.current = nextThemeSettings;
     setCurrentFontSize(nextThemeSettings.fontSize);
     setCurrentFontFamily(nextThemeSettings.fontFamily);
+    setCurrentLineSpacing(nextThemeSettings.lineSpacing);
 
     return nextThemeSettings;
   };
@@ -703,6 +806,14 @@ function Toolbar({ border = 'top', onOpenBibleThemeSettings }: BibleReaderToolba
     return applyThemeSettings({
       ...themesSettingsValuesRef.current,
       fontFamily,
+    });
+  };
+
+  const handleLineSpacingChange = (): BibleThemeSettingsValues => {
+    const settings = themesSettingsValuesRef.current;
+    return applyThemeSettings({
+      ...settings,
+      lineSpacing: changeBibleReaderLineSpacing(settings.lineSpacing),
     });
   };
 
@@ -861,9 +972,11 @@ function Toolbar({ border = 'top', onOpenBibleThemeSettings }: BibleReaderToolba
                 theme={background}
                 fontSize={currentFontSize}
                 fontFamily={currentFontFamily}
+                lineSpacing={currentLineSpacing}
                 onFontDecreased={handleFontDecreased}
                 onFontIncreased={handleFontIncreased}
                 onFontSelected={handleFontSelected}
+                onChangeLineSpacing={handleLineSpacingChange}
               />
             </PopoverContent>
           </Popover>

--- a/packages/ui/src/components/bible-reader.tsx
+++ b/packages/ui/src/components/bible-reader.tsx
@@ -677,9 +677,9 @@ export function BibleThemeSettingsContent({
           aria-label="Change line spacing"
         >
           <div className={cn('yv:flex yv:flex-col', lineSpacingButtonGapClass(lineSpacing))}>
-            <span className="yv:h-0.5 yv:w-8 yv:bg-current"></span>
-            <span className="yv:h-0.5 yv:w-8 yv:bg-current"></span>
-            <span className="yv:h-0.5 yv:w-8 yv:bg-current"></span>
+            <span className="yv:h-0.5 yv:w-8 yv:bg-black yv:dark:bg-current"></span>
+            <span className="yv:h-0.5 yv:w-8 yv:bg-black yv:dark:bg-current"></span>
+            <span className="yv:h-0.5 yv:w-8 yv:bg-black yv:dark:bg-current"></span>
           </div>
         </Button>
       </div>

--- a/packages/ui/src/components/bible-reader.tsx
+++ b/packages/ui/src/components/bible-reader.tsx
@@ -91,6 +91,12 @@ export type RootProps = {
   lineSpacing?: number;
   defaultLineSpacing?: number;
   onChangeLineSpacing?: (size: number) => void;
+  /**
+   * @deprecated Use `defaultLineSpacing` (uncontrolled) or `lineSpacing` +
+   * `onChangeLineSpacing` (controlled) instead. When provided, this is used as
+   * the initial line spacing. Will be removed in the next major version.
+   */
+  lineHeight?: number;
   showVerseNumbers?: boolean;
   background?: 'light' | 'dark';
   onFootnotePress?: (data: FootnoteData) => void;
@@ -232,8 +238,9 @@ function Root({
   defaultFontFamily = SOURCE_SERIF_FONT,
   onFontFamilyChange,
   lineSpacing: lineSpacingProp,
-  defaultLineSpacing = BIBLE_READER_SPACING.DEFAULT,
+  defaultLineSpacing,
   onChangeLineSpacing,
+  lineHeight,
   showVerseNumbers = true,
   background,
   onFootnotePress,
@@ -288,9 +295,12 @@ function Root({
     onChange: onFontFamilyChange,
   });
 
+  const resolvedDefaultLineSpacing =
+    defaultLineSpacing ?? lineHeight ?? BIBLE_READER_SPACING.DEFAULT;
+
   const [currentLineSpacing, setCurrentLineSpacing] = useControllableState({
     prop: isLineSpacingControlled ? lineSpacingProp : undefined,
-    defaultProp: defaultLineSpacing,
+    defaultProp: resolvedDefaultLineSpacing,
     onChange: onChangeLineSpacing,
   });
 


### PR DESCRIPTION
- Add a line-spacing button to BibleReader theme settings that cycles through three presets (SM 1.45, DEFAULT 1.7, LG 2.0) on click
  - Manage line spacing as controllable state on BibleReader.Root via lineSpacing/defaultLineSpacing/onChangeLineSpacing, with localStorage persistence under youversion-platform:reader:line-spacing
  - Feed the selected spacing into BibleTextView and include it in the BibleThemeSettingsSnapshot/values for native (Expo DOM) hosts
  - Export BIBLE_READER_SPACING and changeBibleReaderLineSpacing, and add an onChangeLineSpacing handler to createBibleThemeSettingsContentHandlers
  - Resize the line-spacing button icon's bar gap to preview the current spacing (tighter bars for less spacing, wider for more)
  - Update stories to expose a lineSpacing control in place of lineHeight
  - Add unit and integration tests covering the spacing cycle and the button icon gap changes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a cycling line-spacing button to the BibleReader theme settings panel that rotates through three presets (SM 1.45, DEFAULT 1.7, LG 2.0). The implementation follows the established controlled/uncontrolled pattern already used for font size and family, adds localStorage persistence, and updates both unit and integration tests.

- `BibleReader.Root` gains `lineSpacing`/`defaultLineSpacing`/`onChangeLineSpacing` props; the existing `lineHeight` prop is deprecated but honored as a fallback initial value, preserving backwards compatibility.
- `BIBLE_READER_SPACING`, `changeBibleReaderLineSpacing`, and `onChangeLineSpacing` are exported for native (Expo DOM) host use; the line-spacing button icon dynamically reflects the current preset via a Tailwind gap class switch.
- The localStorage hydration path now validates against `Object.values(BIBLE_READER_SPACING)` before applying a stored value, preventing stale or tampered entries from producing unsupported spacing.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the feature is self-contained, follows the established controlled/uncontrolled pattern, and the localStorage hydration now validates against known presets.

The new line-spacing state, persistence, and cycling logic mirror the existing font-size and font-family implementations without introducing new failure modes. The localStorage guard added in this PR correctly rejects out-of-range values, and all three cycling branches are covered by unit and integration tests.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/bible-reader.tsx | Core implementation: adds line-spacing state, localStorage persistence, cycling helper, button icon gap, and threads values through context/toolbar/settings panel; follows existing font-size/family patterns consistently. |
| packages/ui/src/components/bible-reader.test.tsx | Adds unit tests for the full cycle and unknown-value fallback, an integration test verifying localStorage writes and icon gap classes, and a snapshot assertion for the new lineSpacing field. |
| packages/ui/src/components/bible-reader.stories.tsx | Replaces deprecated lineHeight story arg with lineSpacing, updates options/defaults, and corrects the font-button count assertion now that size buttons carry explicit aria-labels. |
| .changeset/nine-gifts-check.md | Accurate minor-version changeset entry describing the new feature and deprecation note. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[BibleReader.Root mounts] --> B{isLineSpacingControlled?}
    B -- yes --> C[useControllableState\nprop = lineSpacingProp]
    B -- no --> D[useControllableState\nprop = undefined\ndefaultProp = defaultLineSpacing ?? lineHeight ?? DEFAULT]

    D --> E[useLayoutEffect\nhydrate from localStorage]
    E --> F{saved value in\nBIBLE_READER_SPACING?}
    F -- yes --> G[setCurrentLineSpacing\nsaved value]
    F -- no --> H[keep default]

    G & H & C --> I[currentLineSpacing in context]

    I --> J[BibleTextView\nlineHeight=currentLineSpacing]
    I --> K[BibleThemeSettingsContent\nlineSpacing=currentLineSpacing]
    I --> L[lineSpacingButtonGapClass\ngap-1 / gap-1.5 / gap-2]

    K --> M[User clicks line-spacing button]
    M --> N[handleLineSpacingChange\nchangeBibleReaderLineSpacing]
    N --> O{current spacing}
    O -- DEFAULT 1.7 --> P[LG 2.0]
    O -- LG 2.0 --> Q[SM 1.45]
    O -- SM / other --> R[DEFAULT 1.7]

    P & Q & R --> S[applyThemeSettings\nsetCurrentLineSpacing]
    S -- uncontrolled --> T[useEffect\nlocalStorage.setItem]
    S -- controlled --> U[onChangeLineSpacing callback\nto host]
```

<sub>Reviews (6): Last reviewed commit: ["Merge branch &#39;main&#39; into bm/YPE-3006-rea..."](https://github.com/youversion/platform-sdk-react/commit/3569574a86bd0fc3e15e2f246dd21d03f46d3dc0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36521759)</sub>

<!-- /greptile_comment -->