### PR TITLE
feat(ui): add ProfileAvatar with initials fallback (YPE-3648)

### DIFF
--- a/.changeset/profile-avatar-initials-fallback.md
+++ b/.changeset/profile-avatar-initials-fallback.md
@@ -1,0 +1,5 @@
+---
+'@youversion/platform-react-ui': minor
+---
+
+Add `ProfileAvatar` component with initials fallback (YPE-3648). Signed-in users without a profile image now see their initials ("Cam Anderson" → "CA", "Cher" → "C") in a bordered circle instead of a broken avatar; loaded photos get a 3px gray ring per design. `BibleReader`'s user menu now uses `ProfileAvatar` for all authenticated states, and the component is exported for direct use.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -57,6 +57,7 @@
     "clsx": "2.1.1",
     "tailwind-merge": "3.3.1",
     "i18next": "^26.0.0",
+    "radix-ui": "^1.4.3",
     "react-i18next": "^17.0.0",
     "tw-animate-css": "1.4.0"
   },

--- a/packages/ui/src/components/bible-reader.stories.tsx
+++ b/packages/ui/src/components/bible-reader.stories.tsx
@@ -433,7 +433,7 @@ export const SignOutFlow: Story = {
     const userMenuTrigger = screen.getByTestId('user-menu-trigger');
 
     await waitFor(async () => {
-      const avatar = userMenuTrigger.querySelector('img');
+      const avatar = userMenuTrigger.querySelector('[data-slot="avatar"]');
       await expect(avatar).toBeInTheDocument();
     });
 
@@ -464,7 +464,7 @@ export const AuthenticatedWithAvatar: Story = {
   beforeEach: async () => {
     localStorage.clear();
     await setupAuthenticatedUser({
-      avatarUrl: 'https://example.com/avatar/{width}/{height}.jpg',
+      avatarUrl: 'https://notion-avatar.app/image/avatar-1.jpg',
     });
   },
   render: (args) => (
@@ -486,10 +486,11 @@ export const AuthenticatedWithAvatar: Story = {
 
     const userMenuTrigger = screen.getByTestId('user-menu-trigger');
 
+    // Radix only renders the <img> once it loads successfully.
     await waitFor(async () => {
       const avatar = userMenuTrigger.querySelector('img');
       await expect(avatar).toBeInTheDocument();
-      await expect(avatar?.getAttribute('src')).toContain('example.com/avatar');
+      await expect(avatar?.getAttribute('src')).toContain('notion-avatar.app/image/avatar-1.jpg');
     });
   },
 };
@@ -578,7 +579,13 @@ export const AuthenticatedWithoutAvatar: Story = {
     );
 
     const userMenuTrigger = screen.getByTestId('user-menu-trigger');
+    // No image URL → initials fallback ("Test User" → "TU") inside the avatar circle.
     await expect(userMenuTrigger.querySelector('img')).not.toBeInTheDocument();
+    await waitFor(async () => {
+      const fallback = userMenuTrigger.querySelector('[data-slot="avatar-fallback"]');
+      await expect(fallback).toBeInTheDocument();
+      await expect(fallback).toHaveTextContent('TU');
+    });
 
     await userEvent.click(userMenuTrigger);
 

--- a/packages/ui/src/components/bible-reader.tsx
+++ b/packages/ui/src/components/bible-reader.tsx
@@ -35,6 +35,7 @@ import { GearIcon } from './icons/gear';
 import { InfoIcon } from './icons/info';
 import { LoaderIcon } from './icons/loader';
 import { PersonIcon } from './icons/person';
+import { ProfileAvatar } from './profile-avatar';
 import { Button } from './ui/button';
 import { Popover, PopoverClose, PopoverContent, PopoverTrigger } from './ui/popover';
 import { VerseActionPopover } from './verse-action-popover';
@@ -858,12 +859,13 @@ function UserMenu() {
   return (
     <Popover>
       <PopoverTrigger asChild data-testid="user-menu-trigger">
-        {auth.isAuthenticated && userInfo?.avatarUrlFormat ? (
+        {auth.isAuthenticated ? (
           <Button size="icon" variant="outline">
-            <img
-              src={userInfo.getAvatarUrl(32, 32)?.toString()}
-              alt={userInfo.name || t('userAvatarAlt')}
-              className="yv:size-full yv:rounded-full yv:object-cover"
+            <ProfileAvatar
+              name={userInfo?.name}
+              src={userInfo?.getAvatarUrl(32, 32)?.toString()}
+              aria-label={userInfo?.name || t('userAvatarAlt')}
+              className="yv:size-full"
             />
           </Button>
         ) : (

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -51,5 +51,6 @@ export {
 // { id, color, label } shape). Import it from './verse-action-popover' if needed.
 export { VerseActionPopover, HIGHLIGHT_COLORS } from './verse-action-popover';
 export { BibleCard, type BibleCardProps } from './bible-card';
+export { ProfileAvatar, type ProfileAvatarProps } from './profile-avatar';
 export { Separator } from './ui/separator';
 export { Textarea } from './ui/textarea';

--- a/packages/ui/src/components/profile-avatar.stories.tsx
+++ b/packages/ui/src/components/profile-avatar.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect, waitFor } from 'storybook/test';
+import { ProfileAvatar } from './profile-avatar';
+
+const TEST_IMAGE = 'https://notion-avatar.app/image/avatar-1.jpg';
+
+const meta = {
+  title: 'Components/ProfileAvatar',
+  component: ProfileAvatar,
+  parameters: {
+    layout: 'centered',
+  },
+  render: (args) => (
+    <div data-yv-sdk>
+      <ProfileAvatar {...args} />
+    </div>
+  ),
+  tags: ['autodocs'],
+  argTypes: {
+    name: {
+      control: 'text',
+      description: 'Full display name; first initial is used as the fallback',
+    },
+    src: {
+      control: 'text',
+      description: 'Profile image URL',
+    },
+  },
+} satisfies Meta<typeof ProfileAvatar>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const WithImage: Story = {
+  args: {
+    name: 'Cam Anderson',
+    src: TEST_IMAGE,
+  },
+  tags: ['integration'],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(async () => {
+      const img = canvasElement.querySelector('img');
+      await expect(img).toBeInTheDocument();
+      await expect(img).toHaveAttribute('src', TEST_IMAGE);
+    });
+    await expect(canvas.queryByText('CA')).not.toBeInTheDocument();
+  },
+};
+
+export const InitialsFallback: Story = {
+  args: {
+    name: 'Cam Anderson',
+  },
+  tags: ['integration'],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('CA')).toBeInTheDocument();
+    await expect(canvasElement.querySelector('[data-slot="avatar"]')).toHaveAttribute(
+      'aria-label',
+      'Cam Anderson',
+    );
+  },
+};
+
+export const SingleName: Story = {
+  args: {
+    name: 'Cher',
+  },
+  tags: ['integration'],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('C')).toBeInTheDocument();
+  },
+};
+
+export const EmptyName: Story = {
+  args: {
+    name: '',
+  },
+  tags: ['integration'],
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelector('[data-slot="avatar-fallback"]')).toHaveTextContent(
+      '',
+    );
+  },
+};

--- a/packages/ui/src/components/profile-avatar.test.tsx
+++ b/packages/ui/src/components/profile-avatar.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ProfileAvatar } from './profile-avatar';
+
+// Note: Radix AvatarImage only renders after the image load event fires, which
+// never happens in jsdom — image rendering is covered by the Storybook
+// integration tests in profile-avatar.stories.tsx.
+describe('ProfileAvatar', () => {
+  it('renders two-letter initials when no image URL is present', () => {
+    render(<ProfileAvatar name="Cam Anderson" />);
+    expect(screen.getByText('CA')).toBeInTheDocument();
+  });
+
+  it('uses first and last word for names with middle names', () => {
+    render(<ProfileAvatar name="Cam Michael Anderson" />);
+    expect(screen.getByText('CA')).toBeInTheDocument();
+  });
+
+  it('uppercases the initials', () => {
+    render(<ProfileAvatar name="cam anderson" />);
+    expect(screen.getByText('CA')).toBeInTheDocument();
+  });
+
+  it('handles single-name inputs', () => {
+    render(<ProfileAvatar name="Cher" />);
+    expect(screen.getByText('C')).toBeInTheDocument();
+  });
+
+  it('renders an empty circle for empty names without crashing', () => {
+    const { container } = render(<ProfileAvatar name="" />);
+    expect(container.querySelector('[data-slot="avatar-fallback"]')).toHaveTextContent('');
+  });
+
+  it('renders an empty circle for missing names without crashing', () => {
+    const { container } = render(<ProfileAvatar />);
+    expect(container.querySelector('[data-slot="avatar-fallback"]')).toHaveTextContent('');
+  });
+
+  it('sets aria-label to the full name', () => {
+    const { container } = render(<ProfileAvatar name="Cam Anderson" />);
+    expect(container.querySelector('[data-slot="avatar"]')).toHaveAttribute(
+      'aria-label',
+      'Cam Anderson',
+    );
+  });
+
+  it('renders an empty circle for whitespace-only names without crashing', () => {
+    const { container } = render(<ProfileAvatar name="   " />);
+    expect(container.querySelector('[data-slot="avatar-fallback"]')).toHaveTextContent('');
+  });
+});

--- a/packages/ui/src/components/profile-avatar.tsx
+++ b/packages/ui/src/components/profile-avatar.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { cn } from '@/lib/utils';
+
+export interface ProfileAvatarProps extends React.ComponentProps<typeof Avatar> {
+  /** Full display name; initials are used as the fallback. */
+  name?: string | null;
+  /** Profile image URL. Fallback renders while loading or on error. */
+  src?: string | null;
+}
+
+/** "Cam Anderson" → "CA", "Cher" → "C". Names always include first (and usually last). */
+function getInitials(name?: string | null): string {
+  const words = name?.trim().split(/\s+/) ?? [];
+  const first = words[0]?.charAt(0) ?? '';
+  const last = words.length > 1 ? (words[words.length - 1]?.charAt(0) ?? '') : '';
+  return (first + last).toUpperCase();
+}
+
+/**
+ * Profile avatar: shows the user's image when available, otherwise their
+ * initials ("CA" or "C") inside a bordered circle (YPE-3648).
+ */
+export function ProfileAvatar({
+  name,
+  src,
+  className,
+  ...props
+}: ProfileAvatarProps): React.ReactNode {
+  const initial = getInitials(name);
+  const [imageLoaded, setImageLoaded] = React.useState(false);
+  return (
+    <Avatar
+      aria-label={name?.trim() || undefined}
+      className={cn(imageLoaded && 'yv:bg-(--yv-gray-10) yv:p-[3px]', className)}
+      {...props}
+    >
+      {src ? (
+        <AvatarImage
+          src={src}
+          alt=""
+          className="yv:rounded-full"
+          onLoadingStatusChange={(status) => setImageLoaded(status === 'loaded')}
+        />
+      ) : null}
+      <AvatarFallback
+        className={cn(
+          'yv:border-2 yv:border-foreground yv:bg-background yv:font-sans yv:text-xs yv:font-bold yv:text-foreground',
+        )}
+      >
+        {initial}
+      </AvatarFallback>
+    </Avatar>
+  );
+}

--- a/packages/ui/src/components/profile-avatar.tsx
+++ b/packages/ui/src/components/profile-avatar.tsx
@@ -33,7 +33,7 @@ export function ProfileAvatar({
   return (
     <Avatar
       aria-label={name?.trim() || undefined}
-      className={cn(imageLoaded && 'yv:bg-(--yv-gray-10) yv:p-[3px]', className)}
+      className={cn(src && imageLoaded && 'yv:bg-(--yv-gray-10) yv:p-[3px]', className)}
       {...props}
     >
       {src ? (

--- a/packages/ui/src/components/ui/avatar.tsx
+++ b/packages/ui/src/components/ui/avatar.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { Avatar as AvatarPrimitive } from 'radix-ui';
+
+import { cn } from '@/lib/utils';
+
+function Avatar({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Root>): React.ReactNode {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      className={cn(
+        'yv:relative yv:flex yv:size-8 yv:shrink-0 yv:overflow-hidden yv:rounded-full yv:select-none',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AvatarImage({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Image>): React.ReactNode {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn('yv:aspect-square yv:size-full yv:object-cover', className)}
+      {...props}
+    />
+  );
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Fallback>): React.ReactNode {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        'yv:flex yv:size-full yv:items-center yv:justify-center yv:rounded-full',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Avatar, AvatarImage, AvatarFallback };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,6 +264,9 @@ importers:
       i18next:
         specifier: ^26.0.0
         version: 26.0.4(typescript@5.9.3)
+      radix-ui:
+        specifier: ^1.4.3
+        version: 1.4.3(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
       react:
         specifier: 19.1.2
         version: 19.1.2


### PR DESCRIPTION
## Summary
- Added `ProfileAvatar` component: Radix/shadcn avatar primitives + two-letter initials fallback (YPE-3648)
- Signed-in users without a profile photo now see initials in a bordered circle instead of a broken/missing `<img>`
- Loaded photos get a 3px gray-10 ring per Figma spec (ring hidden if image fails to load — no ring around a broken state)
- `bible-reader.tsx` UserMenu now renders `ProfileAvatar` for any authenticated user, not just ones with an avatar URL

## PR Description
### What changed
- `packages/ui/src/components/ui/avatar.tsx` — new Radix `Avatar`/`AvatarImage`/`AvatarFallback` primitives (via shadcn), `yv:`-prefixed
- `packages/ui/src/components/profile-avatar.tsx` — new `ProfileAvatar`: derives initials from `name` ("Cam Anderson" → "CA", "Cher" → "C"), shows image when it loads, ring appears only after successful load (`onLoadingStatusChange`), `aria-label` set to full name
- `packages/ui/src/components/bible-reader.tsx` — `UserMenu` swaps the raw `<img>` avatar for `ProfileAvatar`; now covers authenticated users with *and* without a photo
- `packages/ui/src/components/index.ts` — exports `ProfileAvatar`
- `packages/ui/src/components/bible-reader.stories.tsx` — updated avatar assertions (`[data-slot="avatar"]` instead of raw `img`, real test image URL, initials assertion for the no-photo signed-in story)
- New: `profile-avatar.stories.tsx` (Storybook, integration-tagged), `profile-avatar.test.tsx` (8 unit tests)
- `radix-ui` added as a dependency of `@youversion/platform-react-ui`

### Why
YPE-3648: broken/empty avatar looked bad for signed-in users with no profile image. Now falls back gracefully to initials, matching Figma.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a shared ProfileAvatar component for signed-in user avatars. The main changes are:

- New Radix-based avatar primitives in the UI package.
- New ProfileAvatar with initials fallback and loaded-image ring styling.
- BibleReader UserMenu now renders ProfileAvatar for authenticated users.
- Storybook stories and Vitest coverage for avatar states.
- UI package dependency, lockfile, export, and changeset updates.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/profile-avatar.tsx | Adds ProfileAvatar with initials fallback and image-loaded styling. |
| packages/ui/src/components/bible-reader.tsx | Replaces the signed-in avatar image branch with ProfileAvatar. |
| packages/ui/src/components/ui/avatar.tsx | Adds Radix avatar wrapper primitives for shared UI use. |
| packages/ui/package.json | Adds the radix-ui runtime dependency for the UI package. |

<sub>Reviews (3): Last reviewed commit: ["fix(ui): drop stale avatar ring when src..."](https://github.com/youversion/platform-sdk-react/commit/463ca355d6d72281ca635f0162c4e9ae9a636dc6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44262496)</sub>

<details><summary><h4>Context used (6)</h4></summary>

- Rule used - Unified versioning: All packages must maintain exa... ([source](greptile.json))
- Rule used - Auto-injected styles: index.ts calls injectStyles(... ([source](greptile.json))
- Context used - CLAUDE.md ([source](https://app.greptile.com/youversion/github/youversion/platform-sdk-react/-/custom-context?memory=1d4229ea-7afd-4a57-9bfe-5a95b4452b46))
- Context used - AGENTS.md ([source](https://app.greptile.com/youversion/github/youversion/platform-sdk-react/-/custom-context?memory=37f8a741-f912-4c06-b454-a491395588fc))
- File used - docs/review-guidelines.md ([source](docs/review-guidelines.md))
- Context used - Enforce project-specific review guidelines - see d... ([source](greptile.json))
</details>

<!-- /greptile_comment -->