### PR TITLE
YPE-2923: feat(ui): Move VOTD reference under label and hide verse numbers

### DIFF
--- a/.changeset/votd-reference-and-verse-numbers.md
+++ b/.changeset/votd-reference-and-verse-numbers.md
@@ -1,0 +1,5 @@
+---
+'@youversion/platform-react-ui': patch
+---
+
+VerseOfTheDay now shows the Bible reference directly under the "Verse of the Day" label in foreground text instead of below the verse body. BibleCard and VerseOfTheDay no longer display inline verse numbers in passage text.

--- a/packages/ui/src/components/bible-card.test.tsx
+++ b/packages/ui/src/components/bible-card.test.tsx
@@ -140,6 +140,20 @@ describe('BibleCard - Delayed spinner', () => {
     expect(contentGroup).toHaveClass('yv:card-content');
     expect(bibleTextView).not.toHaveClass('yv:max-w-[600px]');
   });
+
+  it('should hide inline verse numbers in the bible renderer', () => {
+    vi.mocked(usePassage).mockReturnValue({
+      passage: mockPassage,
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    const { container } = render(<BibleCard reference="JHN.3.16" versionId={3034} />);
+    const bibleRenderer = container.querySelector('[data-slot="yv-bible-renderer"]');
+
+    expect(bibleRenderer).toHaveAttribute('data-show-verse-numbers', 'false');
+  });
 });
 
 describe('BibleCard - onFootnotePress callback', () => {

--- a/packages/ui/src/components/bible-card.tsx
+++ b/packages/ui/src/components/bible-card.tsx
@@ -184,6 +184,7 @@ export function BibleCard({
             fontFamily={SOURCE_SERIF_FONT}
             reference={reference}
             versionId={versionNum}
+            showVerseNumbers={false}
             passageState={{
               passage,
               loading: passageLoading,

--- a/packages/ui/src/components/verse-of-the-day.test.tsx
+++ b/packages/ui/src/components/verse-of-the-day.test.tsx
@@ -105,6 +105,30 @@ describe('VerseOfTheDay i18n integration', () => {
     expect(card).toHaveClass('yv:box-border');
     expect(contentGroup).toHaveClass('yv:card-content');
   });
+
+  it('renders the reference under the label in the header, not below the verse text', () => {
+    const { container } = render(<VerseOfTheDay />);
+    const reference = screen.getByText(MOCK_REFERENCE);
+    const bibleRenderer = container.querySelector('[data-slot="yv-bible-renderer"]');
+    const label = screen.getByText(en.verseOfTheDay);
+
+    expect(reference).toHaveClass('yv:text-black');
+    expect(reference).not.toHaveClass('yv:text-muted-foreground');
+    expect(
+      label.compareDocumentPosition(reference) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(bibleRenderer).not.toBeNull();
+    expect(
+      bibleRenderer!.compareDocumentPosition(reference) & Node.DOCUMENT_POSITION_PRECEDING,
+    ).toBeTruthy();
+  });
+
+  it('hides inline verse numbers in the bible renderer', () => {
+    const { container } = render(<VerseOfTheDay />);
+    const bibleRenderer = container.querySelector('[data-slot="yv-bible-renderer"]');
+
+    expect(bibleRenderer).toHaveAttribute('data-show-verse-numbers', 'false');
+  });
 });
 
 describe('VerseOfTheDay - share', () => {

--- a/packages/ui/src/components/verse-of-the-day.tsx
+++ b/packages/ui/src/components/verse-of-the-day.tsx
@@ -191,7 +191,7 @@ export function VerseOfTheDay({
               <Votd className="yv:shrink-0 yv:h-10 yv:w-10" />
             </div>
           ) : null}
-          <div className="yv:grow yv:grid">
+          <div className="yv:grow yv:flex yv:flex-col">
             <p
               className={
                 'trim-both yv:line-clamp-1 yv:text-muted-foreground yv:uppercase yv:text-xs yv:font-medium yv:select-none'
@@ -199,6 +199,11 @@ export function VerseOfTheDay({
             >
               {t('verseOfTheDay')}
             </p>
+            {referenceText && !errorPassage && !errorVerseOfTheDay ? (
+              <p className="yv:text-black yv:dark:text-white yv:font-medium yv:text-sm">
+                {referenceText}
+              </p>
+            ) : null}
           </div>
           {showShareButton ? (
             <div
@@ -232,27 +237,20 @@ export function VerseOfTheDay({
               />
             </div>
           ) : (
-            <div className="yv:flex yv:flex-col yv:gap-2">
-              <BibleTextView
-                ref={verseRef}
-                theme={theme}
-                reference={data?.passage_id || ''}
-                versionId={versionId}
-                fontSize={size === 'default' ? 16 : 20}
-                fontFamily={size === 'default' ? 'var(--yv-font-sans)' : 'var(--yv-font-serif)'}
-                passageState={{
-                  passage,
-                  loading: isLoading,
-                  error: errorPassage || errorVerseOfTheDay || null,
-                }}
-              />
-
-              {errorPassage || errorVerseOfTheDay ? null : (
-                <p className="yv:text-muted-foreground yv:font-medium yv:text-sm yv:mt-3">
-                  {referenceText}
-                </p>
-              )}
-            </div>
+            <BibleTextView
+              ref={verseRef}
+              theme={theme}
+              reference={data?.passage_id || ''}
+              versionId={versionId}
+              fontSize={size === 'default' ? 16 : 20}
+              fontFamily={size === 'default' ? 'var(--yv-font-sans)' : 'var(--yv-font-serif)'}
+              showVerseNumbers={false}
+              passageState={{
+                passage,
+                loading: isLoading,
+                error: errorPassage || errorVerseOfTheDay || null,
+              }}
+            />
           )}
         </AnimatedHeight>
 


### PR DESCRIPTION
## Summary
- Move the Bible reference in `VerseOfTheDay` directly under the "Verse of the Day" label with foreground (black) text instead of below the verse body
- Hide inline verse numbers in `VerseOfTheDay` and `BibleCard` via `showVerseNumbers={false}`
- Add patch changeset for `@youversion/platform-react-ui`

Before
<img width="734" height="275" alt="Screenshot 2026-06-09 at 1 38 20 PM" src="https://github.com/user-attachments/assets/a1684f0c-65b0-4429-8f2e-e3569dc5ae2d" />

After
<img width="786" height="199" alt="Screenshot 2026-06-09 at 1 45 30 PM" src="https://github.com/user-attachments/assets/58334624-d1f2-4b1a-bc6a-72fcc2205876" />




## Test plan
- [x] Unit tests pass for `verse-of-the-day.test.tsx` and `bible-card.test.tsx`
- [ ] Storybook: `VerseOfTheDay` Default — reference appears under label, black in light mode
- [ ] Storybook: `BibleCard` Default (`LUK.1.39-45`) — no inline verse numbers in passage text
- [x] Verify share payload still includes verse text + reference line


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves the Bible reference in `VerseOfTheDay` from below the verse body into the header row, directly under the "Verse of the Day" label with foreground text, and adds `showVerseNumbers={false}` to both `VerseOfTheDay` and `BibleCard`.

- **`verse-of-the-day.tsx`**: Reference `<p>` relocated to the header flex column (under the label), styled `yv:text-black yv:dark:text-white`; the bottom reference paragraph and its wrapping `gap-2` div are removed; `showVerseNumbers={false}` added to `BibleTextView`.
- **`bible-card.tsx`**: Single-line addition of `showVerseNumbers={false}` to `BibleTextView`.
- **Tests**: Two new assertions for `VerseOfTheDay` (DOM position of reference, verse-number attribute) and one for `BibleCard` (verse-number attribute); share payload behaviour is unchanged and existing tests are preserved.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are narrowly scoped UI layout tweaks with no logic regressions.

The reference relocation is a pure structural change: the same `referenceText` string is rendered in a different place with a different class, and the share payload path (`buildVerseOfTheDayShareData`) continues to receive the string directly from state rather than from the DOM, so sharing is unaffected. The `showVerseNumbers={false}` additions are a single prop each. All three new tests are well-targeted and cover the specific DOM positions and attributes being changed.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/verse-of-the-day.tsx | Reference paragraph moved to header flex column under label; wrapping gap-2 div removed; showVerseNumbers={false} added — straightforward and correct. |
| packages/ui/src/components/bible-card.tsx | Single-line addition of showVerseNumbers={false} to BibleTextView; no other logic changes. |
| packages/ui/src/components/verse-of-the-day.test.tsx | Two new tests verify reference DOM position (using compareDocumentPosition) and data-show-verse-numbers attribute; existing share tests are unaffected. |
| packages/ui/src/components/bible-card.test.tsx | New test validates data-show-verse-numbers="false" attribute on the bible renderer element. |
| .changeset/votd-reference-and-verse-numbers.md | Patch-level changeset for @youversion/platform-react-ui; description matches the PR changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[VerseOfTheDay render] --> B{isLoading?}
    B -- yes --> C[Spinner in AnimatedHeight]
    B -- no --> D[BibleTextView\nshowVerseNumbers=false]

    A --> E[Header flex row]
    E --> F[Sun icon optional]
    E --> G[Text flex col]
    G --> H[Label: 'Verse of the Day'\nmuted / uppercase]
    G --> I{referenceText\n&& no errors?}
    I -- yes --> J[Reference p\ntext-black dark:text-white]
    I -- no --> K[Nothing]
    E --> L[Share button optional]

    D --> M[Verse body text\nno inline verse numbers]
```

<sub>Reviews (1): Last reviewed commit: ["chore: add changeset for VOTD reference ..."](https://github.com/youversion/platform-sdk-react/commit/c665e5e923da016a1504639260e4705dfcb7a13a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36525374)</sub>

<!-- /greptile_comment -->