### PR TITLE
feat(ui): match Book/Chapter picker typography to Figma

### DIFF
--- a/.changeset/bible-chapter-picker-typography.md
+++ b/.changeset/bible-chapter-picker-typography.md
@@ -1,0 +1,5 @@
+---
+"@youversion/platform-react-ui": minor
+---
+
+Match Book/Chapter picker typography to the Figma design. `BibleChapterPicker` now uses the Aktiv Grotesk App brand font (served from the YouVersion CDN): book rows render at 16px regular and bold when expanded, chapter/intro number buttons at 16px bold, and the search input at 16px. Falls back to the default sans font if the webfont fails to load.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -53,6 +53,18 @@ import '@youversion/platform-react-ui/styles.css';
 
 All component classes are prefixed with `yv:` to avoid collisions with your app's styles. Override design tokens with CSS variables on `[data-yv-sdk]` (see [Custom CSS variables](#custom-css-variables)).
 
+### Content Security Policy
+
+The SDK loads webfonts from external origins. If your app sets a strict `Content-Security-Policy`, allowlist these hosts so fonts aren't blocked (without them, components fall back to a system sans-serif):
+
+```
+font-src  https://fonts.gstatic.com https://storage.googleapis.com;
+style-src https://fonts.googleapis.com;
+```
+
+- `fonts.gstatic.com` / `fonts.googleapis.com` — Inter and Source Serif (base typography)
+- `storage.googleapis.com` — Aktiv Grotesk App, the brand font used by `BibleChapterPicker`
+
 ## Theming
 
 Set the theme via the `YouVersionProvider`'s `theme` prop. Defaults to `'light'`.

--- a/packages/ui/src/components/bible-chapter-picker.test.tsx
+++ b/packages/ui/src/components/bible-chapter-picker.test.tsx
@@ -196,3 +196,56 @@ describe('BibleChapterPicker.Content onSelect', () => {
     });
   });
 });
+
+describe('BibleChapterPicker - typography (matches Figma: Aktiv Grotesk App)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDefaultMocks();
+  });
+
+  function findAccordionTrigger(name: RegExp): HTMLElement | undefined {
+    return screen
+      .queryAllByRole('button', { name })
+      .find((button) => button.getAttribute('data-slot') === 'accordion-trigger');
+  }
+
+  // Render Content inline (onChapterPickerPress path renders children without the popover portal).
+  function renderContent() {
+    render(
+      <BibleChapterPicker.Root
+        versionId={3034}
+        book="GEN"
+        chapter="1"
+        onChapterPickerPress={vi.fn()}
+      >
+        <BibleChapterPicker.Trigger />
+        <BibleChapterPicker.Content />
+      </BibleChapterPicker.Root>,
+    );
+  }
+
+  it('book row uses Aktiv 16px, regular collapsed and bold when expanded', () => {
+    renderContent();
+
+    // GEN is the default-expanded book (book="GEN").
+    const genesisTrigger = findAccordionTrigger(/Genesis/i);
+    expect(genesisTrigger).toBeDefined();
+    expect(genesisTrigger).toHaveClass('yv:font-aktiv', 'yv:text-base', 'yv:font-normal');
+    expect(genesisTrigger).toHaveAttribute('data-state', 'open');
+    expect(genesisTrigger).toHaveClass('yv:data-[state=open]:font-bold');
+  });
+
+  it('chapter number buttons use Aktiv 16px bold', () => {
+    renderContent();
+
+    const chapterButton = screen.getByText('2').closest('button');
+    expect(chapterButton).not.toBeNull();
+    expect(chapterButton).toHaveClass('yv:font-aktiv', 'yv:text-base', 'yv:font-bold');
+  });
+
+  it('search input uses Aktiv 16px', () => {
+    renderContent();
+
+    expect(screen.getByPlaceholderText('Search')).toHaveClass('yv:font-aktiv', 'yv:text-base');
+  });
+});

--- a/packages/ui/src/components/bible-chapter-picker.tsx
+++ b/packages/ui/src/components/bible-chapter-picker.tsx
@@ -340,7 +340,9 @@ function Content({ onRequestClose, onSelect }: BibleChapterPickerContentProps) {
               id={bookItem.id}
               ref={(node) => registerBookElement(bookItem.id, node)}
             >
-              <AccordionTrigger className="yv:rounded-none">{bookItem.title}</AccordionTrigger>
+              <AccordionTrigger className="yv:rounded-none yv:font-aktiv yv:text-base yv:font-normal yv:leading-normal yv:text-foreground yv:data-[state=open]:font-bold">
+                {bookItem.title}
+              </AccordionTrigger>
               <AccordionContent>
                 {bookItem.chapters && bookItem.chapters.length > 0 ? (
                   <div className="yv:grid yv:grid-cols-5 yv:gap-2">
@@ -365,7 +367,7 @@ function Content({ onRequestClose, onSelect }: BibleChapterPickerContentProps) {
                           key={`${bookItem.id}-${chapterRef.passage_id}`}
                           variant="secondary"
                           size="icon"
-                          className="yv:aspect-square yv:w-full yv:h-full yv:flex yv:items-center yv:justify-center yv:rounded-[4px]"
+                          className="yv:aspect-square yv:w-full yv:h-full yv:flex yv:items-center yv:justify-center yv:rounded-[4px] yv:font-aktiv yv:text-base yv:font-bold yv:leading-none yv:text-foreground"
                           onClick={() =>
                             handleChapterButtonClick(bookItem.id, chapterRef.passage_id)
                           }
@@ -396,6 +398,7 @@ function Content({ onRequestClose, onSelect }: BibleChapterPickerContentProps) {
             tabIndex={1}
             type="text"
             placeholder={t('searchPlaceholder')}
+            className="yv:font-aktiv yv:text-base yv:leading-normal"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
           />

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -45,6 +45,25 @@ layer(yv-sdk-fonts);
 @import '@youversion/platform-core/browser/styles/bible-reader.css' layer(yv-sdk-bible-reader);
 @import 'tw-animate-css';
 
+/* Aktiv Grotesk App — YouVersion brand font (Book/Chapter picker). Served from prod CDN.
+   Declared at top level (not in a cascade layer) — @font-face is not subject to @layer. */
+@font-face {
+  font-family: 'Aktiv Grotesk App';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://storage.googleapis.com/cdn-youversion-com/fonts/aktiv-grotesk/AktivGrotesk_A_Rg.woff2')
+    format('woff2');
+}
+@font-face {
+  font-family: 'Aktiv Grotesk App';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url('https://storage.googleapis.com/cdn-youversion-com/fonts/aktiv-grotesk/AktivGrotesk_A_Bd.woff2')
+    format('woff2');
+}
+
 /* #region shadcn UI theme */
 @custom-variant dark (&:is([data-yv-sdk][data-yv-theme='dark'] *));
 
@@ -53,6 +72,12 @@ layer(yv-sdk-fonts);
     @theme inline {
       --font-sans: 'Inter', sans-serif;
       --font-serif: 'Source Serif 4', serif;
+      /* Aktiv Grotesk App — YouVersion brand font for Book/Chapter picker (CDN @font-face above).
+         Falls back to --yv-font-sans (Inter) if the woff2 fails to load.
+         NOTE: must use --yv-font-sans (a real runtime var), NOT --font-sans — the latter is
+         declared via `@theme inline` and is inlined into utilities, so it is not emitted as a
+         runtime custom property; referencing var(--font-sans) here would invalidate the value. */
+      --font-aktiv: 'Aktiv Grotesk App', var(--yv-font-sans);
       --color-background: var(--yv-background);
       --color-foreground: var(--yv-foreground);
       --color-card: var(--yv-card);

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -46,7 +46,9 @@ layer(yv-sdk-fonts);
 @import 'tw-animate-css';
 
 /* Aktiv Grotesk App — YouVersion brand font (Book/Chapter picker). Served from prod CDN.
-   Declared at top level (not in a cascade layer) — @font-face is not subject to @layer. */
+   Declared at top level (not in a cascade layer) — @font-face is not subject to @layer.
+   CSP: consumers with a strict font-src must allowlist storage.googleapis.com (see README
+   "Content Security Policy"), else this falls back to --yv-font-sans. */
 @font-face {
   font-family: 'Aktiv Grotesk App';
   font-style: normal;


### PR DESCRIPTION
## Summary
- Applies the **Aktiv Grotesk App** brand font to `BibleChapterPicker` so its typography matches the Reader SDK Figma design.
- Scoped entirely to the picker; generic `accordion.tsx` / `popover.tsx` untouched (no regressions).
- Font self-served from the YouVersion prod CDN via `@font-face`; falls back to Inter if it fails to load.
- Files: `packages/ui/src/components/bible-chapter-picker.tsx`, `bible-chapter-picker.test.tsx`, `src/styles/global.css`.

## PR Description
### What changed
- **Book rows** (`AccordionTrigger`): Aktiv Grotesk App, 16px, regular when collapsed → **bold when expanded** (`data-[state=open]`).
- **Chapter & intro number buttons**: Aktiv Grotesk App, 16px, bold.
- **Search input**: Aktiv Grotesk App, 16px.
- **`global.css`**: added `--font-aktiv` token + two `@font-face` declarations (400 / 700) served from prod CDN (`storage.googleapis.com/cdn-youversion-com/fonts/aktiv-grotesk/`), declared at top level (not in a cascade layer).
- **Tests**: added a typography suite asserting font classes on book rows input.

### Why
- Ticket: *react-sdk — Match Book/Chapter Picker Typography To Figma*. The picker was rendering generic `text-sm`/Inter styling instead of the Figma spec (Aktiv Grotesk App, 16px, regular/bold treatment).
- Note: the ticket assumed "Untitled Serif"; verifying against Figma showed the picker uses **Aktiv Grotesk App** (Untitled Serif is the reader pane only).
- The token uses `var(--yv-font-sans)` (a real runtime variable) rather than `--font-sans`, which is declared via `@theme inline` and therefore never emitted as a runtime custom property — referencing it would invalidate the `font-family`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies Aktiv Grotesk App brand typography to `BibleChapterPicker` to match the Figma spec, self-serving the font from the YouVersion CDN via `@font-face` with an Inter fallback. All supporting concerns (changeset, CSP documentation, `--yv-font-sans` runtime fallback) are correctly handled.

- **`global.css`**: Two `@font-face` rules (400/700) added at top level (correct — `@font-face` is layer-agnostic), and `--font-aktiv` registered in `@theme inline` using `var(--yv-font-sans)` as a runtime fallback (verified to be a real runtime custom property in `theme.css`).
- **`bible-chapter-picker.tsx`**: `AccordionTrigger` (book rows), chapter number `Button` elements, and `InputGroupInput` each receive `yv:font-aktiv yv:text-base` plus the appropriate weight/leading; the intro icon button is intentionally omitted since it renders only an `<InfoIcon />`.
- **Tests, changeset, and README CSP section** are all present and accurate.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are purely additive typography styling scoped to BibleChapterPicker with a verified runtime fallback chain.

The change is narrow: CSS font token, two @font-face declarations, and Tailwind utility classes on three elements in one component. The --yv-font-sans fallback is confirmed as a real runtime CSS custom property in theme.css. The changeset, CSP README update, and typography tests are all present and correct. No logic, API, or data-flow changes are involved.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/styles/global.css | Adds two @font-face declarations for Aktiv Grotesk App (400/700) at top-level (correct, @font-face is layer-agnostic) and registers the --font-aktiv theme token using var(--yv-font-sans) as a runtime fallback; confirmed valid since --yv-font-sans is defined in theme.css. |
| packages/ui/src/components/bible-chapter-picker.tsx | Applies yv:font-aktiv, yv:text-base, and appropriate weight/leading classes to AccordionTrigger (book rows), chapter number Buttons, and the search InputGroupInput; intro icon-only button intentionally omitted. |
| packages/ui/src/components/bible-chapter-picker.test.tsx | Adds a dedicated typography describe block with three tests covering book row classes (including the data-state=open bold variant), chapter button classes, and search input classes. |
| .changeset/bible-chapter-picker-typography.md | Correctly bumps @youversion/platform-react-ui as a minor version with a clear changelog description of the typography change. |
| packages/ui/README.md | Adds a CSP section documenting both the existing gstatic/googleapis origins and the new storage.googleapis.com origin needed for Aktiv Grotesk App. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["global.css\n@font-face (400 & 700)\nstorage.googleapis.com CDN"] --> B["--font-aktiv theme token\n'Aktiv Grotesk App', var(--yv-font-sans)"]
    B --> C["yv:font-aktiv utility class"]
    C --> D["AccordionTrigger\n(book rows)\nfont-normal → font-bold on open"]
    C --> E["Chapter number Buttons\nfont-bold, text-base"]
    C --> F["Search InputGroupInput\ntext-base, leading-normal"]
    G["theme.css\n--yv-font-sans: 'Inter', sans-serif"] --> B
    H["CDN load failure"] -- fallback --> G
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["global.css\n@font-face (400 & 700)\nstorage.googleapis.com CDN"] --> B["--font-aktiv theme token\n'Aktiv Grotesk App', var(--yv-font-sans)"]
    B --> C["yv:font-aktiv utility class"]
    C --> D["AccordionTrigger\n(book rows)\nfont-normal → font-bold on open"]
    C --> E["Chapter number Buttons\nfont-bold, text-base"]
    C --> F["Search InputGroupInput\ntext-base, leading-normal"]
    G["theme.css\n--yv-font-sans: 'Inter', sans-serif"] --> B
    H["CDN load failure"] -- fallback --> G
```

</a>

<sub>Reviews (2): Last reviewed commit: ["docs(ui): document font CSP host require..."](https://github.com/youversion/platform-sdk-react/commit/026e0b28fe0d0c2b34d6f8fc6e2a7c9062db9a61) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38710631)</sub>

<!-- /greptile_comment -->