### PR TITLE
Split dev vs partner traffic in the X-YVP-Sdk header

### DIFF
--- a/.changeset/sdk-version-dev-suffix.md
+++ b/.changeset/sdk-version-dev-suffix.md
@@ -1,0 +1,9 @@
+---
+'@youversion/platform-core': patch
+'@youversion/platform-react-hooks': patch
+'@youversion/platform-react-ui': patch
+---
+
+Tag the `X-YVP-Sdk` header with a `-dev` suffix for non-published builds so platform telemetry can separate internal YouVersion dev-time traffic from published partner traffic.
+
+Published builds report the real version (`ReactSDK=2.2.0`); builds from source, dev, or tests report `ReactSDK=2.2.0-dev`. The version is stamped at build time via `YVP_PUBLISH_BUILD` (set by each package's `prepublishOnly`), and a publish guard aborts the release if an unstamped `-dev` build would ship. Published header values are otherwise unchanged, and consumers can still override `X-YVP-Sdk` via `additionalHeaders`.

--- a/docs/adr/0002-sdk-version-dev-suffix-on-build.md
+++ b/docs/adr/0002-sdk-version-dev-suffix-on-build.md
@@ -1,0 +1,78 @@
+# 2. Suffix the X-YVP-Sdk version with `-dev` for non-published builds
+
+Date: 2026-07-15
+
+## Status
+
+Accepted
+
+## Context
+
+Every request carries an `X-YVP-Sdk: ReactSDK={version}` header so platform
+telemetry can attribute traffic to the SDK. The tech lead's requirement: the
+value must differentiate **internal YouVersion dev-time traffic** from
+**published partner traffic** (the released SDK used outside YV).
+
+Before this change, `SDK_VERSION` was `pkg.version`, which `tsup` inlines on
+**every** build. A build from source and a published install both reported
+`ReactSDK=2.2.0`, so the two were indistinguishable. The dev/partner split the
+tech lead asked for did not exist.
+
+The React Native Expo SDK (platform-sdk-reactnative-expo#85) solved the same
+requirement differently: it hardcodes a `Dev` sentinel in source and a
+`prepublishOnly` script string-rewrites the compiled output to the real version.
+That approach exists because `expo-module build` does not inline anything. It
+also fails-hard if the sentinel is missing or duplicated.
+
+## Decision
+
+Keep `package.json` as the single source of the version, and vary only a
+suffix by build channel:
+
+- Source/dev/test builds report `ReactSDK={version}-dev`.
+- Published builds report `ReactSDK={version}`.
+
+Mechanism (`packages/core`):
+
+- `src/version.ts` reads a build-time flag: `SDK_VERSION = isPublishBuild ?
+  pkg.version : `${pkg.version}-dev``.
+- `tsup.config.ts` replaces `process.env.YVP_PUBLISH_BUILD` at build time via
+  tsup's `env` option, so the flag folds to a constant (works in the browser
+  bundle, where `process` is undefined).
+- `prepublishOnly` sets `YVP_PUBLISH_BUILD=true`, so every `npm publish`
+  produces a stamped build; any other build stays `-dev`.
+- A publish guard (`scripts/check-sdk-version-stamp.mjs`) fails the publish if
+  the built artifact still contains the `-dev` marker. It keys off the folded
+  `isPublishBuild = false` constant, not a `-dev` string match, because the
+  compiled ternary keeps the `-dev` suffix in its (dead) else branch in every
+  build.
+
+`@youversion/platform-react-ui` bundles core (`noExternal`), so it inherits the
+stamp from the core dist it bundles; its `prepublishOnly` runs the same guard.
+`@youversion/platform-react-hooks` imports core at runtime and bakes no version,
+so it needs no change.
+
+## Why this differs from the React Native SDK
+
+We inject at build time via tsup's native `env`/`define` instead of rewriting
+compiled output, because `tsup` (unlike `expo-module build`) supports it. Porting
+the RN post-build rewrite would import fragility this repo does not need: the
+Web SDK emits cjs + esm across three entry points, so RN's "exactly one `Dev`
+occurrence" guard would not hold. The tech lead's requirement is the dev/partner
+split (the outcome), not the stamping mechanism, so matching the outcome while
+using the tool's native capability is the right trade-off.
+
+`-dev` (a semver prerelease tag) was chosen over RN's bare `Dev`: it keeps the
+version line in dev traffic (`2.2.0-dev` tells you which release the dev traffic
+came from, where bare `Dev` does not) and makes the telemetry filter a simple
+`endsWith('-dev')`.
+
+## Consequences
+
+- Published header value is unchanged (`ReactSDK=2.2.0`); only source/dev builds
+  change (now `-dev`).
+- Publishing outside the `prepublishOnly` lifecycle (e.g. a raw `tsup` build then
+  manual `npm publish`) is caught by the guard and aborts.
+- `prepublishOnly` uses POSIX inline env syntax (`YVP_PUBLISH_BUILD=true ...`).
+  Publishing from Windows would need `cross-env`; CI (Linux) and maintainers
+  (macOS) are unaffected.

--- a/docs/adr/0002-sdk-version-dev-suffix-on-build.md
+++ b/docs/adr/0002-sdk-version-dev-suffix-on-build.md
@@ -41,11 +41,15 @@ Mechanism (`packages/core`):
   bundle, where `process` is undefined).
 - `prepublishOnly` sets `YVP_PUBLISH_BUILD=true`, so every `npm publish`
   produces a stamped build; any other build stays `-dev`.
-- A publish guard (`scripts/check-sdk-version-stamp.mjs`) fails the publish if
-  the built artifact still contains the `-dev` marker. It keys off the folded
-  `isPublishBuild = false` constant, not a `-dev` string match, because the
-  compiled ternary keeps the `-dev` suffix in its (dead) else branch in every
-  build.
+- A publish guard (`scripts/check-sdk-version-stamp.mjs`) aborts the publish
+  unless the artifact carries the folded `isPublishBuild = true` stamp. It
+  asserts that positive stamp rather than matching `-dev` for two reasons. A
+  `-dev` string match would false-positive, because the compiled ternary keeps
+  the suffix in its (dead) else branch in every build. And checking only that
+  `isPublishBuild = false` is absent would fail **open**: if build tooling ever
+  minified the constant away, neither literal would survive and a dev build
+  would sail through. Requiring the stamp fails closed instead — a build whose
+  channel cannot be confirmed aborts the publish.
 
 `@youversion/platform-react-ui` bundles core (`noExternal`), so it inherits the
 stamp from the core dist it bundles; its `prepublishOnly` runs the same guard.
@@ -73,6 +77,11 @@ came from, where bare `Dev` does not) and makes the telemetry filter a simple
   change (now `-dev`).
 - Publishing outside the `prepublishOnly` lifecycle (e.g. a raw `tsup` build then
   manual `npm publish`) is caught by the guard and aborts.
+- Enabling `minify` (or `minifyIdentifiers`) in either tsup config will trip the
+  guard: the `isPublishBuild` literal no longer survives, so the stamp cannot be
+  confirmed and the publish aborts until the guard is taught the new output
+  shape. That is the intended trade — a loud, fixable abort beats silently
+  tagging partner traffic as `-dev`.
 - `prepublishOnly` uses POSIX inline env syntax (`YVP_PUBLISH_BUILD=true ...`).
   Publishing from Windows would need `cross-env`; CI (Linux) and maintainers
   (macOS) are unaffected.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,8 +35,9 @@
     }
   },
   "scripts": {
-    "dev": "tsup src/index.ts src/browser.ts src/server.ts --format cjs,esm --dts --watch",
-    "build": "tsup src/index.ts src/browser.ts src/server.ts --format cjs,esm --dts",
+    "dev": "tsup --watch",
+    "build": "tsup",
+    "prepublishOnly": "YVP_PUBLISH_BUILD=true pnpm build && node ../../scripts/check-sdk-version-stamp.mjs core",
     "lint": "eslint . --max-warnings 0",
     "typecheck": "tsc --noEmit",
     "test": "dotenv -e .env.local -- vitest run",

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,10 +1,20 @@
 import pkg from '../package.json' with { type: 'json' };
 
-export const SDK_VERSION = pkg.version;
-
 export const SDK_NAME = 'ReactSDK';
 
 export const SDK_VERSION_HEADER_NAME = 'X-YVP-Sdk';
+
+/**
+ * `true` only in builds produced for publishing (see `tsup.config.ts`, which
+ * replaces `process.env.YVP_PUBLISH_BUILD` at build time). Dev, source, and
+ * test builds leave it falsy so their traffic is tagged with a `-dev` suffix.
+ *
+ * This lets platform telemetry separate internal YouVersion dev-time traffic
+ * (`ReactSDK=2.2.0-dev`) from published partner traffic (`ReactSDK=2.2.0`).
+ */
+const isPublishBuild = process.env.YVP_PUBLISH_BUILD === 'true';
+
+export const SDK_VERSION = isPublishBuild ? pkg.version : `${pkg.version}-dev`;
 
 export function buildSdkVersionHeaderValue(): string {
   return `${SDK_NAME}=${SDK_VERSION}`;

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'tsup';
+
+/**
+ * Stamp the `X-YVP-Sdk` version header depending on how the bundle is built.
+ *
+ * Published builds report the real version (`ReactSDK=2.2.0`); dev, source, and
+ * test builds report a `-dev` suffix (`ReactSDK=2.2.0-dev`) so platform
+ * telemetry can separate internal YouVersion traffic from published partner
+ * traffic. See `src/version.ts`.
+ *
+ * The package's `prepublishOnly` script sets `YVP_PUBLISH_BUILD=true` so every
+ * `npm publish` produces a stamped build; any other build stays `-dev`.
+ */
+const isPublishBuild = process.env.YVP_PUBLISH_BUILD === 'true';
+
+export default defineConfig({
+  entry: ['src/index.ts', 'src/browser.ts', 'src/server.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  env: {
+    YVP_PUBLISH_BUILD: isPublishBuild ? 'true' : '',
+  },
+});

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -38,7 +38,7 @@
     "test:coverage": "vitest run --project unit --coverage",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --max-warnings 0",
-    "prepublishOnly": "pnpm build && node ../../scripts/check-sdk-version-stamp.mjs ui",
+    "prepublishOnly": "YVP_PUBLISH_BUILD=true pnpm --filter @youversion/platform-core build && pnpm build && node ../../scripts/check-sdk-version-stamp.mjs ui",
     "storybook": "concurrently \"tailwindcss -i src/styles/global.css -o dist/tailwind.css --watch\" \"storybook dev -p 6006\"",
     "build-storybook": "storybook build",
     "test:integration": "vitest run"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -38,7 +38,7 @@
     "test:coverage": "vitest run --project unit --coverage",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --max-warnings 0",
-    "prepublishOnly": "pnpm build",
+    "prepublishOnly": "pnpm build && node ../../scripts/check-sdk-version-stamp.mjs ui",
     "storybook": "concurrently \"tailwindcss -i src/styles/global.css -o dist/tailwind.css --watch\" \"storybook dev -p 6006\"",
     "build-storybook": "storybook build",
     "test:integration": "vitest run"

--- a/packages/ui/tsup.config.ts
+++ b/packages/ui/tsup.config.ts
@@ -13,7 +13,12 @@ export default defineConfig({
   },
   format: ['esm', 'cjs'],
   target: 'es2020',
-  // Always bundle workspace packages to avoid resolution issues
+  // Always bundle workspace packages to avoid resolution issues.
+  // This inlines core's *dist*, so the `X-YVP-Sdk` version constant core baked in
+  // at its own build time is the one we ship — this build never computes it. That
+  // is why `prepublishOnly` rebuilds core with `YVP_PUBLISH_BUILD=true` before
+  // building here, and why the env var is scoped to that command alone. See
+  // packages/core/tsup.config.ts.
   noExternal: ['@youversion/platform-core'],
   // Consumers provide these:
   external: ['react', 'react/jsx-runtime', 'react-dom'],

--- a/scripts/check-sdk-version-stamp.mjs
+++ b/scripts/check-sdk-version-stamp.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// Fail-hard publish guard for the X-YVP-Sdk version header.
+//
+// Published builds must report the real version (`ReactSDK=2.2.0`), never the
+// `-dev` suffix used for internal YouVersion dev traffic. `src/version.ts`
+// compiles to `isPublishBuild ? version : `${version}-dev``; a stamped build
+// folds `isPublishBuild` to `true`, a dev build to `false`. `@youversion/
+// platform-react-ui` bundles core, so the same constant appears in its output.
+//
+// This runs from each package's `prepublishOnly`, so `npm publish` aborts if the
+// artifact would tag traffic as `-dev`. (Grepping for `-dev` directly would
+// false-positive: the ternary's dead branch keeps the suffix in every build.)
+//
+// Usage: node scripts/check-sdk-version-stamp.mjs <core|ui>
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+const PACKAGE_DIRS = {
+  core: 'packages/core',
+  ui: 'packages/ui',
+};
+
+const pkg = process.argv[2];
+const packageDir = PACKAGE_DIRS[pkg];
+if (!packageDir) {
+  console.error(
+    `check-sdk-version-stamp: unknown package "${pkg}". Expected one of: ${Object.keys(
+      PACKAGE_DIRS,
+    ).join(', ')}`,
+  );
+  process.exit(1);
+}
+
+const distDir = join(repoRoot, packageDir, 'dist');
+
+let bundleFiles;
+try {
+  bundleFiles = readdirSync(distDir).filter((f) => /\.(js|cjs)$/.test(f));
+} catch {
+  console.error(`check-sdk-version-stamp: no dist found at ${distDir}. Build before publishing.`);
+  process.exit(1);
+}
+
+const DEV_MARKER = /isPublishBuild\s*=\s*false/;
+
+const unstamped = [];
+let sawVersionCode = false;
+
+for (const file of bundleFiles) {
+  const content = readFileSync(join(distDir, file), 'utf8');
+  if (content.includes('SDK_VERSION')) sawVersionCode = true;
+  if (DEV_MARKER.test(content)) unstamped.push(file);
+}
+
+if (!sawVersionCode) {
+  console.error(
+    `check-sdk-version-stamp: no SDK version code found in ${packageDir}/dist. ` +
+      `The guard could not verify the stamp; investigate before publishing.`,
+  );
+  process.exit(1);
+}
+
+if (unstamped.length > 0) {
+  console.error(
+    `check-sdk-version-stamp: ${packageDir} would publish an unstamped (-dev) X-YVP-Sdk header.\n` +
+      `Affected files: ${unstamped.join(', ')}\n` +
+      `Publish via a build with YVP_PUBLISH_BUILD=true (core's prepublishOnly does this).`,
+  );
+  process.exit(1);
+}
+
+console.log(`check-sdk-version-stamp: ${packageDir} X-YVP-Sdk header is stamped for release.`);

--- a/scripts/check-sdk-version-stamp.mjs
+++ b/scripts/check-sdk-version-stamp.mjs
@@ -45,15 +45,29 @@ try {
   process.exit(1);
 }
 
+// A stamped (publish) build folds `isPublishBuild` to `true`; a dev build folds
+// it to `false`. We assert the *positive* stamp is present rather than merely
+// checking the dev marker is absent: if the build tooling ever inlines or
+// minifies the constant away (renaming/removing `isPublishBuild`), neither
+// literal survives, and an absence-only check would silently pass a `-dev`
+// build. Requiring the positive stamp fails *closed* in that case — a loud,
+// fixable publish abort instead of shipping dev-tagged telemetry to partners.
 const DEV_MARKER = /isPublishBuild\s*=\s*false/;
+const STAMP_MARKER = /isPublishBuild\s*=\s*true/;
 
 const unstamped = [];
+const unverifiable = [];
 let sawVersionCode = false;
 
 for (const file of bundleFiles) {
   const content = readFileSync(join(distDir, file), 'utf8');
-  if (content.includes('SDK_VERSION')) sawVersionCode = true;
-  if (DEV_MARKER.test(content)) unstamped.push(file);
+  if (!content.includes('SDK_VERSION')) continue;
+  sawVersionCode = true;
+  if (DEV_MARKER.test(content)) {
+    unstamped.push(file);
+  } else if (!STAMP_MARKER.test(content)) {
+    unverifiable.push(file);
+  }
 }
 
 if (!sawVersionCode) {
@@ -69,6 +83,16 @@ if (unstamped.length > 0) {
     `check-sdk-version-stamp: ${packageDir} would publish an unstamped (-dev) X-YVP-Sdk header.\n` +
       `Affected files: ${unstamped.join(', ')}\n` +
       `Publish via a build with YVP_PUBLISH_BUILD=true (core's prepublishOnly does this).`,
+  );
+  process.exit(1);
+}
+
+if (unverifiable.length > 0) {
+  console.error(
+    `check-sdk-version-stamp: could not confirm the X-YVP-Sdk stamp in ${packageDir}/dist.\n` +
+      `Affected files: ${unverifiable.join(', ')}\n` +
+      `Version code is present but neither the stamped nor dev marker was found — the build ` +
+      `output shape likely changed (e.g. minify/inline was enabled). Update this guard before publishing.`,
   );
   process.exit(1);
 }

--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,7 @@
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**", ".next/", "lib/**"],
-      "env": ["NODE_ENV"],
+      "env": ["NODE_ENV", "YVP_PUBLISH_BUILD"],
       "cache": true
     },
     "dev": {


### PR DESCRIPTION
## Summary

The X-YVP-Sdk telemetry header couldn't tell internal YouVersion dev traffic apart from published partner traffic — both reported `ReactSDK=2.2.0`. Non-published builds now report a `-dev` suffix so telemetry can separate the two.

## Changes

1. Dev, source, and test builds report `ReactSDK=2.2.0-dev`; published builds still report `ReactSDK=2.2.0`.
2. The version is stamped at build time via a `YVP_PUBLISH_BUILD` flag that `tsup` folds to a constant, set by each package's `prepublishOnly`.
3. A fail-hard publish guard aborts the release if an unstamped `-dev` build would ship, and fails closed if it can't confirm the stamp at all.
4. Documented the decision and why it diverges from the React Native SDK's stamping mechanism (ADR 0002).
5. UI rebuilds core in publish mode before bundling it, so its stamp no longer depends on core being republished first.
6. Added `YVP_PUBLISH_BUILD` to the turbo build cache key so a cached `-dev` build can never be reused for a publish.

**Start here:** change 3 — the guard now asserts the `isPublishBuild = true` stamp is present rather than only checking the `-dev` marker is absent, so a future minify/inline that drops the marker aborts the publish instead of silently shipping `-dev`.

## Breaking / Migration

None. Published header values are unchanged; consumers can still override `X-YVP-Sdk` via `additionalHeaders`.

## Test plan

- core 318, hooks 276, ui 181 tests pass (incl. X-YVP-Sdk header + override tests)
- typecheck and lint pass
- Header proof: published build → `ReactSDK=2.2.0`, dev build → `ReactSDK=2.2.0-dev`
- Guard verified: stamped core passes, dev core fails, and a minified build fails closed via the positive-stamp assertion
- UI `prepublishOnly` rebuilds core stamped first → ui stamps correctly and the guard passes even when core's dist started dev-built

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a build-time stamping mechanism to differentiate internal YouVersion dev-time SDK traffic from published partner traffic in the `X-YVP-Sdk` header. Previously both reported `ReactSDK=2.2.0`; dev/source builds now report `ReactSDK=2.2.0-dev`. The implementation is well-documented with a thorough ADR, a fail-closed publish guard, and a Turbo cache-key update to prevent cache poisoning.

- **Stamp mechanism**: `tsup`'s `env`/`define` option folds `process.env.YVP_PUBLISH_BUILD` to a constant at build time in `packages/core`, so `isPublishBuild` resolves to a boolean literal (never a runtime lookup) in the output bundle.
- **Publish guard** (`scripts/check-sdk-version-stamp.mjs`): asserts the positive `isPublishBuild = true` stamp is present rather than merely checking for absence of the `-dev` marker; this fails closed if minification or inlining ever removes the constant, aborting the publish rather than silently shipping dev-tagged telemetry to partners.
- **UI publish flow**: `prepublishOnly` rebuilds core with `YVP_PUBLISH_BUILD=true` before bundling it into UI via `noExternal`, so the stamp is always current regardless of what was previously in `packages/core/dist`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the publish pipeline is fail-closed, published header values are unchanged, and the Turbo cache key change prevents a stale dev build from being reused as a publish artifact.

The stamp mechanism, guard logic, and UI rebuild-before-bundle flow are all correctly wired. The ADR documents the known trade-offs (Windows POSIX syntax, minification tripping the guard) and the fail-closed design means any future tooling change that breaks the marker would abort the publish rather than silently ship dev-tagged telemetry to partners.

No files require special attention. The guard script and the UI prepublishOnly flow have been verified by the author and the logic checks out on inspection.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/check-sdk-version-stamp.mjs | Fail-closed publish guard; logic is sound for current (non-minified) output shape. Correctly uses positive-stamp assertion and "unverifiable" path to fail closed when neither marker survives. |
| packages/core/src/version.ts | Adds `isPublishBuild` flag and conditional `-dev` suffix. The `process.env.YVP_PUBLISH_BUILD` expression is replaced at build time by tsup's `env` option, so it never appears as a runtime lookup in the bundle. |
| packages/core/tsup.config.ts | New config; correctly uses tsup's `env` option to fold `YVP_PUBLISH_BUILD` to a string constant at build time, enabling esbuild dead-code elimination of the unused ternary branch. |
| packages/core/package.json | Adds `prepublishOnly` with inline `YVP_PUBLISH_BUILD=true` prefix and post-build guard; dev/build scripts now delegate all entry points to tsup.config.ts cleanly. |
| packages/ui/package.json | Updated `prepublishOnly` rebuilds core stamped (`YVP_PUBLISH_BUILD=true pnpm --filter core build`) before the UI bundle step, ensuring core's inlined dist always carries the publish stamp for UI releases. |
| turbo.json | Adds `YVP_PUBLISH_BUILD` to the build task's env cache key; prevents a cached `-dev` build from being restored and used as a publish artifact by Turbo. |
| packages/ui/tsup.config.ts | Added explanatory comment clarifying why `noExternal` means the stamp flows from core's dist (not from a UI-level env substitution); no functional change. |
| docs/adr/0002-sdk-version-dev-suffix-on-build.md | Well-structured ADR documenting the decision, the comparison with the React Native SDK approach, and the known trade-offs (Windows, minification fail-closed behavior). |
| .changeset/sdk-version-dev-suffix.md | Patch changeset covering all three packages per the unified versioning strategy; description accurately reflects the change. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Dev as Developer
    participant CorePkg as packages/core
    participant UIPkg as packages/ui
    participant Guard as check-sdk-version-stamp.mjs
    participant NPM as npm publish

    Note over Dev,NPM: Core publish flow
    Dev->>CorePkg: pnpm prepublishOnly
    CorePkg->>CorePkg: "YVP_PUBLISH_BUILD=true tsup"
    CorePkg->>Guard: node check-sdk-version-stamp.mjs core
    Guard->>Guard: "scan dist, assert isPublishBuild = true"
    alt stamp found
        Guard-->>CorePkg: exit 0
        CorePkg->>NPM: "publish ReactSDK=2.2.0"
    else dev marker or unverifiable
        Guard-->>CorePkg: exit 1 ABORT
    end

    Note over Dev,NPM: UI publish flow
    Dev->>UIPkg: pnpm prepublishOnly
    UIPkg->>CorePkg: "YVP_PUBLISH_BUILD=true pnpm --filter core build"
    CorePkg-->>UIPkg: "dist with isPublishBuild = true"
    UIPkg->>UIPkg: pnpm build, tsup inlines stamped core dist
    UIPkg->>Guard: node check-sdk-version-stamp.mjs ui
    Guard->>Guard: "scan dist, assert isPublishBuild = true"
    alt stamp found
        Guard-->>UIPkg: exit 0
        UIPkg->>NPM: "publish ReactSDK=2.2.0"
    else dev marker or unverifiable
        Guard-->>UIPkg: exit 1 ABORT
    end

    Note over Dev,NPM: Normal dev build
    Dev->>CorePkg: pnpm build
    CorePkg->>CorePkg: tsup folds isPublishBuild to false
    Note right of CorePkg: telemetry receives ReactSDK=2.2.0-dev
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Dev as Developer
    participant CorePkg as packages/core
    participant UIPkg as packages/ui
    participant Guard as check-sdk-version-stamp.mjs
    participant NPM as npm publish

    Note over Dev,NPM: Core publish flow
    Dev->>CorePkg: pnpm prepublishOnly
    CorePkg->>CorePkg: "YVP_PUBLISH_BUILD=true tsup"
    CorePkg->>Guard: node check-sdk-version-stamp.mjs core
    Guard->>Guard: "scan dist, assert isPublishBuild = true"
    alt stamp found
        Guard-->>CorePkg: exit 0
        CorePkg->>NPM: "publish ReactSDK=2.2.0"
    else dev marker or unverifiable
        Guard-->>CorePkg: exit 1 ABORT
    end

    Note over Dev,NPM: UI publish flow
    Dev->>UIPkg: pnpm prepublishOnly
    UIPkg->>CorePkg: "YVP_PUBLISH_BUILD=true pnpm --filter core build"
    CorePkg-->>UIPkg: "dist with isPublishBuild = true"
    UIPkg->>UIPkg: pnpm build, tsup inlines stamped core dist
    UIPkg->>Guard: node check-sdk-version-stamp.mjs ui
    Guard->>Guard: "scan dist, assert isPublishBuild = true"
    alt stamp found
        Guard-->>UIPkg: exit 0
        UIPkg->>NPM: "publish ReactSDK=2.2.0"
    else dev marker or unverifiable
        Guard-->>UIPkg: exit 1 ABORT
    end

    Note over Dev,NPM: Normal dev build
    Dev->>CorePkg: pnpm build
    CorePkg->>CorePkg: tsup folds isPublishBuild to false
    Note right of CorePkg: telemetry receives ReactSDK=2.2.0-dev
```

</a>

<sub>Reviews (5): Last reviewed commit: ["Merge branch &#39;main&#39; into claude/x-yvp-sd..."](https://github.com/youversion/platform-sdk-react/commit/c1eb747b5d7296c0b83279878916653576feae38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44527140)</sub>

<!-- /greptile_comment -->