### PR TITLE
fix(core,hooks): remove unreleased recent highlight colors API

### DIFF
--- a/.changeset/fix-highlights-api-contract.md
+++ b/.changeset/fix-highlights-api-contract.md
@@ -11,5 +11,4 @@ Fix `HighlightsClient` to match the live highlights API contract. The client pre
 - `getHighlights` now requires `version_id` and `passage_id` (verse or chapter USFM), and `deleteHighlight` requires `version_id`, matching the API's required parameters; `useHighlights` options are updated accordingly
 - `getHighlights` now treats a `204` (no highlights for the passage) as an empty collection instead of throwing
 - `createHighlight` normalizes `color` to lowercase before sending, since the API accepts lowercase hex only
-- Added `getRecentColors()` (`GET /v1/highlights/recent-colors`) to `HighlightsClient` and exposed it from `useHighlights` for building color pickers
 - API responses are validated with Zod and mapped from the wire shape

--- a/packages/core/src/__tests__/handlers.ts
+++ b/packages/core/src/__tests__/handlers.ts
@@ -123,15 +123,6 @@ export const handlers = [
     });
   }),
 
-  http.get(`https://${apiHost}/v1/highlights/recent-colors`, ({ request }) => {
-    const authError = requireBearerAuth(request);
-    if (authError) return authError;
-
-    return HttpResponse.json({
-      data: [{ color: 'fffe00' }, { color: '5dff79' }],
-    });
-  }),
-
   http.post(`https://${apiHost}/v1/highlights`, async ({ request }) => {
     const authError = requireBearerAuth(request);
     if (authError) return authError;

--- a/packages/core/src/__tests__/highlights.test.ts
+++ b/packages/core/src/__tests__/highlights.test.ts
@@ -117,43 +117,6 @@ describe('HighlightsClient', () => {
     });
   });
 
-  describe('getRecentColors', () => {
-    it('returns the ordered list of hex colors with Bearer auth', async () => {
-      const fetchSpy = vi.spyOn(global, 'fetch');
-
-      const colors = await highlightsClient.getRecentColors('test-token');
-
-      expect(colors).toEqual(['fffe00', '5dff79']);
-
-      const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
-      expect(url).toContain('/v1/highlights/recent-colors');
-      expect((init.headers as Record<string, string>).Authorization).toBe('Bearer test-token');
-    });
-
-    it('returns an empty list when the API responds 204', async () => {
-      server.use(
-        http.get(
-          `https://${apiHost}/v1/highlights/recent-colors`,
-          () => new HttpResponse(null, { status: 204 }),
-        ),
-      );
-
-      await expect(highlightsClient.getRecentColors('test-token')).resolves.toEqual([]);
-    });
-
-    it('throws a helpful error when the API response is malformed', async () => {
-      server.use(
-        http.get(`https://${apiHost}/v1/highlights/recent-colors`, () =>
-          HttpResponse.json({ data: [{ not_a_color: true }] }),
-        ),
-      );
-
-      await expect(highlightsClient.getRecentColors('test-token')).rejects.toThrow(
-        'Unexpected highlights API response',
-      );
-    });
-  });
-
   describe('createHighlight', () => {
     it('POSTs the enveloped body ({ request_id, highlight: { bible_id, ... } })', async () => {
       let capturedBody: unknown;

--- a/packages/core/src/highlights.ts
+++ b/packages/core/src/highlights.ts
@@ -5,7 +5,6 @@ import { YouVersionPlatformConfiguration } from './YouVersionPlatformConfigurati
 import {
   HighlightCollectionWireSchema,
   HighlightWireSchema,
-  RecentHighlightColorsWireSchema,
   toHighlight,
 } from './schemas/highlight';
 
@@ -161,33 +160,6 @@ export class HighlightsClient {
       data: parsed.data.data.map(toHighlight),
       next_page_token: parsed.data.next_page_token ?? null,
     };
-  }
-
-  /**
-   * Fetches the user's recently used highlight colors, followed by the default
-   * colors, as hex strings (no `#`). Useful for building a color picker.
-   * Requires OAuth with read_highlights scope.
-   * @param lat Optional long access token. If not provided, retrieves from YouVersionPlatformConfiguration.
-   * @returns An ordered list of hex color strings.
-   */
-  async getRecentColors(lat?: string): Promise<string[]> {
-    const response = await this.client.get<unknown>(
-      `/v1/highlights/recent-colors`,
-      undefined,
-      this.authHeaders(lat),
-    );
-
-    // The API returns 204 (empty body) when there is nothing to return.
-    if (response === '' || response == null) {
-      return [];
-    }
-
-    const parsed = RecentHighlightColorsWireSchema.safeParse(response);
-    if (!parsed.success) {
-      throw new Error(`Unexpected highlights API response: ${parsed.error.message}`);
-    }
-
-    return parsed.data.data.map((entry) => entry.color);
   }
 
   /**

--- a/packages/core/src/schemas/highlight.ts
+++ b/packages/core/src/schemas/highlight.ts
@@ -27,16 +27,6 @@ export const HighlightCollectionWireSchema = z.object({
 
 export type HighlightCollectionWire = z.infer<typeof HighlightCollectionWireSchema>;
 
-/**
- * Wire format for `GET /v1/highlights/recent-colors`, a collection of hex color
- * strings (recently used followed by default colors).
- */
-export const RecentHighlightColorsWireSchema = z.object({
-  data: z.array(z.object({ color: z.string().regex(HEX_COLOR_REGEX) })),
-});
-
-export type RecentHighlightColorsWire = z.infer<typeof RecentHighlightColorsWireSchema>;
-
 const _HighlightSchema = z.object({
   /** Bible version identifier (sent to / received from the API as `bible_id`) */
   version_id: z.number().int().positive(),

--- a/packages/hooks/src/useHighlights.test.tsx
+++ b/packages/hooks/src/useHighlights.test.tsx
@@ -54,20 +54,17 @@ describe('useHighlights', () => {
   let mockGetHighlights: Mock;
   let mockCreateHighlight: Mock;
   let mockDeleteHighlight: Mock;
-  let mockGetRecentColors: Mock;
 
   beforeEach(() => {
     mockGetHighlights = vi.fn().mockResolvedValue(mockHighlights);
     mockCreateHighlight = vi.fn().mockResolvedValue(mockHighlight);
     mockDeleteHighlight = vi.fn().mockResolvedValue(undefined);
-    mockGetRecentColors = vi.fn().mockResolvedValue(['fffe00', '5dff79']);
 
     (HighlightsClient as unknown as ReturnType<typeof vi.fn>).mockImplementation(function () {
       return {
         getHighlights: mockGetHighlights,
         createHighlight: mockCreateHighlight,
         deleteHighlight: mockDeleteHighlight,
-        getRecentColors: mockGetRecentColors,
       };
     });
 
@@ -312,20 +309,6 @@ describe('useHighlights', () => {
       );
 
       expect(mockGetHighlights).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('getRecentColors', () => {
-    it('delegates to the client and returns the color list', async () => {
-      const wrapper = createYVWrapper();
-      const { result } = renderHook(() => useHighlights(defaultOptions), { wrapper });
-
-      await waitFor(() => {
-        expect(result.current.loading).toBe(false);
-      });
-
-      await expect(result.current.getRecentColors()).resolves.toEqual(['fffe00', '5dff79']);
-      expect(mockGetRecentColors).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/hooks/src/useHighlights.ts
+++ b/packages/hooks/src/useHighlights.ts
@@ -23,7 +23,6 @@ export function useHighlights(
   refetch: () => void;
   createHighlight: (data: CreateHighlight) => Promise<Highlight>;
   deleteHighlight: (passageId: string, deleteOptions: DeleteHighlightOptions) => Promise<void>;
-  getRecentColors: () => Promise<string[]>;
 } {
   const context = useContext(YouVersionContext);
 
@@ -72,11 +71,6 @@ export function useHighlights(
     [highlightsClient, refetch],
   );
 
-  const getRecentColors = useCallback(
-    (): Promise<string[]> => highlightsClient.getRecentColors(),
-    [highlightsClient],
-  );
-
   return {
     highlights: data,
     loading,
@@ -84,6 +78,5 @@ export function useHighlights(
     refetch,
     createHighlight,
     deleteHighlight,
-    getRecentColors,
   };
 }


### PR DESCRIPTION
## Why

Brad flagged this on the pending release PR ([#277](https://github.com/youversion/platform-sdk-react/pull/277#discussion_r3596331538)):

> I'm sorry I didn't mean for this API to be used yet. We're still in process on it. I removed it from the documentation on Monday. Can we make sure this doesn't get released to the wild? We're still iterating on it and the contract is changing.

The recent-colors endpoint slipped into the highlights contract fix. It has never shipped, so we can pull it cleanly instead of deprecating it.

## Nothing breaks

- Latest published version is `2.2.0`; the `fix-highlights-api-contract` changeset that introduced this is still unconsumed
- No UI package usage, no consumers
- [#277](https://github.com/youversion/platform-sdk-react/pull/277) is still marked "DO NOT MERGE YET", so it never went out

## What's removed

| Package | Removed |
|---|---|
| core | `HighlightsClient.getRecentColors()` |
| core | `RecentHighlightColorsWireSchema` + `RecentHighlightColorsWire` (both were publicly re-exported) |
| core | msw handler + `getRecentColors` tests |
| hooks | `getRecentColors` from the `useHighlights` return type and object |
| hooks | `useHighlights` recent-colors test and mock |

Also drops the bullet from `.changeset/fix-highlights-api-contract.md` so the regenerated CHANGELOG on #277 never advertises it. The bump stays `minor` for core and hooks: what remains still changes the public shape of `getHighlights` (`version_id` and `passage_id` are now required).

`HEX_COLOR_REGEX` stays put, it's shared by three other schemas.

## Verification

Full gate is green across all three packages: build, typecheck, lint, and 779 tests (core 315, hooks 275, UI 189).

Once this lands on main, the changesets bot regenerates #277 without the recent-colors line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the `getRecentColors()` method from `HighlightsClient` and its corresponding `useHighlights` wrapper — an API that was accidentally included in an unreleased changeset and has never shipped to consumers. Since the `fix-highlights-api-contract` changeset is still unconsumed (latest published version is `2.2.0`), this is a clean deletion with no deprecation needed.

- **`packages/core`**: Removes `HighlightsClient.getRecentColors()`, the `RecentHighlightColorsWireSchema`/`RecentHighlightColorsWire` types, the MSW handler, and all associated tests.
- **`packages/hooks`**: Removes `getRecentColors` from `useHighlights`'s return type, implementation, and test suite.
- **`.changeset/fix-highlights-api-contract.md`**: Drops the bullet advertising the removed feature so the upcoming CHANGELOG in PR #277 won't mention it.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely removes code that was never published, with no remaining references in the codebase.

Every reference to getRecentColors is removed consistently across the client, hook, tests, MSW handler, schema, and changeset. HEX_COLOR_REGEX is correctly retained as it is still used by three other schemas. The index exports for core do not directly expose schema types, so no public re-export cleanup is needed beyond what was done. The changeset bump stays minor, which is correct given the still-present breaking changes to getHighlights and deleteHighlight.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/highlights.ts | Removes getRecentColors() method and its RecentHighlightColorsWireSchema import; remaining client methods are untouched. |
| packages/core/src/schemas/highlight.ts | Removes RecentHighlightColorsWireSchema and RecentHighlightColorsWire; HEX_COLOR_REGEX retained and still used by existing schemas. |
| packages/hooks/src/useHighlights.ts | Removes getRecentColors useCallback and its entry from the return type and returned object; hook logic is otherwise unchanged. |
| packages/core/src/__tests__/highlights.test.ts | Removes the entire getRecentColors describe block (3 tests); remaining test suites are intact. |
| packages/hooks/src/useHighlights.test.tsx | Removes the getRecentColors test and its mock setup; remaining tests cover the still-exposed hook surface. |
| packages/core/src/__tests__/handlers.ts | Drops the /v1/highlights/recent-colors MSW handler; remaining handlers are unaffected. |
| .changeset/fix-highlights-api-contract.md | Drops the recent-colors bullet from the changeset description; version bump (minor) and remaining bullets are correct. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[useHighlights hook] -->|delegates to| B[HighlightsClient]
    B --> C[getHighlights]
    B --> D[createHighlight]
    B --> E[deleteHighlight]
    B -.->|REMOVED| F["~~getRecentColors~~"]

    G[highlight.ts schema] --> H[HighlightWireSchema]
    G --> I[HighlightCollectionWireSchema]
    G -.->|REMOVED| J["~~RecentHighlightColorsWireSchema~~"]

    K[.changeset] -.->|bullet removed| L["~~getRecentColors bullet~~"]

    style F color:#999
    style J color:#999
    style L color:#999
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[useHighlights hook] -->|delegates to| B[HighlightsClient]
    B --> C[getHighlights]
    B --> D[createHighlight]
    B --> E[deleteHighlight]
    B -.->|REMOVED| F["~~getRecentColors~~"]

    G[highlight.ts schema] --> H[HighlightWireSchema]
    G --> I[HighlightCollectionWireSchema]
    G -.->|REMOVED| J["~~RecentHighlightColorsWireSchema~~"]

    K[.changeset] -.->|bullet removed| L["~~getRecentColors bullet~~"]

    style F color:#999
    style J color:#999
    style L color:#999
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(core,hooks): remove unreleased recen..."](https://github.com/youversion/platform-sdk-react/commit/5371b22f7e462edf77a417cffaaf12394ffb984c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44853338)</sub>

<!-- /greptile_comment -->