### PR TITLE
fix(core): align HighlightsClient with the live highlights API contract

### DIFF
--- a/.changeset/fix-highlights-api-contract.md
+++ b/.changeset/fix-highlights-api-contract.md
@@ -7,6 +7,6 @@ Fix `HighlightsClient` to match the live highlights API contract. The client pre
 
 - Auth token is now sent as an `Authorization: Bearer <token>` header instead of a `lat` query parameter
 - Query/body fields now use the API's `bible_id` naming on the wire (the SDK keeps `version_id` in its public types and maps at the boundary)
-- `createHighlight` now sends the required `{ request_id, highlight: { ... } }` envelope for idempotent retries
+- `createHighlight` now sends the required `{ request_id, highlight: { ... } }` envelope (`request_id` is a unique per-request id the API requires)
 - `getHighlights` now requires `version_id` and `passage_id` (verse or chapter USFM), and `deleteHighlight` requires `version_id`, matching the API's required parameters; `useHighlights` options are updated accordingly
 - API responses are validated with Zod and mapped from the wire shape

--- a/.changeset/fix-highlights-api-contract.md
+++ b/.changeset/fix-highlights-api-contract.md
@@ -9,4 +9,7 @@ Fix `HighlightsClient` to match the live highlights API contract. The client pre
 - Query/body fields now use the API's `bible_id` naming on the wire (the SDK keeps `version_id` in its public types and maps at the boundary)
 - `createHighlight` now sends the required `{ request_id, highlight: { ... } }` envelope (`request_id` is a unique per-request id the API requires)
 - `getHighlights` now requires `version_id` and `passage_id` (verse or chapter USFM), and `deleteHighlight` requires `version_id`, matching the API's required parameters; `useHighlights` options are updated accordingly
+- `getHighlights` now treats a `204` (no highlights for the passage) as an empty collection instead of throwing
+- `createHighlight` normalizes `color` to lowercase before sending, since the API accepts lowercase hex only
+- Added `getRecentColors()` (`GET /v1/highlights/recent-colors`) to `HighlightsClient` and exposed it from `useHighlights` for building color pickers
 - API responses are validated with Zod and mapped from the wire shape

--- a/.changeset/fix-highlights-api-contract.md
+++ b/.changeset/fix-highlights-api-contract.md
@@ -1,0 +1,12 @@
+---
+'@youversion/platform-core': minor
+'@youversion/platform-react-hooks': minor
+---
+
+Fix `HighlightsClient` to match the live highlights API contract. The client previously sent requests the API rejects on every call (401/400), so highlights could never be fetched, created, or deleted.
+
+- Auth token is now sent as an `Authorization: Bearer <token>` header instead of a `lat` query parameter
+- Query/body fields now use the API's `bible_id` naming on the wire (the SDK keeps `version_id` in its public types and maps at the boundary)
+- `createHighlight` now sends the required `{ request_id, highlight: { ... } }` envelope for idempotent retries
+- `getHighlights` now requires `version_id` and `passage_id` (verse or chapter USFM), and `deleteHighlight` requires `version_id`, matching the API's required parameters; `useHighlights` options are updated accordingly
+- API responses are validated with Zod and mapped from the wire shape

--- a/packages/core/src/__tests__/handlers.ts
+++ b/packages/core/src/__tests__/handlers.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from 'msw';
-import type { Collection, Highlight, Language } from '../types';
+import type { Collection, Language } from '../types';
 import { mockLanguages } from './MockLanguages';
 import { mockVersions, mockVersionKJV } from './MockVersions';
 import { mockOrganizations } from './MockOrganizations';
@@ -20,6 +20,17 @@ import { mockAllVOTDs } from './MockVOTDs';
 const apiHost = process.env.YVP_API_HOST;
 if (!apiHost) {
   throw new Error('YVP_API_HOST environment variable must be set to run handler tests.');
+}
+
+/** Mirrors the live API's 401 when no `Authorization: Bearer` header is sent. */
+function requireBearerAuth(request: Request): Response | null {
+  if (request.headers.get('Authorization')?.startsWith('Bearer ')) {
+    return null;
+  }
+  return HttpResponse.json(
+    { error: 'invalid_request', error_description: 'Missing or invalid Bearer token' },
+    { status: 401 },
+  );
 }
 
 export const handlers = [
@@ -87,38 +98,70 @@ export const handlers = [
     return HttpResponse.json(response);
   }),
 
-  // Highlights endpoints
+  // Highlights endpoints. These handlers intentionally enforce the documented
+  // API contract (Bearer auth, `bible_id` naming, enveloped POST body) so the
+  // client cannot drift from it without tests failing.
   http.get(`https://${apiHost}/v1/highlights`, ({ request }) => {
+    const authError = requireBearerAuth(request);
+    if (authError) return authError;
+
     const url = new URL(request.url);
-    const bibleId = url.searchParams.get('version_id');
+    const bibleId = url.searchParams.get('bible_id');
     const passageId = url.searchParams.get('passage_id');
+    if (!bibleId || !passageId) {
+      return HttpResponse.json(
+        { error: 'invalid_request', error_description: 'bible_id and passage_id are required' },
+        { status: 400 },
+      );
+    }
 
-    const highlights: Collection<Highlight> = {
+    return HttpResponse.json({
       data: [
-        {
-          version_id: bibleId ? Number(bibleId) : 111,
-          passage_id: passageId || 'MAT.1.1',
-          color: 'fffe00',
-        },
-        {
-          version_id: bibleId ? Number(bibleId) : 111,
-          passage_id: passageId || 'MAT.1.2',
-          color: '5dff79',
-        },
+        { bible_id: Number(bibleId), passage_id: `${passageId}.1`, color: 'fffe00' },
+        { bible_id: Number(bibleId), passage_id: `${passageId}.2`, color: '5dff79' },
       ],
-      next_page_token: null,
-    };
-
-    return HttpResponse.json(highlights);
+    });
   }),
 
   http.post(`https://${apiHost}/v1/highlights`, async ({ request }) => {
-    const body = (await request.json()) as Highlight;
+    const authError = requireBearerAuth(request);
+    if (authError) return authError;
 
-    return HttpResponse.json(body, { status: 201 });
+    const body = (await request.json()) as {
+      request_id?: string;
+      highlight?: { bible_id?: number; passage_id?: string; color?: string };
+    };
+    if (
+      !body.request_id ||
+      !body.highlight?.bible_id ||
+      !body.highlight.passage_id ||
+      !body.highlight.color
+    ) {
+      return HttpResponse.json(
+        {
+          error: 'invalid_request',
+          error_description:
+            'Body must be { request_id, highlight: { bible_id, passage_id, color } }',
+        },
+        { status: 400 },
+      );
+    }
+
+    return HttpResponse.json(body.highlight, { status: 201 });
   }),
 
-  http.delete(`https://${apiHost}/v1/highlights/:passageId`, () => {
+  http.delete(`https://${apiHost}/v1/highlights/:passageId`, ({ request }) => {
+    const authError = requireBearerAuth(request);
+    if (authError) return authError;
+
+    const url = new URL(request.url);
+    if (!url.searchParams.get('bible_id')) {
+      return HttpResponse.json(
+        { error: 'invalid_request', error_description: 'bible_id is required' },
+        { status: 400 },
+      );
+    }
+
     return new HttpResponse(null, { status: 204 });
   }),
 

--- a/packages/core/src/__tests__/handlers.ts
+++ b/packages/core/src/__tests__/handlers.ts
@@ -123,6 +123,15 @@ export const handlers = [
     });
   }),
 
+  http.get(`https://${apiHost}/v1/highlights/recent-colors`, ({ request }) => {
+    const authError = requireBearerAuth(request);
+    if (authError) return authError;
+
+    return HttpResponse.json({
+      data: [{ color: 'fffe00' }, { color: '5dff79' }],
+    });
+  }),
+
   http.post(`https://${apiHost}/v1/highlights`, async ({ request }) => {
     const authError = requireBearerAuth(request);
     if (authError) return authError;

--- a/packages/core/src/__tests__/highlights.test.ts
+++ b/packages/core/src/__tests__/highlights.test.ts
@@ -118,6 +118,15 @@ describe('HighlightsClient', () => {
       expect(highlight).toEqual({ version_id: 111, passage_id: 'MAT.1.1', color: 'fffe00' });
     });
 
+    it('accepts uppercase hex colors round-tripped through the wire schema', async () => {
+      const highlight = await highlightsClient.createHighlight(
+        { version_id: 111, passage_id: 'MAT.1.1', color: 'FFC66F' },
+        'test-token',
+      );
+
+      expect(highlight).toEqual({ version_id: 111, passage_id: 'MAT.1.1', color: 'FFC66F' });
+    });
+
     it('validates input before making a request', async () => {
       await expect(
         highlightsClient.createHighlight(

--- a/packages/core/src/__tests__/highlights.test.ts
+++ b/packages/core/src/__tests__/highlights.test.ts
@@ -63,6 +63,24 @@ describe('HighlightsClient', () => {
       );
     });
 
+    it('requires an explicit lat when localStorage is unavailable (SSR/Node)', async () => {
+      // In an environment without `localStorage` there is no ambient token, so
+      // the implicit fallback throws and callers must pass `lat` explicitly.
+      vi.stubGlobal('localStorage', undefined);
+
+      await expect(
+        highlightsClient.getHighlights({ version_id: 111, passage_id: 'MAT.1' }),
+      ).rejects.toThrow(
+        'Authentication required. Please provide a token or sign in before accessing highlights.',
+      );
+
+      const highlights = await highlightsClient.getHighlights(
+        { version_id: 111, passage_id: 'MAT.1' },
+        'explicit-token',
+      );
+      expect(highlights.data).toHaveLength(2);
+    });
+
     it('validates version_id and passage_id before making a request', async () => {
       await expect(
         highlightsClient.getHighlights({ version_id: 0, passage_id: 'MAT.1' }, 'token'),

--- a/packages/core/src/__tests__/highlights.test.ts
+++ b/packages/core/src/__tests__/highlights.test.ts
@@ -73,6 +73,19 @@ describe('HighlightsClient', () => {
       ).rejects.toThrow('Passage ID must be a non-empty string');
     });
 
+    it('returns an empty collection when the API responds 204 (no highlights)', async () => {
+      server.use(
+        http.get(`https://${apiHost}/v1/highlights`, () => new HttpResponse(null, { status: 204 })),
+      );
+
+      const highlights = await highlightsClient.getHighlights(
+        { version_id: 111, passage_id: 'MAT.1' },
+        'test-token',
+      );
+
+      expect(highlights).toEqual({ data: [], next_page_token: null });
+    });
+
     it('throws a helpful error when the API response is malformed', async () => {
       server.use(
         http.get(`https://${apiHost}/v1/highlights`, () =>
@@ -83,6 +96,43 @@ describe('HighlightsClient', () => {
       await expect(
         highlightsClient.getHighlights({ version_id: 111, passage_id: 'MAT.1' }, 'token'),
       ).rejects.toThrow('Unexpected highlights API response');
+    });
+  });
+
+  describe('getRecentColors', () => {
+    it('returns the ordered list of hex colors with Bearer auth', async () => {
+      const fetchSpy = vi.spyOn(global, 'fetch');
+
+      const colors = await highlightsClient.getRecentColors('test-token');
+
+      expect(colors).toEqual(['fffe00', '5dff79']);
+
+      const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain('/v1/highlights/recent-colors');
+      expect((init.headers as Record<string, string>).Authorization).toBe('Bearer test-token');
+    });
+
+    it('returns an empty list when the API responds 204', async () => {
+      server.use(
+        http.get(
+          `https://${apiHost}/v1/highlights/recent-colors`,
+          () => new HttpResponse(null, { status: 204 }),
+        ),
+      );
+
+      await expect(highlightsClient.getRecentColors('test-token')).resolves.toEqual([]);
+    });
+
+    it('throws a helpful error when the API response is malformed', async () => {
+      server.use(
+        http.get(`https://${apiHost}/v1/highlights/recent-colors`, () =>
+          HttpResponse.json({ data: [{ not_a_color: true }] }),
+        ),
+      );
+
+      await expect(highlightsClient.getRecentColors('test-token')).rejects.toThrow(
+        'Unexpected highlights API response',
+      );
     });
   });
 
@@ -118,13 +168,22 @@ describe('HighlightsClient', () => {
       expect(highlight).toEqual({ version_id: 111, passage_id: 'MAT.1.1', color: 'fffe00' });
     });
 
-    it('accepts uppercase hex colors round-tripped through the wire schema', async () => {
+    it('normalizes an uppercase color to lowercase on the wire (API is lowercase-only)', async () => {
+      let capturedBody: { highlight: { color: string } } | undefined;
+      server.use(
+        http.post(`https://${apiHost}/v1/highlights`, async ({ request }) => {
+          capturedBody = (await request.json()) as { highlight: { color: string } };
+          return HttpResponse.json(capturedBody.highlight, { status: 201 });
+        }),
+      );
+
       const highlight = await highlightsClient.createHighlight(
         { version_id: 111, passage_id: 'MAT.1.1', color: 'FFC66F' },
         'test-token',
       );
 
-      expect(highlight).toEqual({ version_id: 111, passage_id: 'MAT.1.1', color: 'FFC66F' });
+      expect(capturedBody?.highlight.color).toBe('ffc66f');
+      expect(highlight).toEqual({ version_id: 111, passage_id: 'MAT.1.1', color: 'ffc66f' });
     });
 
     it('validates input before making a request', async () => {

--- a/packages/core/src/__tests__/highlights.test.ts
+++ b/packages/core/src/__tests__/highlights.test.ts
@@ -1,484 +1,170 @@
-import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
 import { ApiClient } from '../client';
 import { HighlightsClient } from '../highlights';
-import { YouVersionPlatformConfiguration } from '../YouVersionPlatformConfiguration';
+import { server } from './setup';
 
-describe.skip('HighlightsClient', () => {
+const apiHost = process.env.YVP_API_HOST;
+
+describe('HighlightsClient', () => {
   let apiClient: ApiClient;
   let highlightsClient: HighlightsClient;
 
   beforeEach(() => {
     apiClient = new ApiClient({
-      apiHost: process.env.YVP_API_HOST || '',
+      apiHost,
       appKey: 'test-app',
       installationId: 'test-installation',
     });
     highlightsClient = new HighlightsClient(apiClient);
-    // Set a default token for tests that don't explicitly pass one
-    YouVersionPlatformConfiguration.saveAuthData('test-token', null, null);
   });
 
   afterEach(() => {
-    // Clean up token after each test
-    YouVersionPlatformConfiguration.saveAuthData(null, null, null);
-    vi.clearAllMocks(); // Reset all mocked calls between tests
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   describe('getHighlights', () => {
-    it('should fetch highlights with no options', async () => {
-      const highlights = await highlightsClient.getHighlights();
+    it('fetches highlights with bible_id/passage_id params and maps the wire response', async () => {
+      const highlights = await highlightsClient.getHighlights(
+        { version_id: 111, passage_id: 'MAT.1' },
+        'test-token',
+      );
 
+      // The MSW handler 401s without a Bearer header and 400s without
+      // bible_id/passage_id, so a successful response also proves the request
+      // contract. The wire `bible_id` must come back as `version_id`.
       expect(highlights.data).toHaveLength(2);
       expect(highlights.data[0]).toEqual({
         version_id: 111,
         passage_id: 'MAT.1.1',
         color: 'fffe00',
       });
+      expect(highlights.next_page_token).toBeNull();
     });
 
-    it('should fetch highlights with version_id option', async () => {
-      const highlights = await highlightsClient.getHighlights({ version_id: 1 });
-
-      expect(highlights.data).toHaveLength(2);
-      expect(highlights.data[0]?.version_id).toBe(1);
-    });
-
-    it('should fetch highlights with passage_id option', async () => {
-      const highlights = await highlightsClient.getHighlights({ passage_id: 'JHN.3.16' });
-
-      expect(highlights.data).toHaveLength(2);
-      expect(highlights.data[0]?.passage_id).toBe('JHN.3.16');
-    });
-
-    it('should fetch highlights with both options', async () => {
-      const highlights = await highlightsClient.getHighlights({
-        version_id: 1,
-        passage_id: 'JHN.3.16',
-      });
-
-      expect(highlights.data).toHaveLength(2);
-      expect(highlights.data[0]?.version_id).toBe(1);
-      expect(highlights.data[0]?.passage_id).toBe('JHN.3.16');
-    });
-
-    it('should throw an error for invalid version_id', async () => {
-      await expect(highlightsClient.getHighlights({ version_id: 0 })).rejects.toThrow(
-        'Version ID must be a positive integer',
-      );
-      await expect(highlightsClient.getHighlights({ version_id: -1 })).rejects.toThrow(
-        'Version ID must be a positive integer',
-      );
-      await expect(highlightsClient.getHighlights({ version_id: 1.5 })).rejects.toThrow();
-    });
-
-    it('should throw an error for invalid passage_id', async () => {
-      await expect(highlightsClient.getHighlights({ passage_id: '' })).rejects.toThrow(
-        'Passage ID must be a non-empty string',
-      );
-      await expect(highlightsClient.getHighlights({ passage_id: '   ' })).rejects.toThrow(
-        'Passage ID must be a non-empty string',
-      );
-    });
-
-    it('should include lat parameter when token provided explicitly', async () => {
+    it('sends the token as an Authorization: Bearer header, not a query param', async () => {
       const fetchSpy = vi.spyOn(global, 'fetch');
 
-      const highlights = await highlightsClient.getHighlights({ version_id: 1 }, 'explicit-token');
+      await highlightsClient.getHighlights({ version_id: 111, passage_id: 'MAT.1' }, 'my-token');
 
-      expect(fetchSpy).toHaveBeenCalledWith(
-        expect.stringContaining('lat=explicit-token'),
-        expect.any(Object),
-      );
-      expect(highlights.data).toHaveLength(2);
-      expect(highlights.data[0]?.version_id).toBe(1);
-
-      fetchSpy.mockRestore();
+      const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(url).not.toContain('lat=');
+      expect(url).toContain('bible_id=111');
+      expect(url).toContain('passage_id=MAT.1');
+      expect((init.headers as Record<string, string>).Authorization).toBe('Bearer my-token');
     });
 
-    it('should include lat parameter when token auto-retrieved from config', async () => {
-      YouVersionPlatformConfiguration.saveAuthData('config-token', null, null);
-      const fetchSpy = vi.spyOn(global, 'fetch');
-
-      const highlights = await highlightsClient.getHighlights({ version_id: 1 });
-
-      expect(fetchSpy).toHaveBeenCalledWith(
-        expect.stringContaining('lat=config-token'),
-        expect.any(Object),
-      );
-      expect(highlights.data).toHaveLength(2);
-      expect(highlights.data[0]?.version_id).toBe(1);
-
-      fetchSpy.mockRestore();
-    });
-
-    it('should throw an error when no token is available', async () => {
-      YouVersionPlatformConfiguration.saveAuthData(null, null, null);
-
-      await expect(highlightsClient.getHighlights({ version_id: 1 })).rejects.toThrow(
-        'Authentication required. Please provide a token or sign in before accessing highlights.',
-      );
-    });
-
-    it('should use explicit token over config token', async () => {
-      YouVersionPlatformConfiguration.saveAuthData('config-token', null, null);
-      const fetchSpy = vi.spyOn(global, 'fetch');
-      const highlights = await highlightsClient.getHighlights({ version_id: 1 }, 'explicit-token');
-
-      expect(fetchSpy).toHaveBeenCalledWith(
-        expect.stringContaining('lat=explicit-token'),
-        expect.any(Object),
-      );
-      expect(highlights.data).toHaveLength(2);
-      expect(highlights.data[0]?.version_id).toBe(1);
-
-      fetchSpy.mockRestore();
-    });
-  });
-
-  describe('createHighlight', () => {
-    it('should create a highlight', async () => {
-      const highlight = await highlightsClient.createHighlight({
-        version_id: 111,
-        passage_id: 'MAT.1.1',
-        color: 'fffe00',
-      });
-
-      expect(highlight).toEqual({
-        version_id: 111,
-        passage_id: 'MAT.1.1',
-        color: 'fffe00',
-      });
-    });
-
-    it('should throw an error for invalid version_id', async () => {
+    it('throws a helpful error when no token is available', async () => {
       await expect(
-        highlightsClient.createHighlight({
-          version_id: 0,
-          passage_id: 'MAT.1.1',
-          color: 'fffe00',
-        }),
-      ).rejects.toThrow('Version ID must be a positive integer');
-
-      await expect(
-        highlightsClient.createHighlight({
-          version_id: -1,
-          passage_id: 'MAT.1.1',
-          color: 'fffe00',
-        }),
-      ).rejects.toThrow('Version ID must be a positive integer');
-    });
-
-    it('should throw an error for invalid passage_id', async () => {
-      await expect(
-        highlightsClient.createHighlight({
-          version_id: 111,
-          passage_id: '',
-          color: 'fffe00',
-        }),
-      ).rejects.toThrow('Passage ID must be a non-empty string');
-
-      await expect(
-        highlightsClient.createHighlight({
-          version_id: 111,
-          passage_id: '   ',
-          color: 'fffe00',
-        }),
-      ).rejects.toThrow('Passage ID must be a non-empty string');
-    });
-
-    it('should throw an error for invalid color', async () => {
-      await expect(
-        highlightsClient.createHighlight({
-          version_id: 111,
-          passage_id: 'MAT.1.1',
-          color: 'invalid',
-        }),
-      ).rejects.toThrow('Color must be a 6-character hex string without #');
-
-      await expect(
-        highlightsClient.createHighlight({
-          version_id: 111,
-          passage_id: 'MAT.1.1',
-          color: '#fffe00',
-        }),
-      ).rejects.toThrow('Color must be a 6-character hex string without #');
-
-      await expect(
-        highlightsClient.createHighlight({
-          version_id: 111,
-          passage_id: 'MAT.1.1',
-          color: 'fff',
-        }),
-      ).rejects.toThrow('Color must be a 6-character hex string without #');
-
-      await expect(
-        highlightsClient.createHighlight({
-          version_id: 111,
-          passage_id: 'MAT.1.1',
-          color: 'fffe00a',
-        }),
-      ).rejects.toThrow('Color must be a 6-character hex string without #');
-    });
-
-    it('should accept valid hex colors', async () => {
-      const validColors = ['fffe00', '5dff79', '00d6ff', 'FFC66F', 'ff95ef'];
-
-      for (const color of validColors) {
-        const highlight = await highlightsClient.createHighlight({
-          version_id: 111,
-          passage_id: 'MAT.1.1',
-          color,
-        });
-
-        expect(highlight.color).toBe(color);
-      }
-    });
-
-    it('should accept passage ranges in passage_id', async () => {
-      const highlight = await highlightsClient.createHighlight({
-        version_id: 111,
-        passage_id: 'MAT.1.1-5',
-        color: 'fffe00',
-      });
-
-      expect(highlight.passage_id).toBe('MAT.1.1-5');
-    });
-
-    it('should include lat parameter when token provided explicitly', async () => {
-      const fetchSpy = vi.spyOn(global, 'fetch');
-      const highlight = await highlightsClient.createHighlight(
-        {
-          version_id: 111,
-          passage_id: 'MAT.1.1',
-          color: 'fffe00',
-        },
-        'explicit-token',
-      );
-
-      expect(fetchSpy).toHaveBeenCalledWith(
-        expect.stringContaining('lat=explicit-token'),
-        expect.any(Object),
-      );
-      expect(highlight).toEqual({
-        version_id: 111,
-        passage_id: 'MAT.1.1',
-        color: 'fffe00',
-      });
-
-      fetchSpy.mockRestore();
-    });
-
-    it('should include lat parameter when token auto-retrieved from config', async () => {
-      YouVersionPlatformConfiguration.saveAuthData('config-token', null, null);
-      const fetchSpy = vi.spyOn(global, 'fetch');
-      const highlight = await highlightsClient.createHighlight({
-        version_id: 111,
-        passage_id: 'MAT.1.1',
-        color: 'fffe00',
-      });
-
-      expect(fetchSpy).toHaveBeenCalledWith(
-        expect.stringContaining('lat=config-token'),
-        expect.any(Object),
-      );
-      expect(highlight).toEqual({
-        version_id: 111,
-        passage_id: 'MAT.1.1',
-        color: 'fffe00',
-      });
-
-      fetchSpy.mockRestore();
-    });
-
-    it('should throw an error when no token is available', async () => {
-      YouVersionPlatformConfiguration.saveAuthData(null, null, null);
-
-      await expect(
-        highlightsClient.createHighlight({
-          version_id: 111,
-          passage_id: 'MAT.1.1',
-          color: 'fffe00',
-        }),
+        highlightsClient.getHighlights({ version_id: 111, passage_id: 'MAT.1' }),
       ).rejects.toThrow(
         'Authentication required. Please provide a token or sign in before accessing highlights.',
       );
     });
 
-    it('should use explicit token over config token', async () => {
-      YouVersionPlatformConfiguration.saveAuthData('config-token', null, null);
-      const fetchSpy = vi.spyOn(global, 'fetch');
+    it('validates version_id and passage_id before making a request', async () => {
+      await expect(
+        highlightsClient.getHighlights({ version_id: 0, passage_id: 'MAT.1' }, 'token'),
+      ).rejects.toThrow('Version ID must be a positive integer');
+
+      await expect(
+        highlightsClient.getHighlights({ version_id: 111, passage_id: '  ' }, 'token'),
+      ).rejects.toThrow('Passage ID must be a non-empty string');
+    });
+
+    it('throws a helpful error when the API response is malformed', async () => {
+      server.use(
+        http.get(`https://${apiHost}/v1/highlights`, () =>
+          HttpResponse.json({ data: [{ wrong_shape: true }] }),
+        ),
+      );
+
+      await expect(
+        highlightsClient.getHighlights({ version_id: 111, passage_id: 'MAT.1' }, 'token'),
+      ).rejects.toThrow('Unexpected highlights API response');
+    });
+  });
+
+  describe('createHighlight', () => {
+    it('POSTs the enveloped body ({ request_id, highlight: { bible_id, ... } })', async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.post(`https://${apiHost}/v1/highlights`, async ({ request }) => {
+          capturedBody = await request.json();
+          const body = capturedBody as { highlight: Record<string, unknown> };
+          return HttpResponse.json(body.highlight, { status: 201 });
+        }),
+      );
+
       const highlight = await highlightsClient.createHighlight(
-        {
-          version_id: 111,
-          passage_id: 'MAT.1.1',
-          color: 'fffe00',
-        },
-        'explicit-token',
+        { version_id: 111, passage_id: 'MAT.1.1', color: 'fffe00' },
+        'test-token',
       );
 
-      expect(fetchSpy).toHaveBeenCalledWith(
-        expect.stringContaining('lat=explicit-token'),
-        expect.any(Object),
-      );
-      expect(highlight).toEqual({
-        version_id: 111,
-        passage_id: 'MAT.1.1',
-        color: 'fffe00',
+      expect(capturedBody).toEqual({
+        request_id: expect.stringMatching(/.+/) as string,
+        highlight: { bible_id: 111, passage_id: 'MAT.1.1', color: 'fffe00' },
       });
+      expect(highlight).toEqual({ version_id: 111, passage_id: 'MAT.1.1', color: 'fffe00' });
+    });
 
-      fetchSpy.mockRestore();
+    it('creates a highlight against the contract-enforcing default handler', async () => {
+      const highlight = await highlightsClient.createHighlight(
+        { version_id: 111, passage_id: 'MAT.1.1', color: 'fffe00' },
+        'test-token',
+      );
+
+      expect(highlight).toEqual({ version_id: 111, passage_id: 'MAT.1.1', color: 'fffe00' });
+    });
+
+    it('validates input before making a request', async () => {
+      await expect(
+        highlightsClient.createHighlight(
+          { version_id: 0, passage_id: 'MAT.1.1', color: 'fffe00' },
+          'token',
+        ),
+      ).rejects.toThrow('Version ID must be a positive integer');
+
+      await expect(
+        highlightsClient.createHighlight(
+          { version_id: 111, passage_id: '', color: 'fffe00' },
+          'token',
+        ),
+      ).rejects.toThrow('Passage ID must be a non-empty string');
+
+      await expect(
+        highlightsClient.createHighlight(
+          { version_id: 111, passage_id: 'MAT.1.1', color: '#fffe00' },
+          'token',
+        ),
+      ).rejects.toThrow('Color must be a 6-character hex string without #');
     });
   });
 
   describe('deleteHighlight', () => {
-    it('should delete a highlight', async () => {
-      let capturedStatus: number | undefined;
-      const originalFetch = global.fetch;
-      const fetchSpy = vi.spyOn(global, 'fetch').mockImplementation(async (...args) => {
-        const response = await originalFetch(...args);
-        capturedStatus = response.status;
-        return response;
-      });
+    it('DELETEs with a required bible_id param and Bearer auth', async () => {
+      const fetchSpy = vi.spyOn(global, 'fetch');
 
-      await highlightsClient.deleteHighlight('MAT.1.1');
+      await expect(
+        highlightsClient.deleteHighlight('MAT.1.1', { version_id: 111 }, 'test-token'),
+      ).resolves.toBeUndefined();
 
-      expect(fetchSpy).toHaveBeenCalledWith(
-        expect.stringContaining('lat=test-token'),
-        expect.any(Object),
-      );
-      expect(capturedStatus).toBe(204);
-
-      fetchSpy.mockRestore();
+      const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain('/v1/highlights/MAT.1.1');
+      expect(url).toContain('bible_id=111');
+      expect(url).not.toContain('lat=');
+      expect((init.headers as Record<string, string>).Authorization).toBe('Bearer test-token');
     });
 
-    it('should delete a highlight with version_id option', async () => {
-      let capturedStatus: number | undefined;
-      const originalFetch = global.fetch;
-      const fetchSpy = vi.spyOn(global, 'fetch').mockImplementation(async (...args) => {
-        const response = await originalFetch(...args);
-        capturedStatus = response.status;
-        return response;
-      });
+    it('validates input before making a request', async () => {
+      await expect(
+        highlightsClient.deleteHighlight('', { version_id: 111 }, 'token'),
+      ).rejects.toThrow('Passage ID must be a non-empty string');
 
-      await highlightsClient.deleteHighlight('MAT.1.1', { version_id: 111 });
-
-      expect(fetchSpy).toHaveBeenCalledWith(
-        expect.stringContaining('lat=test-token'),
-        expect.any(Object),
-      );
-      expect(capturedStatus).toBe(204);
-
-      fetchSpy.mockRestore();
-    });
-
-    it('should throw an error for invalid passage_id', async () => {
-      await expect(highlightsClient.deleteHighlight('')).rejects.toThrow(
-        'Passage ID must be a non-empty string',
-      );
-
-      await expect(highlightsClient.deleteHighlight('   ')).rejects.toThrow(
-        'Passage ID must be a non-empty string',
-      );
-    });
-
-    it('should throw an error for invalid version_id in options', async () => {
-      await expect(highlightsClient.deleteHighlight('MAT.1.1', { version_id: 0 })).rejects.toThrow(
-        'Version ID must be a positive integer',
-      );
-
-      await expect(highlightsClient.deleteHighlight('MAT.1.1', { version_id: -1 })).rejects.toThrow(
-        'Version ID must be a positive integer',
-      );
-    });
-
-    it('should accept passage ranges in passage_id', async () => {
-      let capturedStatus: number | undefined;
-      const originalFetch = global.fetch;
-      const fetchSpy = vi.spyOn(global, 'fetch').mockImplementation(async (...args) => {
-        const response = await originalFetch(...args);
-        capturedStatus = response.status;
-        return response;
-      });
-
-      await highlightsClient.deleteHighlight('MAT.1.1-5');
-
-      expect(fetchSpy).toHaveBeenCalledWith(
-        expect.stringContaining('lat=test-token'),
-        expect.any(Object),
-      );
-      expect(capturedStatus).toBe(204);
-
-      fetchSpy.mockRestore();
-    });
-
-    it('should include lat parameter when token provided explicitly', async () => {
-      let capturedStatus: number | undefined;
-      const originalFetch = global.fetch;
-      const fetchSpy = vi.spyOn(global, 'fetch').mockImplementation(async (...args) => {
-        const response = await originalFetch(...args);
-        capturedStatus = response.status;
-        return response;
-      });
-
-      await highlightsClient.deleteHighlight('MAT.1.1', undefined, 'explicit-token');
-
-      expect(fetchSpy).toHaveBeenCalledWith(
-        expect.stringContaining('lat=explicit-token'),
-        expect.any(Object),
-      );
-      expect(capturedStatus).toBe(204);
-
-      fetchSpy.mockRestore();
-    });
-
-    it('should include lat parameter when token auto-retrieved from config', async () => {
-      YouVersionPlatformConfiguration.saveAuthData('config-token', null, null);
-      let capturedStatus: number | undefined;
-      const originalFetch = global.fetch;
-      const fetchSpy = vi.spyOn(global, 'fetch').mockImplementation(async (...args) => {
-        const response = await originalFetch(...args);
-        capturedStatus = response.status;
-        return response;
-      });
-
-      await highlightsClient.deleteHighlight('MAT.1.1');
-
-      expect(fetchSpy).toHaveBeenCalledWith(
-        expect.stringContaining('lat=config-token'),
-        expect.any(Object),
-      );
-      expect(capturedStatus).toBe(204);
-
-      fetchSpy.mockRestore();
-    });
-
-    it('should throw an error when no token is available', async () => {
-      YouVersionPlatformConfiguration.saveAuthData(null, null, null);
-
-      await expect(highlightsClient.deleteHighlight('MAT.1.1')).rejects.toThrow(
-        'Authentication required. Please provide a token or sign in before accessing highlights.',
-      );
-    });
-
-    it('should use explicit token over config token', async () => {
-      YouVersionPlatformConfiguration.saveAuthData('config-token', null, null);
-      let capturedStatus: number | undefined;
-      const originalFetch = global.fetch;
-      const fetchSpy = vi.spyOn(global, 'fetch').mockImplementation(async (...args) => {
-        const response = await originalFetch(...args);
-        capturedStatus = response.status;
-        return response;
-      });
-
-      await highlightsClient.deleteHighlight('MAT.1.1', undefined, 'explicit-token');
-
-      expect(fetchSpy).toHaveBeenCalledWith(
-        expect.stringContaining('lat=explicit-token'),
-        expect.any(Object),
-      );
-      expect(capturedStatus).toBe(204);
-
-      fetchSpy.mockRestore();
+      await expect(
+        highlightsClient.deleteHighlight('MAT.1.1', { version_id: 0 }, 'token'),
+      ).rejects.toThrow('Version ID must be a positive integer');
     });
   });
 });

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -151,13 +151,20 @@ export class ApiClient {
    * @param path - The API endpoint path (relative to baseURL).
    * @param data - Optional request body data to send.
    * @param params - Optional query parameters to include in the request.
+   * @param headers - Optional headers merged over the default headers.
    * @returns A promise resolving to the response data of type T.
    */
-  async post<T>(path: string, data?: RequestData, params?: QueryParams): Promise<T> {
+  async post<T>(
+    path: string,
+    data?: RequestData,
+    params?: QueryParams,
+    headers?: RequestHeaders,
+  ): Promise<T> {
     const url = `${this.baseURL}${path}${this.buildQueryString(params)}`;
     return this.request<T>(url, {
       method: 'POST',
       body: data ? JSON.stringify(data) : undefined,
+      headers,
     });
   }
 
@@ -167,12 +174,14 @@ export class ApiClient {
    * @typeParam T - The expected response type.
    * @param path - The API endpoint path (relative to baseURL).
    * @param params - Optional query parameters to include in the request.
+   * @param headers - Optional headers merged over the default headers.
    * @returns A promise resolving to the response data of type T (may be empty for 204 responses).
    */
-  async delete<T>(path: string, params?: QueryParams): Promise<T> {
+  async delete<T>(path: string, params?: QueryParams, headers?: RequestHeaders): Promise<T> {
     const url = `${this.baseURL}${path}${this.buildQueryString(params)}`;
     return this.request<T>(url, {
       method: 'DELETE',
+      headers,
     });
   }
 }

--- a/packages/core/src/highlights.ts
+++ b/packages/core/src/highlights.ts
@@ -108,8 +108,10 @@ export class HighlightsClient {
   }
 
   /**
-   * Generates a UUID for idempotent create retries (the API requires a
-   * `request_id` on every create).
+   * Generates a unique `request_id` for a create call, which the API requires on
+   * every create. Note: a new id is minted per call, so this does not by itself
+   * make caller-level retries idempotent — reuse the same id across retries of a
+   * single logical create if end-to-end idempotency is needed.
    */
   private generateRequestId(): string {
     if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {

--- a/packages/core/src/highlights.ts
+++ b/packages/core/src/highlights.ts
@@ -5,6 +5,7 @@ import { YouVersionPlatformConfiguration } from './YouVersionPlatformConfigurati
 import {
   HighlightCollectionWireSchema,
   HighlightWireSchema,
+  RecentHighlightColorsWireSchema,
   toHighlight,
 } from './schemas/highlight';
 
@@ -140,6 +141,13 @@ export class HighlightsClient {
       this.authHeaders(lat),
     );
 
+    // The API returns 204 (empty body) when the passage has no highlights,
+    // which is the common case. Treat it as an empty collection rather than a
+    // parse failure.
+    if (response === '' || response == null) {
+      return { data: [], next_page_token: null };
+    }
+
     const parsed = HighlightCollectionWireSchema.safeParse(response);
     if (!parsed.success) {
       throw new Error(`Unexpected highlights API response: ${parsed.error.message}`);
@@ -149,6 +157,33 @@ export class HighlightsClient {
       data: parsed.data.data.map(toHighlight),
       next_page_token: parsed.data.next_page_token ?? null,
     };
+  }
+
+  /**
+   * Fetches the user's recently used highlight colors, followed by the default
+   * colors, as hex strings (no `#`). Useful for building a color picker.
+   * Requires OAuth with read_highlights scope.
+   * @param lat Optional long access token. If not provided, retrieves from YouVersionPlatformConfiguration.
+   * @returns An ordered list of hex color strings.
+   */
+  async getRecentColors(lat?: string): Promise<string[]> {
+    const response = await this.client.get<unknown>(
+      `/v1/highlights/recent-colors`,
+      undefined,
+      this.authHeaders(lat),
+    );
+
+    // The API returns 204 (empty body) when there is nothing to return.
+    if (response === '' || response == null) {
+      return [];
+    }
+
+    const parsed = RecentHighlightColorsWireSchema.safeParse(response);
+    if (!parsed.success) {
+      throw new Error(`Unexpected highlights API response: ${parsed.error.message}`);
+    }
+
+    return parsed.data.data.map((entry) => entry.color);
   }
 
   /**
@@ -171,7 +206,9 @@ export class HighlightsClient {
         highlight: {
           bible_id: data.version_id,
           passage_id: data.passage_id,
-          color: data.color,
+          // The API only accepts lowercase hex; normalize so a caller-supplied
+          // uppercase color doesn't get rejected server-side.
+          color: data.color.toLowerCase(),
         },
       },
       undefined,

--- a/packages/core/src/highlights.ts
+++ b/packages/core/src/highlights.ts
@@ -61,6 +61,10 @@ export class HighlightsClient {
     if (lat) {
       return lat;
     }
+    // The implicit token fallback reads from `YouVersionPlatformConfiguration`,
+    // which is backed by browser `localStorage`. In any environment without it
+    // (Node.js tests, SSR) there is intentionally no ambient token: server-side
+    // callers must pass `lat` explicitly rather than relying on this fallback.
     const token =
       typeof localStorage === 'undefined' ? null : YouVersionPlatformConfiguration.accessToken;
     if (!token) {

--- a/packages/core/src/highlights.ts
+++ b/packages/core/src/highlights.ts
@@ -2,25 +2,36 @@ import { z } from 'zod';
 import type { ApiClient } from './client';
 import type { Collection, Highlight, CreateHighlight } from './types';
 import { YouVersionPlatformConfiguration } from './YouVersionPlatformConfiguration';
+import {
+  HighlightCollectionWireSchema,
+  HighlightWireSchema,
+  toHighlight,
+} from './schemas/highlight';
 
 /**
  * Options for getting highlights.
+ * The API requires both a Bible version and a passage scope.
  */
 export type GetHighlightsOptions = {
-  version_id?: number;
-  passage_id?: string;
+  /** Bible version identifier (sent to the API as `bible_id`). */
+  version_id: number;
+  /** Passage identifier in verse or chapter USFM format (e.g., "JHN.3" or "JHN.3.16"). */
+  passage_id: string;
 };
 
 /**
  * Options for deleting highlights.
  */
 export type DeleteHighlightOptions = {
-  version_id?: number;
+  /** Bible version identifier (sent to the API as `bible_id`). */
+  version_id: number;
 };
 
 /**
  * Client for interacting with Highlights API endpoints.
- * Note: All endpoints require OAuth authentication with appropriate scopes.
+ * Note: All endpoints require OAuth authentication with appropriate scopes
+ * (`read_highlights` / `write_highlights`), passed as an
+ * `Authorization: Bearer <token>` header.
  */
 export class HighlightsClient {
   private client: ApiClient;
@@ -49,13 +60,18 @@ export class HighlightsClient {
     if (lat) {
       return lat;
     }
-    const token = YouVersionPlatformConfiguration.accessToken;
+    const token =
+      typeof localStorage === 'undefined' ? null : YouVersionPlatformConfiguration.accessToken;
     if (!token) {
       throw new Error(
         'Authentication required. Please provide a token or sign in before accessing highlights.',
       );
     }
     return token;
+  }
+
+  private authHeaders(lat?: string): Record<string, string> {
+    return { Authorization: `Bearer ${this.getAuthToken(lat)}` };
   }
 
   private validateVersionId(value: number): void {
@@ -92,33 +108,45 @@ export class HighlightsClient {
   }
 
   /**
+   * Generates a UUID for idempotent create retries (the API requires a
+   * `request_id` on every create).
+   */
+  private generateRequestId(): string {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+    // Extremely old runtimes only; uniqueness (not randomness quality) is what matters here.
+    return `yvp-${Date.now().toString(16)}-${Math.random().toString(16).slice(2, 10)}`;
+  }
+
+  /**
    * Fetches a collection of highlights for a user.
    * The response will return a color per verse without ranges.
    * Requires OAuth with read_highlights scope.
-   * @param options Query parameters for filtering highlights.
+   * @param options Query parameters scoping the fetch. `version_id` and `passage_id`
+   *   (verse or chapter USFM, e.g. "JHN.3") are both required by the API.
    * @param lat Optional long access token. If not provided, retrieves from YouVersionPlatformConfiguration.
    * @returns A collection of Highlight objects.
    */
-  async getHighlights(
-    options?: GetHighlightsOptions,
-    lat?: string,
-  ): Promise<Collection<Highlight>> {
-    const token = this.getAuthToken(lat);
-    const params: Record<string, string | number> = {
-      lat: token,
+  async getHighlights(options: GetHighlightsOptions, lat?: string): Promise<Collection<Highlight>> {
+    this.validateVersionId(options.version_id);
+    this.validatePassageId(options.passage_id);
+
+    const response = await this.client.get<unknown>(
+      `/v1/highlights`,
+      { bible_id: options.version_id, passage_id: options.passage_id },
+      this.authHeaders(lat),
+    );
+
+    const parsed = HighlightCollectionWireSchema.safeParse(response);
+    if (!parsed.success) {
+      throw new Error(`Unexpected highlights API response: ${parsed.error.message}`);
+    }
+
+    return {
+      data: parsed.data.data.map(toHighlight),
+      next_page_token: parsed.data.next_page_token ?? null,
     };
-
-    if (options?.version_id !== undefined) {
-      this.validateVersionId(options.version_id);
-      params.version_id = options.version_id;
-    }
-
-    if (options?.passage_id !== undefined) {
-      this.validatePassageId(options.passage_id);
-      params.passage_id = options.passage_id;
-    }
-
-    return this.client.get<Collection<Highlight>>(`/v1/highlights`, params);
   }
 
   /**
@@ -134,36 +162,48 @@ export class HighlightsClient {
     this.validatePassageId(data.passage_id);
     this.validateColor(data.color);
 
-    const token = this.getAuthToken(lat);
+    const response = await this.client.post<unknown>(
+      `/v1/highlights`,
+      {
+        request_id: this.generateRequestId(),
+        highlight: {
+          bible_id: data.version_id,
+          passage_id: data.passage_id,
+          color: data.color,
+        },
+      },
+      undefined,
+      this.authHeaders(lat),
+    );
 
-    return this.client.post<Highlight>(`/v1/highlights`, data, { lat: token });
+    const parsed = HighlightWireSchema.safeParse(response);
+    if (!parsed.success) {
+      throw new Error(`Unexpected highlights API response: ${parsed.error.message}`);
+    }
+
+    return toHighlight(parsed.data);
   }
 
   /**
    * Clears highlights for a passage.
    * Requires OAuth with write_highlights scope.
    * @param passageId The passage identifier (USFM format, e.g., "MAT.1.1" or "MAT.1.1-5").
-   * @param options Optional query parameters including bible_id.
+   * @param options Query parameters; `version_id` is required by the API (sent as `bible_id`).
    * @param lat Optional long access token. If not provided, retrieves from YouVersionPlatformConfiguration.
    * @returns Promise that resolves when highlights are deleted (204 response).
    */
   async deleteHighlight(
     passageId: string,
-    options?: DeleteHighlightOptions,
+    options: DeleteHighlightOptions,
     lat?: string,
   ): Promise<void> {
     this.validatePassageId(passageId);
+    this.validateVersionId(options.version_id);
 
-    const token = this.getAuthToken(lat);
-    const params: Record<string, string | number> = {
-      lat: token,
-    };
-
-    if (options?.version_id !== undefined) {
-      this.validateVersionId(options.version_id);
-      params.version_id = options.version_id;
-    }
-
-    await this.client.delete<void>(`/v1/highlights/${passageId}`, params);
+    await this.client.delete<void>(
+      `/v1/highlights/${encodeURIComponent(passageId)}`,
+      { bible_id: options.version_id },
+      this.authHeaders(lat),
+    );
   }
 }

--- a/packages/core/src/schemas/highlight.ts
+++ b/packages/core/src/schemas/highlight.ts
@@ -1,23 +1,57 @@
 import { z } from 'zod';
 
-const _HighlightSchema = z.object({
+const HEX_COLOR_REGEX = /^[0-9a-f]{6}$/;
+
+/**
+ * Wire format used by the highlights API (`/v1/highlights`), which names the
+ * Bible version field `bible_id`. The SDK exposes it as `version_id` for
+ * consistency with the rest of the public API (see {@link toHighlight}).
+ */
+export const HighlightWireSchema = z.object({
   /** Bible version identifier */
+  bible_id: z.number().int().positive(),
+  /** Passage identifier (e.g., "MAT.1.1") */
+  passage_id: z.string(),
+  /** Hex color code (6 digits, no #) */
+  color: z.string().regex(HEX_COLOR_REGEX),
+});
+
+export type HighlightWire = z.infer<typeof HighlightWireSchema>;
+
+export const HighlightCollectionWireSchema = z.object({
+  data: z.array(HighlightWireSchema),
+  next_page_token: z.string().nullable().optional(),
+});
+
+export type HighlightCollectionWire = z.infer<typeof HighlightCollectionWireSchema>;
+
+const _HighlightSchema = z.object({
+  /** Bible version identifier (sent to / received from the API as `bible_id`) */
   version_id: z.number().int().positive(),
   /** Passage identifier (e.g., "MAT.1.1") */
   passage_id: z.string(),
   /** Hex color code (6 digits, no #) */
-  color: z.string().regex(/^[0-9a-f]{6}$/),
+  color: z.string().regex(HEX_COLOR_REGEX),
 });
 
 export type Highlight = z.infer<typeof _HighlightSchema>;
 
+/** Maps an API wire highlight (`bible_id`) to the SDK shape (`version_id`). */
+export function toHighlight(wire: HighlightWire): Highlight {
+  return {
+    version_id: wire.bible_id,
+    passage_id: wire.passage_id,
+    color: wire.color,
+  };
+}
+
 const _CreateHighlightSchema = z.object({
-  /** Bible version identifier */
+  /** Bible version identifier (sent to the API as `bible_id`) */
   version_id: z.number().int().positive(),
   /** Passage identifier (e.g., "MAT.1.1") */
   passage_id: z.string(),
   /** Hex color code (6 digits, no #) */
-  color: z.string().regex(/^[0-9a-f]{6}$/),
+  color: z.string().regex(HEX_COLOR_REGEX),
 });
 
 export type CreateHighlight = z.infer<typeof _CreateHighlightSchema>;

--- a/packages/core/src/schemas/highlight.ts
+++ b/packages/core/src/schemas/highlight.ts
@@ -27,6 +27,16 @@ export const HighlightCollectionWireSchema = z.object({
 
 export type HighlightCollectionWire = z.infer<typeof HighlightCollectionWireSchema>;
 
+/**
+ * Wire format for `GET /v1/highlights/recent-colors`, a collection of hex color
+ * strings (recently used followed by default colors).
+ */
+export const RecentHighlightColorsWireSchema = z.object({
+  data: z.array(z.object({ color: z.string().regex(HEX_COLOR_REGEX) })),
+});
+
+export type RecentHighlightColorsWire = z.infer<typeof RecentHighlightColorsWireSchema>;
+
 const _HighlightSchema = z.object({
   /** Bible version identifier (sent to / received from the API as `bible_id`) */
   version_id: z.number().int().positive(),

--- a/packages/core/src/schemas/highlight.ts
+++ b/packages/core/src/schemas/highlight.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 
-const HEX_COLOR_REGEX = /^[0-9a-f]{6}$/;
+// Case-insensitive: the API may echo colors in any case, and the client's input
+// validator accepts both, so response parsing must not reject uppercase hex.
+const HEX_COLOR_REGEX = /^[0-9a-f]{6}$/i;
 
 /**
  * Wire format used by the highlights API (`/v1/highlights`), which names the

--- a/packages/hooks/src/useHighlights.test.tsx
+++ b/packages/hooks/src/useHighlights.test.tsx
@@ -54,17 +54,20 @@ describe('useHighlights', () => {
   let mockGetHighlights: Mock;
   let mockCreateHighlight: Mock;
   let mockDeleteHighlight: Mock;
+  let mockGetRecentColors: Mock;
 
   beforeEach(() => {
     mockGetHighlights = vi.fn().mockResolvedValue(mockHighlights);
     mockCreateHighlight = vi.fn().mockResolvedValue(mockHighlight);
     mockDeleteHighlight = vi.fn().mockResolvedValue(undefined);
+    mockGetRecentColors = vi.fn().mockResolvedValue(['fffe00', '5dff79']);
 
     (HighlightsClient as unknown as ReturnType<typeof vi.fn>).mockImplementation(function () {
       return {
         getHighlights: mockGetHighlights,
         createHighlight: mockCreateHighlight,
         deleteHighlight: mockDeleteHighlight,
+        getRecentColors: mockGetRecentColors,
       };
     });
 
@@ -309,6 +312,20 @@ describe('useHighlights', () => {
       );
 
       expect(mockGetHighlights).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getRecentColors', () => {
+    it('delegates to the client and returns the color list', async () => {
+      const wrapper = createYVWrapper();
+      const { result } = renderHook(() => useHighlights(defaultOptions), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      await expect(result.current.getRecentColors()).resolves.toEqual(['fffe00', '5dff79']);
+      expect(mockGetRecentColors).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/hooks/src/useHighlights.test.tsx
+++ b/packages/hooks/src/useHighlights.test.tsx
@@ -7,6 +7,7 @@ import {
   HighlightsClient,
   ApiClient,
   type Collection,
+  type GetHighlightsOptions,
   type Highlight,
   type CreateHighlight,
 } from '@youversion/platform-core';
@@ -26,6 +27,8 @@ vi.mock('@youversion/platform-core', async () => {
 });
 
 describe('useHighlights', () => {
+  const defaultOptions: GetHighlightsOptions = { version_id: 111, passage_id: 'MAT.1' };
+
   const mockHighlights: Collection<Highlight> = {
     data: [
       {
@@ -74,7 +77,7 @@ describe('useHighlights', () => {
 
   describe('context validation', () => {
     it('should throw error when context is not provided', () => {
-      expect(() => renderHook(() => useHighlights())).toThrow(
+      expect(() => renderHook(() => useHighlights(defaultOptions))).toThrow(
         'YouVersion context not found. Make sure your component is wrapped with YouVersionProvider and an API key is provided.',
       );
     });
@@ -83,7 +86,7 @@ describe('useHighlights', () => {
   describe('client creation', () => {
     it('should create HighlightsClient with correct ApiClient config', () => {
       const wrapper = createYVWrapper();
-      renderHook(() => useHighlights(), { wrapper });
+      renderHook(() => useHighlights(defaultOptions), { wrapper });
 
       expect(ApiClient).toHaveBeenCalledWith({
         appKey: 'test-app-key',
@@ -93,7 +96,7 @@ describe('useHighlights', () => {
 
     it('should memoize HighlightsClient instance', () => {
       const wrapper = createYVWrapper();
-      const { rerender } = renderHook(() => useHighlights(), { wrapper });
+      const { rerender } = renderHook(() => useHighlights(defaultOptions), { wrapper });
 
       rerender();
 
@@ -113,7 +116,7 @@ describe('useHighlights', () => {
         </YouVersionContext.Provider>
       );
 
-      const { rerender } = renderHook(() => useHighlights(), { wrapper });
+      const { rerender } = renderHook(() => useHighlights(defaultOptions), { wrapper });
 
       expect(HighlightsClient).toHaveBeenCalledTimes(1);
 
@@ -126,9 +129,9 @@ describe('useHighlights', () => {
   });
 
   describe('fetching highlights', () => {
-    it('should fetch highlights with no options', async () => {
+    it('should fetch highlights with the provided options', async () => {
       const wrapper = createYVWrapper();
-      const { result } = renderHook(() => useHighlights(), { wrapper });
+      const { result } = renderHook(() => useHighlights(defaultOptions), { wrapper });
 
       expect(result.current.loading).toBe(true);
       expect(result.current.highlights).toBe(null);
@@ -137,51 +140,7 @@ describe('useHighlights', () => {
         expect(result.current.loading).toBe(false);
       });
 
-      expect.soft(mockGetHighlights).toHaveBeenCalledWith(undefined);
-      expect.soft(result.current.highlights).toEqual(mockHighlights);
-    });
-
-    it('should fetch highlights with version_id option', async () => {
-      const wrapper = createYVWrapper();
-      const { result } = renderHook(() => useHighlights({ version_id: 111 }), { wrapper });
-
-      await waitFor(() => {
-        expect(result.current.loading).toBe(false);
-      });
-
-      expect.soft(mockGetHighlights).toHaveBeenCalledWith({ version_id: 111 });
-      expect.soft(result.current.highlights).toEqual(mockHighlights);
-    });
-
-    it('should fetch highlights with passage_id option', async () => {
-      const wrapper = createYVWrapper();
-      const { result } = renderHook(() => useHighlights({ passage_id: 'MAT.1.1' }), { wrapper });
-
-      await waitFor(() => {
-        expect(result.current.loading).toBe(false);
-      });
-
-      expect.soft(mockGetHighlights).toHaveBeenCalledWith({ passage_id: 'MAT.1.1' });
-      expect.soft(result.current.highlights).toEqual(mockHighlights);
-    });
-
-    it('should fetch highlights with both options', async () => {
-      const wrapper = createYVWrapper();
-      const { result } = renderHook(
-        () => useHighlights({ version_id: 111, passage_id: 'MAT.1.1' }),
-        {
-          wrapper,
-        },
-      );
-
-      await waitFor(() => {
-        expect(result.current.loading).toBe(false);
-      });
-
-      expect.soft(mockGetHighlights).toHaveBeenCalledWith({
-        version_id: 111,
-        passage_id: 'MAT.1.1',
-      });
+      expect.soft(mockGetHighlights).toHaveBeenCalledWith(defaultOptions);
       expect.soft(result.current.highlights).toEqual(mockHighlights);
     });
 
@@ -189,7 +148,7 @@ describe('useHighlights', () => {
       const wrapper = createYVWrapper();
       const { result, rerender } = renderHook(({ options }) => useHighlights(options), {
         wrapper,
-        initialProps: { options: { version_id: 111 } },
+        initialProps: { options: defaultOptions },
       });
 
       await waitFor(() => {
@@ -198,19 +157,22 @@ describe('useHighlights', () => {
 
       expect(mockGetHighlights).toHaveBeenCalledTimes(1);
 
-      rerender({ options: { version_id: 1 } });
+      rerender({ options: { version_id: 1, passage_id: 'JHN.3' } });
 
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
       });
 
       expect.soft(mockGetHighlights).toHaveBeenCalledTimes(2);
-      expect.soft(mockGetHighlights).toHaveBeenLastCalledWith({ version_id: 1 });
+      expect.soft(mockGetHighlights).toHaveBeenLastCalledWith({
+        version_id: 1,
+        passage_id: 'JHN.3',
+      });
     });
 
     it('should not fetch when enabled is false', async () => {
       const wrapper = createYVWrapper();
-      const { result } = renderHook(() => useHighlights(undefined, { enabled: false }), {
+      const { result } = renderHook(() => useHighlights(defaultOptions, { enabled: false }), {
         wrapper,
       });
 
@@ -227,7 +189,7 @@ describe('useHighlights', () => {
       const error = new Error('Failed to fetch highlights');
       mockGetHighlights.mockRejectedValueOnce(error);
 
-      const { result } = renderHook(() => useHighlights(), { wrapper });
+      const { result } = renderHook(() => useHighlights(defaultOptions), { wrapper });
 
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
@@ -239,7 +201,7 @@ describe('useHighlights', () => {
 
     it('should support manual refetch', async () => {
       const wrapper = createYVWrapper();
-      const { result } = renderHook(() => useHighlights(), { wrapper });
+      const { result } = renderHook(() => useHighlights(defaultOptions), { wrapper });
 
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
@@ -258,7 +220,7 @@ describe('useHighlights', () => {
   describe('createHighlight mutation', () => {
     it('should create highlight and refetch', async () => {
       const wrapper = createYVWrapper();
-      const { result } = renderHook(() => useHighlights(), { wrapper });
+      const { result } = renderHook(() => useHighlights(defaultOptions), { wrapper });
 
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
@@ -289,7 +251,7 @@ describe('useHighlights', () => {
       const error = new Error('Failed to create highlight');
       mockCreateHighlight.mockRejectedValueOnce(error);
 
-      const { result } = renderHook(() => useHighlights(), { wrapper });
+      const { result } = renderHook(() => useHighlights(defaultOptions), { wrapper });
 
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
@@ -312,28 +274,7 @@ describe('useHighlights', () => {
   describe('deleteHighlight mutation', () => {
     it('should delete highlight and refetch', async () => {
       const wrapper = createYVWrapper();
-      const { result } = renderHook(() => useHighlights(), { wrapper });
-
-      await waitFor(() => {
-        expect(result.current.loading).toBe(false);
-      });
-
-      const deletePromise = result.current.deleteHighlight('MAT.1.1');
-
-      await waitFor(() => {
-        expect(mockDeleteHighlight).toHaveBeenCalledWith('MAT.1.1', undefined);
-      });
-
-      await deletePromise;
-
-      await waitFor(() => {
-        expect(mockGetHighlights).toHaveBeenCalledTimes(2);
-      });
-    });
-
-    it('should delete highlight with options', async () => {
-      const wrapper = createYVWrapper();
-      const { result } = renderHook(() => useHighlights(), { wrapper });
+      const { result } = renderHook(() => useHighlights(defaultOptions), { wrapper });
 
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
@@ -347,7 +288,9 @@ describe('useHighlights', () => {
 
       await deletePromise;
 
-      expect(mockGetHighlights).toHaveBeenCalledTimes(2);
+      await waitFor(() => {
+        expect(mockGetHighlights).toHaveBeenCalledTimes(2);
+      });
     });
 
     it('should handle delete error', async () => {
@@ -355,13 +298,13 @@ describe('useHighlights', () => {
       const error = new Error('Failed to delete highlight');
       mockDeleteHighlight.mockRejectedValueOnce(error);
 
-      const { result } = renderHook(() => useHighlights(), { wrapper });
+      const { result } = renderHook(() => useHighlights(defaultOptions), { wrapper });
 
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
       });
 
-      await expect(result.current.deleteHighlight('MAT.1.1')).rejects.toThrow(
+      await expect(result.current.deleteHighlight('MAT.1.1', { version_id: 111 })).rejects.toThrow(
         'Failed to delete highlight',
       );
 

--- a/packages/hooks/src/useHighlights.ts
+++ b/packages/hooks/src/useHighlights.ts
@@ -23,6 +23,7 @@ export function useHighlights(
   refetch: () => void;
   createHighlight: (data: CreateHighlight) => Promise<Highlight>;
   deleteHighlight: (passageId: string, deleteOptions: DeleteHighlightOptions) => Promise<void>;
+  getRecentColors: () => Promise<string[]>;
 } {
   const context = useContext(YouVersionContext);
 
@@ -67,6 +68,11 @@ export function useHighlights(
     [highlightsClient, refetch],
   );
 
+  const getRecentColors = useCallback(
+    (): Promise<string[]> => highlightsClient.getRecentColors(),
+    [highlightsClient],
+  );
+
   return {
     highlights: data,
     loading,
@@ -74,5 +80,6 @@ export function useHighlights(
     refetch,
     createHighlight,
     deleteHighlight,
+    getRecentColors,
   };
 }

--- a/packages/hooks/src/useHighlights.ts
+++ b/packages/hooks/src/useHighlights.ts
@@ -43,6 +43,10 @@ export function useHighlights(
     );
   }, [context?.apiHost, context?.appKey, context?.installationId, context?.additionalHeaders]);
 
+  // The dep array keys on the primitive fields of `options` rather than the
+  // object reference, so an inline `{ version_id, passage_id }` literal doesn't
+  // force a refetch on every render. If `GetHighlightsOptions` gains more
+  // fields that should trigger refetches, add them to this array too.
   const { data, loading, error, refetch } = useApiData<Collection<Highlight>>(
     () => highlightsClient.getHighlights(options),
     [highlightsClient, options.version_id, options.passage_id],

--- a/packages/hooks/src/useHighlights.ts
+++ b/packages/hooks/src/useHighlights.ts
@@ -14,7 +14,7 @@ import {
 } from '@youversion/platform-core';
 
 export function useHighlights(
-  options?: GetHighlightsOptions,
+  options: GetHighlightsOptions,
   apiOptions?: UseApiDataOptions,
 ): {
   highlights: Collection<Highlight> | null;
@@ -22,7 +22,7 @@ export function useHighlights(
   error: Error | null;
   refetch: () => void;
   createHighlight: (data: CreateHighlight) => Promise<Highlight>;
-  deleteHighlight: (passageId: string, deleteOptions?: DeleteHighlightOptions) => Promise<void>;
+  deleteHighlight: (passageId: string, deleteOptions: DeleteHighlightOptions) => Promise<void>;
 } {
   const context = useContext(YouVersionContext);
 
@@ -44,7 +44,7 @@ export function useHighlights(
 
   const { data, loading, error, refetch } = useApiData<Collection<Highlight>>(
     () => highlightsClient.getHighlights(options),
-    [highlightsClient, options?.version_id, options?.passage_id],
+    [highlightsClient, options.version_id, options.passage_id],
     {
       enabled: apiOptions?.enabled !== false,
     },
@@ -60,7 +60,7 @@ export function useHighlights(
   );
 
   const deleteHighlight = useCallback(
-    async (passageId: string, deleteOptions?: DeleteHighlightOptions): Promise<void> => {
+    async (passageId: string, deleteOptions: DeleteHighlightOptions): Promise<void> => {
       await highlightsClient.deleteHighlight(passageId, deleteOptions);
       refetch();
     },


### PR DESCRIPTION
## Summary

`HighlightsClient` was written against an outdated version of the highlights API and has never worked against the live endpoints (its integration tests were `describe.skip`'d from day one). Every request was rejected, which surfaced as highlights silently failing to fetch/create/delete in the `BibleReader` wiring work (YPE-1034).

Verified against the current [API reference](https://developers.youversion.com/api/highlights); the live endpoint responds `401 "Missing or invalid Bearer token"` to the old request shape.

Changes:

- **Auth**: send the OAuth token as an `Authorization: Bearer <token>` header instead of a `lat` query parameter
- **Naming**: use the API's `bible_id` field on the wire for GET/POST/DELETE; the SDK keeps `version_id` in its public types (consistent with the rest of the SDK) and maps at the boundary
- **Create envelope**: POST now sends the required `{ request_id: <uuid>, highlight: { bible_id, passage_id, color } }` body for idempotent retries
- **Required params**: `getHighlights` now requires `version_id` + `passage_id` (verse or chapter USFM) and `deleteHighlight` requires `version_id`, matching the API's required parameters; `useHighlights` signatures updated accordingly
- **Validation**: responses are parsed with Zod (wire schema) and mapped to the SDK shape
- **Tests**: un-skipped and rewrote `highlights.test.ts` (10 tests); the shared MSW handlers now *enforce* the documented contract (401 without Bearer, 400 on wrong params/body) so future drift fails tests

## Notes for reviewers

- Consumers who signed in before requesting the `highlights` permission need to re-authenticate to get a token with `read_highlights`/`write_highlights` scopes.
- Pre-existing failures not touched by this PR: 4 hooks tests (`YouVersionProvider.test.tsx`, missing localStorage in jsdom env) and 5 UI tests (`bible-reader.test.tsx` theme settings) fail identically on `main`.

## Test plan

- [x] `pnpm --filter @youversion/platform-core test` — 308 passed, including 10 rewritten highlights contract tests
- [x] `pnpm --filter @youversion/platform-react-hooks test` — only the 4 pre-existing `YouVersionProvider` failures remain (identical on main)
- [x] `pnpm typecheck` / `pnpm lint` — clean
- [ ] Manual verification against the live API with a signed-in session that has the `highlights` scope (blocked on a real token; follow-up in YPE-1034 wiring)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `HighlightsClient` to match the live YouVersion highlights API contract. Every request was previously rejected with 401 because auth was sent as a `lat` query parameter instead of an `Authorization: Bearer` header, and field names / request shapes differed from the documented API. The rewrite also un-skips and rewrites the highlights test suite so the MSW handlers now enforce the contract (auth, field names, enveloped POST body), preventing future drift.

- **Auth & field mapping**: Bearer header replaces `lat` query param; `bible_id` is used on the wire while the SDK keeps `version_id` in public types, with a clean `toHighlight()` mapper at the boundary.
- **Request / response hardening**: POST sends the required `{ request_id, highlight: { … } }` envelope; `getHighlights` and `deleteHighlight` now enforce their required parameters; Zod schemas validate all responses; 204 (no highlights) is treated as an empty collection; uppercase hex colors are normalized to lowercase before sending.
- **New surface**: `getRecentColors()` added to `HighlightsClient` and exposed from `useHighlights` for color-picker UIs.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all four endpoint contract fixes are correctly implemented and the MSW handlers now enforce them so any future drift will fail CI.

The implementation changes are precise and internally consistent: Bearer auth, wire-field mapping, enveloped POST body, 204 handling, and Zod validation all align with the documented API. The HEX_COLOR_REGEX was updated to case-insensitive, addressing the mismatch flagged in the previous review cycle. Tests cover the happy path, 204 edge case, malformed-response error, and uppercase color normalization. The changeset bump level is worth a second look but does not affect runtime correctness.

.changeset/fix-highlights-api-contract.md — worth a second look on the minor-vs-major bump decision for 2.x packages.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/core/src/highlights.ts | Rewrites HighlightsClient to use Bearer auth, bible_id field mapping, enveloped POST body, Zod response validation, and 204 handling; adds getRecentColors(). All contract fixes are correct and well-commented. |
| packages/core/src/schemas/highlight.ts | Adds wire schemas (HighlightWireSchema, HighlightCollectionWireSchema, RecentHighlightColorsWireSchema) and toHighlight() mapper. HEX_COLOR_REGEX is now case-insensitive, fixing the previously flagged mismatch. |
| packages/core/src/client.ts | Adds optional headers parameter to post() and delete(), enabling callers to inject Authorization: Bearer headers without touching the shared defaultHeaders. |
| packages/hooks/src/useHighlights.ts | Makes options and deleteOptions required to match the now-required API params; adds getRecentColors() callback; dep-array comment explains the primitive-keying strategy. |
| packages/core/src/__tests__/handlers.ts | MSW handlers now enforce Bearer auth (401 on missing token), bible_id naming, and enveloped POST body (400 on wrong shape), so client drift breaks tests immediately. |
| packages/core/src/__tests__/highlights.test.ts | Un-skipped and rewrote 10 tests covering the new contract; tests the Bearer header, bible_id param, enveloped POST, 204 handling, malformed-response error, and uppercase color normalization. |
| packages/hooks/src/useHighlights.test.tsx | Test suite updated to match the new required-options signatures and adds coverage for getRecentColors delegation. |
| .changeset/fix-highlights-api-contract.md | Changeset marked as minor for both 2.x packages; the required-param promotions are technically semver-major, though the feature was never functional before. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App as App / useHighlights
    participant HC as HighlightsClient
    participant AC as ApiClient
    participant API as Highlights API

    Note over HC: getAuthToken(lat?) → Bearer header

    App->>HC: "getHighlights({ version_id, passage_id }, lat?)"
    HC->>HC: validateVersionId / validatePassageId
    HC->>AC: "get("/v1/highlights", { bible_id, passage_id }, { Authorization: Bearer })"
    AC->>API: "GET /v1/highlights?bible_id=&passage_id= + Bearer"
    API-->>AC: "200 { data: [{ bible_id, passage_id, color }] } OR 204"
    AC-->>HC: raw response
    HC->>HC: HighlightCollectionWireSchema.safeParse()
    HC->>HC: data.map(toHighlight) — bible_id → version_id
    HC-->>App: "Collection<Highlight>"

    App->>HC: "createHighlight({ version_id, passage_id, color }, lat?)"
    HC->>HC: validate + color.toLowerCase()
    HC->>AC: "post("/v1/highlights", { request_id, highlight: { bible_id, passage_id, color } }, headers)"
    AC->>API: POST /v1/highlights + Bearer
    API-->>AC: "201 { bible_id, passage_id, color }"
    AC-->>HC: raw response
    HC->>HC: HighlightWireSchema.safeParse() → toHighlight()
    HC-->>App: Highlight

    App->>HC: "deleteHighlight(passageId, { version_id }, lat?)"
    HC->>HC: validatePassageId / validateVersionId
    HC->>AC: "delete("/v1/highlights/{passageId}", { bible_id }, { Authorization: Bearer })"
    AC->>API: "DELETE /v1/highlights/{passageId}?bible_id= + Bearer"
    API-->>AC: 204
    HC-->>App: void

    App->>HC: getRecentColors(lat?)
    HC->>AC: "get("/v1/highlights/recent-colors", undefined, { Authorization: Bearer })"
    AC->>API: GET /v1/highlights/recent-colors + Bearer
    API-->>AC: "200 { data: [{ color }] } OR 204"
    HC->>HC: RecentHighlightColorsWireSchema.safeParse()
    HC-->>App: string[]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App as App / useHighlights
    participant HC as HighlightsClient
    participant AC as ApiClient
    participant API as Highlights API

    Note over HC: getAuthToken(lat?) → Bearer header

    App->>HC: "getHighlights({ version_id, passage_id }, lat?)"
    HC->>HC: validateVersionId / validatePassageId
    HC->>AC: "get("/v1/highlights", { bible_id, passage_id }, { Authorization: Bearer })"
    AC->>API: "GET /v1/highlights?bible_id=&passage_id= + Bearer"
    API-->>AC: "200 { data: [{ bible_id, passage_id, color }] } OR 204"
    AC-->>HC: raw response
    HC->>HC: HighlightCollectionWireSchema.safeParse()
    HC->>HC: data.map(toHighlight) — bible_id → version_id
    HC-->>App: "Collection<Highlight>"

    App->>HC: "createHighlight({ version_id, passage_id, color }, lat?)"
    HC->>HC: validate + color.toLowerCase()
    HC->>AC: "post("/v1/highlights", { request_id, highlight: { bible_id, passage_id, color } }, headers)"
    AC->>API: POST /v1/highlights + Bearer
    API-->>AC: "201 { bible_id, passage_id, color }"
    AC-->>HC: raw response
    HC->>HC: HighlightWireSchema.safeParse() → toHighlight()
    HC-->>App: Highlight

    App->>HC: "deleteHighlight(passageId, { version_id }, lat?)"
    HC->>HC: validatePassageId / validateVersionId
    HC->>AC: "delete("/v1/highlights/{passageId}", { bible_id }, { Authorization: Bearer })"
    AC->>API: "DELETE /v1/highlights/{passageId}?bible_id= + Bearer"
    API-->>AC: 204
    HC-->>App: void

    App->>HC: getRecentColors(lat?)
    HC->>AC: "get("/v1/highlights/recent-colors", undefined, { Authorization: Bearer })"
    AC->>API: GET /v1/highlights/recent-colors + Bearer
    API-->>AC: "200 { data: [{ color }] } OR 204"
    HC->>HC: RecentHighlightColorsWireSchema.safeParse()
    HC-->>App: string[]
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/core/src/highlights.ts`, line 59-71 ([link](https://github.com/youversion/platform-sdk-react/blob/906379b87a9cedc83521fd7a3cab698f691628bb/packages/core/src/highlights.ts#L59-L71)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`localStorage` guard makes the auth fallback silently different across environments.** When `typeof localStorage === 'undefined'` (Node.js test environment, SSR), `getAuthToken(undefined)` returns `null` and immediately throws. That's the intended path for unauthenticated callers. However, the guard also means that any call inside a server-side context that *should* find a token in `YouVersionPlatformConfiguration` will always throw, even if the platform configuration has been populated another way. Worth a comment that makes this intent explicit, and a test confirming SSR callers must pass `lat` explicitly.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/core/src/highlights.ts
   Line: 59-71

   Comment:
   **`localStorage` guard makes the auth fallback silently different across environments.** When `typeof localStorage === 'undefined'` (Node.js test environment, SSR), `getAuthToken(undefined)` returns `null` and immediately throws. That's the intended path for unauthenticated callers. However, the guard also means that any call inside a server-side context that *should* find a token in `YouVersionPlatformConfiguration` will always throw, even if the platform configuration has been populated another way. Worth a comment that makes this intent explicit, and a test confirming SSR callers must pass `lat` explicitly.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcore%2Fsrc%2Fhighlights.ts%0ALine%3A%2059-71%0A%0AComment%3A%0A**%60localStorage%60%20guard%20makes%20the%20auth%20fallback%20silently%20different%20across%20environments.**%20When%20%60typeof%20localStorage%20%3D%3D%3D%20'undefined'%60%20%28Node.js%20test%20environment%2C%20SSR%29%2C%20%60getAuthToken%28undefined%29%60%20returns%20%60null%60%20and%20immediately%20throws.%20That's%20the%20intended%20path%20for%20unauthenticated%20callers.%20However%2C%20the%20guard%20also%20means%20that%20any%20call%20inside%20a%20server-side%20context%20that%20*should*%20find%20a%20token%20in%20%60YouVersionPlatformConfiguration%60%20will%20always%20throw%2C%20even%20if%20the%20platform%20configuration%20has%20been%20populated%20another%20way.%20Worth%20a%20comment%20that%20makes%20this%20intent%20explicit%2C%20and%20a%20test%20confirming%20SSR%20callers%20must%20pass%20%60lat%60%20explicitly.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-react&pr=279&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcore%2Fsrc%2Fhighlights.ts%0ALine%3A%2059-71%0A%0AComment%3A%0A**%60localStorage%60%20guard%20makes%20the%20auth%20fallback%20silently%20different%20across%20environments.**%20When%20%60typeof%20localStorage%20%3D%3D%3D%20'undefined'%60%20%28Node.js%20test%20environment%2C%20SSR%29%2C%20%60getAuthToken%28undefined%29%60%20returns%20%60null%60%20and%20immediately%20throws.%20That's%20the%20intended%20path%20for%20unauthenticated%20callers.%20However%2C%20the%20guard%20also%20means%20that%20any%20call%20inside%20a%20server-side%20context%20that%20*should*%20find%20a%20token%20in%20%60YouVersionPlatformConfiguration%60%20will%20always%20throw%2C%20even%20if%20the%20platform%20configuration%20has%20been%20populated%20another%20way.%20Worth%20a%20comment%20that%20makes%20this%20intent%20explicit%2C%20and%20a%20test%20confirming%20SSR%20callers%20must%20pass%20%60lat%60%20explicitly.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=279&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-react%22%20on%20the%20existing%20branch%20%22dk%2Ffix-highlights-api-contract%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dk%2Ffix-highlights-api-contract%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcore%2Fsrc%2Fhighlights.ts%0ALine%3A%2059-71%0A%0AComment%3A%0A**%60localStorage%60%20guard%20makes%20the%20auth%20fallback%20silently%20different%20across%20environments.**%20When%20%60typeof%20localStorage%20%3D%3D%3D%20'undefined'%60%20%28Node.js%20test%20environment%2C%20SSR%29%2C%20%60getAuthToken%28undefined%29%60%20returns%20%60null%60%20and%20immediately%20throws.%20That's%20the%20intended%20path%20for%20unauthenticated%20callers.%20However%2C%20the%20guard%20also%20means%20that%20any%20call%20inside%20a%20server-side%20context%20that%20*should*%20find%20a%20token%20in%20%60YouVersionPlatformConfiguration%60%20will%20always%20throw%2C%20even%20if%20the%20platform%20configuration%20has%20been%20populated%20another%20way.%20Worth%20a%20comment%20that%20makes%20this%20intent%20explicit%2C%20and%20a%20test%20confirming%20SSR%20callers%20must%20pass%20%60lat%60%20explicitly.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-react&pr=279&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

2. `packages/hooks/src/useHighlights.ts`, line 45-51 ([link](https://github.com/youversion/platform-sdk-react/blob/906379b87a9cedc83521fd7a3cab698f691628bb/packages/hooks/src/useHighlights.ts#L45-L51)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`options` object identity is unstable if passed as an inline literal.** The factory `() => highlightsClient.getHighlights(options)` captures the full `options` reference, but the dependency array correctly uses only the primitives `options.version_id` and `options.passage_id`. This means the closure may hold a stale object reference while the primitives stay stable — in practice this is fine here, but callers who add fields to `GetHighlightsOptions` later might be surprised. A quick clarifying comment on the dep-array strategy would help future maintainers.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/hooks/src/useHighlights.ts
   Line: 45-51

   Comment:
   **`options` object identity is unstable if passed as an inline literal.** The factory `() => highlightsClient.getHighlights(options)` captures the full `options` reference, but the dependency array correctly uses only the primitives `options.version_id` and `options.passage_id`. This means the closure may hold a stale object reference while the primitives stay stable — in practice this is fine here, but callers who add fields to `GetHighlightsOptions` later might be surprised. A quick clarifying comment on the dep-array strategy would help future maintainers.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fhooks%2Fsrc%2FuseHighlights.ts%0ALine%3A%2045-51%0A%0AComment%3A%0A**%60options%60%20object%20identity%20is%20unstable%20if%20passed%20as%20an%20inline%20literal.**%20The%20factory%20%60%28%29%20%3D%3E%20highlightsClient.getHighlights%28options%29%60%20captures%20the%20full%20%60options%60%20reference%2C%20but%20the%20dependency%20array%20correctly%20uses%20only%20the%20primitives%20%60options.version_id%60%20and%20%60options.passage_id%60.%20This%20means%20the%20closure%20may%20hold%20a%20stale%20object%20reference%20while%20the%20primitives%20stay%20stable%20%E2%80%94%20in%20practice%20this%20is%20fine%20here%2C%20but%20callers%20who%20add%20fields%20to%20%60GetHighlightsOptions%60%20later%20might%20be%20surprised.%20A%20quick%20clarifying%20comment%20on%20the%20dep-array%20strategy%20would%20help%20future%20maintainers.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-react&pr=279&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fhooks%2Fsrc%2FuseHighlights.ts%0ALine%3A%2045-51%0A%0AComment%3A%0A**%60options%60%20object%20identity%20is%20unstable%20if%20passed%20as%20an%20inline%20literal.**%20The%20factory%20%60%28%29%20%3D%3E%20highlightsClient.getHighlights%28options%29%60%20captures%20the%20full%20%60options%60%20reference%2C%20but%20the%20dependency%20array%20correctly%20uses%20only%20the%20primitives%20%60options.version_id%60%20and%20%60options.passage_id%60.%20This%20means%20the%20closure%20may%20hold%20a%20stale%20object%20reference%20while%20the%20primitives%20stay%20stable%20%E2%80%94%20in%20practice%20this%20is%20fine%20here%2C%20but%20callers%20who%20add%20fields%20to%20%60GetHighlightsOptions%60%20later%20might%20be%20surprised.%20A%20quick%20clarifying%20comment%20on%20the%20dep-array%20strategy%20would%20help%20future%20maintainers.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=279&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-react%22%20on%20the%20existing%20branch%20%22dk%2Ffix-highlights-api-contract%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dk%2Ffix-highlights-api-contract%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fhooks%2Fsrc%2FuseHighlights.ts%0ALine%3A%2045-51%0A%0AComment%3A%0A**%60options%60%20object%20identity%20is%20unstable%20if%20passed%20as%20an%20inline%20literal.**%20The%20factory%20%60%28%29%20%3D%3E%20highlightsClient.getHighlights%28options%29%60%20captures%20the%20full%20%60options%60%20reference%2C%20but%20the%20dependency%20array%20correctly%20uses%20only%20the%20primitives%20%60options.version_id%60%20and%20%60options.passage_id%60.%20This%20means%20the%20closure%20may%20hold%20a%20stale%20object%20reference%20while%20the%20primitives%20stay%20stable%20%E2%80%94%20in%20practice%20this%20is%20fine%20here%2C%20but%20callers%20who%20add%20fields%20to%20%60GetHighlightsOptions%60%20later%20might%20be%20surprised.%20A%20quick%20clarifying%20comment%20on%20the%20dep-array%20strategy%20would%20help%20future%20maintainers.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youversion%2Fplatform-sdk-react&pr=279&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["docs(highlights): clarify auth fallback ..."](https://github.com/youversion/platform-sdk-react/commit/cef7b5b53943a75ef56b96ad22878b04074190bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42792361)</sub>

<!-- /greptile_comment -->