### PR TITLE
chore: add missing changeset for localization protection (#282)

### DIFF
--- a/.changeset/localization-aria-labels.md
+++ b/.changeset/localization-aria-labels.md
@@ -1,0 +1,5 @@
+---
+"@youversion/platform-react-ui": patch
+---
+
+Localize BibleReader font-size/line-spacing and popover close accessibility labels via i18n.


### PR DESCRIPTION
## What

Adds the changeset that was missing from #282 (`chore: localization protection`, merged as 833aa47).

## Why

#282 merged to main without a changeset. With no pending changeset, the Release workflow took the publish path and tried to re-publish the already-live 2.3.0, failing with `E403 — cannot publish over previously published versions: 2.3.0` ([failed run](https://github.com/youversion/platform-sdk-react/actions/runs/29616967518)).

This changeset gives the release pipeline something to version: merging it opens a "chore: version packages" PR (2.3.0 → 2.3.1), and merging that publishes 2.3.1 cleanly.

## Scope

`patch` on `@youversion/platform-react-ui`; the `fixed` group bumps all three packages to 2.3.1. #282's only publishable changes were localizing existing accessibility labels (aria-labels + popover close) via i18n — no API change.