### PR TITLE
feat(auth): request highlights permission at sign-in

### DIFF
--- a/.changeset/request-highlights-permission.md
+++ b/.changeset/request-highlights-permission.md
@@ -1,0 +1,13 @@
+---
+'@youversion/platform-core': minor
+'@youversion/platform-react-hooks': minor
+'@youversion/platform-react-ui': minor
+---
+
+Allow requesting YouVersion data-exchange permissions (e.g. `highlights`) at sign-in. These are intentionally not OIDC scopes: they ride alongside the standard `scope` param as repeatable `requested_permissions[]` query params on the authorize URL and are authorized via a separate per-app ACL rather than the token's scope claim.
+
+- `YouVersionAPIUsers.signIn(redirectURL, scopes?, permissions?)` and the underlying PKCE authorization request builder now accept a `permissions` array typed as `SignInWithYouVersionPermissionValues[]`.
+- `useYVAuth().signIn({ permissions })` forwards them from React.
+- `<YouVersionAuthButton permissions={['highlights']} />` requests them from the sign-in button.
+
+Scopes and permissions are separate arguments; existing calls that only pass scopes are unaffected.

--- a/packages/core/src/SignInWithYouVersionPKCE.ts
+++ b/packages/core/src/SignInWithYouVersionPKCE.ts
@@ -1,5 +1,5 @@
 import { YouVersionPlatformConfiguration } from './YouVersionPlatformConfiguration';
-import type { AuthenticationScopes } from './types';
+import type { AuthenticationScopes, SignInWithYouVersionPermissionValues } from './types';
 
 type SignInWithYouVersionPKCEParameters = {
   readonly codeVerifier: string;
@@ -17,6 +17,7 @@ export class SignInWithYouVersionPKCEAuthorizationRequestBuilder {
     appKey: string,
     redirectURL: URL,
     scopes?: AuthenticationScopes[],
+    permissions?: SignInWithYouVersionPermissionValues[],
   ): Promise<SignInWithYouVersionPKCEAuthorizationRequest> {
     const codeVerifier = this.randomURLSafeString(32);
     const codeChallenge = await this.codeChallenge(codeVerifier);
@@ -30,7 +31,7 @@ export class SignInWithYouVersionPKCEAuthorizationRequestBuilder {
       nonce,
     };
 
-    const url = this.authorizeURL(appKey, redirectURL, parameters, scopes);
+    const url = this.authorizeURL(appKey, redirectURL, parameters, scopes, permissions);
 
     return { url, parameters };
   }
@@ -40,6 +41,7 @@ export class SignInWithYouVersionPKCEAuthorizationRequestBuilder {
     redirectURL: URL,
     parameters: SignInWithYouVersionPKCEParameters,
     scopes?: AuthenticationScopes[],
+    permissions?: SignInWithYouVersionPermissionValues[],
   ): URL {
     const components = new URL(`https://${YouVersionPlatformConfiguration.apiHost}/auth/authorize`);
 
@@ -64,6 +66,14 @@ export class SignInWithYouVersionPKCEAuthorizationRequestBuilder {
     const scopeValue = this.scopeValue(scopes || []);
     if (scopeValue) {
       queryParams.set('scope', scopeValue);
+    }
+
+    // YouVersion data-exchange permissions (e.g. `highlights`) are intentionally
+    // NOT OIDC scopes. They ride alongside the standard scopes as a repeatable
+    // `requested_permissions[]` query param and are authorized via a separate
+    // per-app ACL rather than the token's scope claim.
+    for (const permission of permissions ?? []) {
+      queryParams.append('requested_permissions[]', permission);
     }
 
     components.search = queryParams.toString();

--- a/packages/core/src/Users.ts
+++ b/packages/core/src/Users.ts
@@ -1,4 +1,4 @@
-import type { AuthenticationScopes } from './types';
+import type { AuthenticationScopes, SignInWithYouVersionPermissionValues } from './types';
 import { YouVersionUserInfo } from './YouVersionUserInfo';
 import { YouVersionPlatformConfiguration } from './YouVersionPlatformConfiguration';
 import { SignInWithYouVersionPKCEAuthorizationRequestBuilder } from './SignInWithYouVersionPKCE';
@@ -11,11 +11,17 @@ export class YouVersionAPIUsers {
    * This function authenticates the user with YouVersion.
    * The function redirects to the YouVersion authorization URL and expects the callback to be handled separately.
    *
-   * @param scopes - The scopes given to the authentication call.
    * @param redirectURL - The URL to redirect back to after authentication.
+   * @param scopes - The OIDC scopes given to the authentication call (e.g. `profile`, `email`).
+   * @param permissions - YouVersion data-exchange permissions to request (e.g. `highlights`).
+   *   These are sent as `requested_permissions[]` params, separate from OIDC scopes.
    * @throws An error if authentication fails or configuration is invalid.
    */
-  static async signIn(redirectURL: string, scopes?: AuthenticationScopes[]): Promise<void> {
+  static async signIn(
+    redirectURL: string,
+    scopes?: AuthenticationScopes[],
+    permissions?: SignInWithYouVersionPermissionValues[],
+  ): Promise<void> {
     const appKey = YouVersionPlatformConfiguration.appKey;
     if (!appKey) {
       throw new Error('YouVersionPlatformConfiguration.appKey must be set before calling signIn');
@@ -25,6 +31,7 @@ export class YouVersionAPIUsers {
       appKey,
       new URL(redirectURL),
       scopes,
+      permissions,
     );
 
     // Store auth data for callback handler

--- a/packages/core/src/__tests__/SignInWithYouVersionPKCE.test.ts
+++ b/packages/core/src/__tests__/SignInWithYouVersionPKCE.test.ts
@@ -216,6 +216,53 @@ describe('SignInWithYouVersionPKCEAuthorizationRequestBuilder', () => {
       expect(scope).toBe('openid');
     });
 
+    it('should send requested permissions as requested_permissions[] params, not scopes', async () => {
+      const redirectURL = new URL('https://example.com/callback');
+
+      const result = await SignInWithYouVersionPKCEAuthorizationRequestBuilder.make(
+        'test-app-key',
+        redirectURL,
+        ['profile', 'email'],
+        ['highlights'],
+      );
+
+      const params = new URLSearchParams(result.url.search);
+
+      // Permission rides alongside scopes as a separate param
+      expect(params.getAll('requested_permissions[]')).toEqual(['highlights']);
+      // ...and is NOT folded into the OIDC scope value
+      expect(params.get('scope')).not.toContain('highlights');
+      // Raw query string uses the encoded array-bracket syntax the API expects
+      expect(result.url.search).toContain('requested_permissions%5B%5D=highlights');
+    });
+
+    it('should support multiple requested permissions', async () => {
+      const redirectURL = new URL('https://example.com/callback');
+
+      const result = await SignInWithYouVersionPKCEAuthorizationRequestBuilder.make(
+        'test-app-key',
+        redirectURL,
+        ['profile'],
+        ['highlights', 'votd'],
+      );
+
+      const params = new URLSearchParams(result.url.search);
+      expect(params.getAll('requested_permissions[]')).toEqual(['highlights', 'votd']);
+    });
+
+    it('should omit requested_permissions[] when no permissions are requested', async () => {
+      const redirectURL = new URL('https://example.com/callback');
+
+      const result = await SignInWithYouVersionPKCEAuthorizationRequestBuilder.make(
+        'test-app-key',
+        redirectURL,
+        ['profile'],
+      );
+
+      const params = new URLSearchParams(result.url.search);
+      expect(params.getAll('requested_permissions[]')).toEqual([]);
+    });
+
     it('should not duplicate openid if already present', async () => {
       const redirectURL = new URL('https://example.com/callback');
 

--- a/packages/core/src/__tests__/Users.test.ts
+++ b/packages/core/src/__tests__/Users.test.ts
@@ -79,6 +79,26 @@ describe('YouVersionAPIUsers', () => {
 
       vi.restoreAllMocks();
     });
+
+    it('should forward requested permissions to the authorize URL', async () => {
+      vi.spyOn(crypto, 'getRandomValues').mockImplementation((array: ArrayBufferView) => {
+        if (array instanceof Uint8Array) {
+          for (let i = 0; i < array.length; i++) {
+            array[i] = i;
+          }
+        }
+        return array;
+      });
+
+      vi.spyOn(crypto.subtle, 'digest').mockResolvedValue(new Uint8Array(32).buffer);
+      mocks.btoa.mockReturnValue('mockBase64Value');
+
+      await YouVersionAPIUsers.signIn('https://example.com/callback', ['profile'], ['highlights']);
+
+      expect(mocks.window.location.href).toContain('requested_permissions%5B%5D=highlights');
+
+      vi.restoreAllMocks();
+    });
   });
 
   describe('handleAuthCallback', () => {

--- a/packages/hooks/src/useYVAuth.test.tsx
+++ b/packages/hooks/src/useYVAuth.test.tsx
@@ -82,7 +82,24 @@ describe('useYVAuth', () => {
         await result.current.signIn({ redirectUrl, scopes: ['profile'] });
       });
 
-      expect(vi.mocked(YouVersionAPIUsers).signIn).toHaveBeenCalledWith(redirectUrl, ['profile']);
+      expect(vi.mocked(YouVersionAPIUsers).signIn).toHaveBeenCalledWith(
+        redirectUrl,
+        ['profile'],
+        undefined,
+      );
+    });
+
+    it('should forward requested permissions to YouVersionAPIUsers.signIn', async () => {
+      const { result } = await renderAuthHook();
+      const redirectUrl = 'https://example.com/callback';
+
+      await act(async () => {
+        await result.current.signIn({ redirectUrl, permissions: ['highlights'] });
+      });
+
+      expect(vi.mocked(YouVersionAPIUsers).signIn).toHaveBeenCalledWith(redirectUrl, undefined, [
+        'highlights',
+      ]);
     });
 
     it('should call signIn with empty scopes when not provided', async () => {
@@ -106,7 +123,11 @@ describe('useYVAuth', () => {
       });
 
       expect(vi.mocked(YouVersionAPIUsers).signIn).toHaveBeenCalledTimes(1);
-      expect(vi.mocked(YouVersionAPIUsers).signIn).toHaveBeenCalledWith(redirectUrl, scopes);
+      expect(vi.mocked(YouVersionAPIUsers).signIn).toHaveBeenCalledWith(
+        redirectUrl,
+        scopes,
+        undefined,
+      );
     });
 
     it('should call YouVersionAPIUsers.signIn exactly once without scopes', async () => {
@@ -155,6 +176,7 @@ describe('useYVAuth', () => {
       expect(vi.mocked(YouVersionAPIUsers).signIn).toHaveBeenCalledWith(
         'http://test.example.com',
         scopes,
+        undefined,
       );
     });
   });

--- a/packages/hooks/src/useYVAuth.test.tsx
+++ b/packages/hooks/src/useYVAuth.test.tsx
@@ -110,7 +110,11 @@ describe('useYVAuth', () => {
         await result.current.signIn({ redirectUrl });
       });
 
-      expect(vi.mocked(YouVersionAPIUsers).signIn).toHaveBeenCalledWith(redirectUrl);
+      expect(vi.mocked(YouVersionAPIUsers).signIn).toHaveBeenCalledWith(
+        redirectUrl,
+        undefined,
+        undefined,
+      );
     });
 
     it('should call YouVersionAPIUsers.signIn exactly once with scopes', async () => {
@@ -139,7 +143,11 @@ describe('useYVAuth', () => {
       });
 
       expect(vi.mocked(YouVersionAPIUsers).signIn).toHaveBeenCalledTimes(1);
-      expect(vi.mocked(YouVersionAPIUsers).signIn).toHaveBeenCalledWith(redirectUrl);
+      expect(vi.mocked(YouVersionAPIUsers).signIn).toHaveBeenCalledWith(
+        redirectUrl,
+        undefined,
+        undefined,
+      );
     });
 
     it('should throw error when signIn fails', async () => {
@@ -162,7 +170,11 @@ describe('useYVAuth', () => {
         await result.current.signIn();
       });
 
-      expect(vi.mocked(YouVersionAPIUsers).signIn).toHaveBeenCalledWith('http://test.example.com');
+      expect(vi.mocked(YouVersionAPIUsers).signIn).toHaveBeenCalledWith(
+        'http://test.example.com',
+        undefined,
+        undefined,
+      );
     });
 
     it('should use redirectUri from provider with scopes when redirectUrl is not passed', async () => {

--- a/packages/hooks/src/useYVAuth.ts
+++ b/packages/hooks/src/useYVAuth.ts
@@ -6,6 +6,7 @@ import {
   type SignInWithYouVersionResult,
   type YouVersionUserInfo,
   type AuthenticationScopes,
+  type SignInWithYouVersionPermissionValues,
 } from '@youversion/platform-core';
 import { useYouVersionAuthContext } from './context/YouVersionAuthContext';
 
@@ -14,7 +15,11 @@ export interface UseYVAuthReturn {
   auth: AuthenticationState;
 
   // Actions
-  signIn: (params?: { redirectUrl?: string; scopes?: AuthenticationScopes[] }) => Promise<void>;
+  signIn: (params?: {
+    redirectUrl?: string;
+    scopes?: AuthenticationScopes[];
+    permissions?: SignInWithYouVersionPermissionValues[];
+  }) => Promise<void>;
   signOut: () => void;
 
   // Callback processing (for callback page) - caches user info
@@ -129,15 +134,19 @@ export function useYVAuth(): UseYVAuthReturn {
 
   // Sign in function
   const signIn = useCallback(
-    async (params?: { redirectUrl?: string; scopes?: AuthenticationScopes[] }) => {
+    async (params?: {
+      redirectUrl?: string;
+      scopes?: AuthenticationScopes[];
+      permissions?: SignInWithYouVersionPermissionValues[];
+    }) => {
       const url = params?.redirectUrl ?? redirectUri;
       if (!url) {
         throw new Error(
           'redirectUrl is required. Provide it via signIn params or configure redirectUri in the auth provider.',
         );
       }
-      if (params?.scopes) {
-        await YouVersionAPIUsers.signIn(url, params.scopes);
+      if (params?.scopes || params?.permissions) {
+        await YouVersionAPIUsers.signIn(url, params.scopes, params.permissions);
       } else {
         await YouVersionAPIUsers.signIn(url);
       }

--- a/packages/hooks/src/useYVAuth.ts
+++ b/packages/hooks/src/useYVAuth.ts
@@ -145,11 +145,7 @@ export function useYVAuth(): UseYVAuthReturn {
           'redirectUrl is required. Provide it via signIn params or configure redirectUri in the auth provider.',
         );
       }
-      if (params?.scopes || params?.permissions) {
-        await YouVersionAPIUsers.signIn(url, params.scopes, params.permissions);
-      } else {
-        await YouVersionAPIUsers.signIn(url);
-      }
+      await YouVersionAPIUsers.signIn(url, params?.scopes, params?.permissions);
       // Note: This will redirect, so code after this won't execute
     },
     [redirectUri],

--- a/packages/ui/src/components/YouVersionAuthButton.tsx
+++ b/packages/ui/src/components/YouVersionAuthButton.tsx
@@ -2,7 +2,10 @@ import React, { useMemo } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import i18n from '@/i18n';
 import { LoaderIcon } from './icons/loader';
-import { type AuthenticationScopes } from '@youversion/platform-core';
+import {
+  type AuthenticationScopes,
+  type SignInWithYouVersionPermissionValues,
+} from '@youversion/platform-core';
 import { useYVAuth, useTheme } from '@youversion/platform-react-hooks';
 import { Button } from '../components/ui/button';
 import { YouVersionLogo } from './icons/youversion-logo';
@@ -15,6 +18,11 @@ interface SignInAuthProps {
    */
   onAuthError?: (error: Error) => void;
   scopes?: AuthenticationScopes[];
+  /**
+   * YouVersion data-exchange permissions to request at sign-in (e.g. `highlights`).
+   * These are distinct from OIDC `scopes` and are sent as `requested_permissions[]`.
+   */
+  permissions?: SignInWithYouVersionPermissionValues[];
 }
 
 export interface YouVersionAuthButtonProps
@@ -111,6 +119,7 @@ export const YouVersionAuthButton = React.forwardRef<HTMLButtonElement, YouVersi
       onClick,
       mode,
       scopes = [],
+      permissions,
       radius = 'rounded',
       size = 'default',
       text,
@@ -137,6 +146,7 @@ export const YouVersionAuthButton = React.forwardRef<HTMLButtonElement, YouVersi
         } else {
           await signIn({
             scopes,
+            permissions,
           });
         }
       } catch (error) {


### PR DESCRIPTION
## What

Lets apps request the **`highlights`** permission (and future data-exchange permissions) at sign-in.

## Why it's not a scope

`highlights` is deliberately **not** an OIDC scope. Per the YouVersion authorize contract, it rides alongside `scope` as a repeatable query param and is authorized via a separate per-app ACL:

```
/auth/authorize?...&scope=openid+profile+email&requested_permissions[]=highlights
```

Scopes stay generic/portable (`profile`, `email`); bespoke YouVersion data (highlights, and later `prayer_requests`, etc.) lives in `requested_permissions[]`.

## Changes

| Layer | Change |
|-------|--------|
| **core** | `signIn(url, scopes?, permissions?)` + PKCE builder append `requested_permissions[]` |
| **hooks** | `useYVAuth().signIn({ permissions })` |
| **ui** | `<YouVersionAuthButton permissions={['highlights']} />` |

Scopes and permissions are separate args. Existing scope-only calls are unaffected.

## Test plan

- [x] Core PKCE + Users suites (53 pass) — asserts `requested_permissions[]`, multiple perms, omitted-when-empty, and not folded into `scope`
- [x] Hooks `useYVAuth` (19 pass)
- [x] `pnpm typecheck` clean, Prettier + ESLint clean
- [x] Changeset added (minor, all 3 packages)

## Not in scope

Grant **verification** after callback. This wires up *requesting*; how a consumer confirms the grant (token claim / userinfo / ACL call) is unresolved and left for a follow-up once the backend contract is known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an optional `permissions` parameter to the sign-in stack — core PKCE builder, `YouVersionAPIUsers.signIn`, `useYVAuth`, and `YouVersionAuthButton` — so apps can request YouVersion data-exchange permissions (starting with `highlights`) at authorize time. The new `requested_permissions[]` query params ride alongside OIDC `scope` as the backend contract requires and are kept fully separate from it.

- **Core**: `SignInWithYouVersionPKCEAuthorizationRequestBuilder` appends each permission as a `requested_permissions[]` param; three new test cases cover single permission, multiple permissions, and the empty/omit case.
- **Hooks**: `useYVAuth().signIn` accepts a `permissions` array and forwards it via optional chaining, replacing the previous redundant if/else branch.
- **UI**: `YouVersionAuthButton` exposes a `permissions` prop typed as `SignInWithYouVersionPermissionValues[]`; all three packages receive a `minor` changeset bump.

<h3>Confidence Score: 5/5</h3>

Additive change with no impact on existing call sites; permissions are appended as typed, URL-encoded query params and never mixed into the OIDC scope string.

The change is backward compatible at every layer, the new code paths are exercised by targeted unit tests (including a guard that `highlights` never appears in `scope`), and the PKCE URL builder uses `URLSearchParams.append` which handles encoding correctly.

No files require special attention; the only suggestion is adding `SignInWithYouVersionPermissionValues` to the UI package re-export list for a complete public surface.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/SignInWithYouVersionPKCE.ts | Adds `permissions` parameter to `make` and `authorizeURL`; appends each permission as a `requested_permissions[]` query param. Logic is correct and well-commented. |
| packages/core/src/Users.ts | Threads the optional `permissions` array through `YouVersionAPIUsers.signIn` to the PKCE builder. Backward compatible; no logic issues. |
| packages/hooks/src/useYVAuth.ts | Adds `permissions` to the `signIn` params object and forwards it via optional chaining, replacing the previous redundant if/else branch. Clean and correct. |
| packages/ui/src/components/YouVersionAuthButton.tsx | Exposes `permissions` prop and passes it through to `signIn`. JSDoc example imports `SignInWithYouVersionPermission` but the existing docblock example doesn't demonstrate its usage — minor pre-existing doc gap. |
| packages/core/src/__tests__/SignInWithYouVersionPKCE.test.ts | Adds three new test cases: single permission, multiple permissions, and omit-when-absent. Also verifies permissions don't leak into the OIDC `scope` param. Good coverage. |
| packages/hooks/src/useYVAuth.test.tsx | Updates existing assertions to match the new always-3-arg call shape and adds a new test for `permissions` forwarding. All assertions align with the updated implementation. |
| .changeset/request-highlights-permission.md | Marks all three packages as `minor` bumps, which is appropriate for a backward-compatible additive API change. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App
    participant YouVersionAuthButton
    participant useYVAuth
    participant YouVersionAPIUsers
    participant PKCEBuilder as SignInWithYouVersionPKCEAuthorizationRequestBuilder
    participant Browser

    App->>YouVersionAuthButton: "render permissions={['highlights']}"
    YouVersionAuthButton->>useYVAuth: "signIn({ scopes, permissions })"
    useYVAuth->>YouVersionAPIUsers: signIn(url, scopes, permissions)
    YouVersionAPIUsers->>PKCEBuilder: make(appKey, redirectURL, scopes, permissions)
    PKCEBuilder->>PKCEBuilder: authorizeURL(..., scopes, permissions)
    Note over PKCEBuilder: queryParams.set('scope', 'openid profile')<br/>queryParams.append('requested_permissions[]', 'highlights')
    PKCEBuilder-->>YouVersionAPIUsers: "{ url, parameters }"
    YouVersionAPIUsers->>Browser: "window.location.href = url"
    Note over Browser: /auth/authorize?scope=openid+profile&requested_permissions%5B%5D=highlights
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App
    participant YouVersionAuthButton
    participant useYVAuth
    participant YouVersionAPIUsers
    participant PKCEBuilder as SignInWithYouVersionPKCEAuthorizationRequestBuilder
    participant Browser

    App->>YouVersionAuthButton: "render permissions={['highlights']}"
    YouVersionAuthButton->>useYVAuth: "signIn({ scopes, permissions })"
    useYVAuth->>YouVersionAPIUsers: signIn(url, scopes, permissions)
    YouVersionAPIUsers->>PKCEBuilder: make(appKey, redirectURL, scopes, permissions)
    PKCEBuilder->>PKCEBuilder: authorizeURL(..., scopes, permissions)
    Note over PKCEBuilder: queryParams.set('scope', 'openid profile')<br/>queryParams.append('requested_permissions[]', 'highlights')
    PKCEBuilder-->>YouVersionAPIUsers: "{ url, parameters }"
    YouVersionAPIUsers->>Browser: "window.location.href = url"
    Note over Browser: /auth/authorize?scope=openid+profile&requested_permissions%5B%5D=highlights
```

</a>

<sub>Reviews (2): Last reviewed commit: ["refactor(hooks): collapse redundant sign..."](https://github.com/youversion/platform-sdk-react/commit/9fb7e134a7666847ae3404e110716a3dc2130ca5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42786104)</sub>

<!-- /greptile_comment -->