### PR TITLE
ci: deploy Storybook to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,0 +1,62 @@
+name: Deploy Storybook
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/ui/**'
+      - 'packages/core/**'
+      - 'packages/hooks/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/deploy-storybook.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Only one Pages deployment at a time; don't cancel an in-flight deploy.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build and Deploy
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: Build Storybook
+        run: cd packages/ui && pnpm build-storybook
+        env:
+          # App keys are public application identity, not secrets; this one is
+          # kept in Actions secrets only for convenience alongside CI config.
+          STORYBOOK_YOUVERSION_APP_KEY: ${{ secrets.STORYBOOK_YOUVERSION_APP_KEY }}
+          STORYBOOK_AUTH_REDIRECT_URL: https://youversion.github.io/platform-sdk-react/
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: packages/ui/storybook-static
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Adds a `Deploy Storybook` workflow that builds `packages/ui` Storybook and publishes it to GitHub Pages at https://youversion.github.io/platform-sdk-react/
- Auto-deploys on every push to `main` that touches `packages/ui`, `packages/core`, `packages/hooks`, or the lockfile; also supports manual runs via `workflow_dispatch`.
- Reuses the existing `STORYBOOK_YOUVERSION_APP_KEY` Actions secret (app keys are public app identity, not secrets) and bakes the Pages URL in as `STORYBOOK_AUTH_REDIRECT_URL`.

## Notes

- Most stories run fully against MSW mocks, so the hosted site works without live API access.
- **One-time setup required before merge takes effect:** in repo Settings → Pages, set the source to "GitHub Actions".
- Live sign-in from the hosted Storybook additionally requires registering `https://youversion.github.io/platform-sdk-react/` as a callback URL on the Storybook app; everything else works without it.

## Test plan

- [x] `pnpm build && pnpm build-storybook` verified locally on `main` (static output in `packages/ui/storybook-static/`)
- [ ] After merge + Pages enablement: confirm workflow run deploys and site loads at the Pages URL

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a GitHub Actions workflow that builds the `packages/ui` Storybook and publishes it to GitHub Pages at `https://youversion.github.io/platform-sdk-react/`, triggered on pushes to `main` that touch relevant packages or the lockfile.

- The workflow correctly uses `actions/upload-pages-artifact` and `actions/deploy-pages` with the appropriate `pages: write` and `id-token: write` permissions, and the `concurrency` block prevents overlapping deployments.
- `STORYBOOK_AUTH_REDIRECT_URL` is intentionally hardcoded to the Pages URL (instead of using a secret as in `storybook.yml`), which is a deliberate and documented choice.
- The `setup-node` step omits `cache: 'pnpm'` that every other workflow in the repo includes, causing a full dependency re-download on each deploy.

<h3>Confidence Score: 4/5</h3>

Safe to merge once the one-time GitHub Pages source setting is configured in repo Settings.

The workflow is well-structured and consistent with the rest of the repo's CI patterns. The only gap is the missing pnpm cache on the setup-node step, which makes every deploy slower but does not affect correctness or security. Permissions are scoped correctly, concurrency is handled properly, and the build steps mirror what is done in other workflows.

.github/workflows/deploy-storybook.yml — the only changed file; minor cache configuration inconsistency.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/deploy-storybook.yml | New workflow to build and publish Storybook to GitHub Pages on pushes to main; missing pnpm cache configuration that every other workflow in the repo uses. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GH as GitHub (push to main)
    participant WF as deploy-storybook workflow
    participant Runner as ubuntu-latest runner
    participant Pages as GitHub Pages

    GH->>WF: push event (packages/ui, core, hooks, or lockfile)
    WF->>Runner: checkout + install pnpm
    Runner->>Runner: pnpm install --frozen-lockfile
    Runner->>Runner: pnpm build (all packages)
    Runner->>Runner: "cd packages/ui && pnpm build-storybook"
    Note over Runner: STORYBOOK_YOUVERSION_APP_KEY (secret)<br/>STORYBOOK_AUTH_REDIRECT_URL (hardcoded Pages URL)
    Runner->>Pages: upload-pages-artifact (storybook-static/)
    Pages-->>Runner: artifact id
    Runner->>Pages: deploy-pages
    Pages-->>WF: page_url output
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GH as GitHub (push to main)
    participant WF as deploy-storybook workflow
    participant Runner as ubuntu-latest runner
    participant Pages as GitHub Pages

    GH->>WF: push event (packages/ui, core, hooks, or lockfile)
    WF->>Runner: checkout + install pnpm
    Runner->>Runner: pnpm install --frozen-lockfile
    Runner->>Runner: pnpm build (all packages)
    Runner->>Runner: "cd packages/ui && pnpm build-storybook"
    Note over Runner: STORYBOOK_YOUVERSION_APP_KEY (secret)<br/>STORYBOOK_AUTH_REDIRECT_URL (hardcoded Pages URL)
    Runner->>Pages: upload-pages-artifact (storybook-static/)
    Pages-->>Runner: artifact id
    Runner->>Pages: deploy-pages
    Pages-->>WF: page_url output
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fdeploy-storybook.yml%3A37-39%0AThe%20%60setup-node%60%20step%20is%20missing%20%60cache%3A%20'pnpm'%60%2C%20which%20every%20other%20workflow%20in%20this%20repo%20includes%20%28see%20%60ci.yml%60%29.%20Without%20it%2C%20pnpm's%20module%20store%20is%20not%20cached%20between%20runs%2C%20so%20every%20deploy%20does%20a%20full%20network%20re-download%20of%20all%20dependencies.%20Adding%20it%20keeps%20this%20workflow%20consistent%20and%20meaningfully%20cuts%20wall-clock%20time.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20uses%3A%20actions%2Fsetup-node%40v6%0A%20%20%20%20%20%20%20%20with%3A%0A%20%20%20%20%20%20%20%20%20%20node-version%3A%2024%0A%20%20%20%20%20%20%20%20%20%20cache%3A%20'pnpm'%0A%60%60%60%0A%0A&repo=youversion%2Fplatform-sdk-react&pr=296&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fdeploy-storybook.yml%3A37-39%0AThe%20%60setup-node%60%20step%20is%20missing%20%60cache%3A%20'pnpm'%60%2C%20which%20every%20other%20workflow%20in%20this%20repo%20includes%20%28see%20%60ci.yml%60%29.%20Without%20it%2C%20pnpm's%20module%20store%20is%20not%20cached%20between%20runs%2C%20so%20every%20deploy%20does%20a%20full%20network%20re-download%20of%20all%20dependencies.%20Adding%20it%20keeps%20this%20workflow%20consistent%20and%20meaningfully%20cuts%20wall-clock%20time.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20uses%3A%20actions%2Fsetup-node%40v6%0A%20%20%20%20%20%20%20%20with%3A%0A%20%20%20%20%20%20%20%20%20%20node-version%3A%2024%0A%20%20%20%20%20%20%20%20%20%20cache%3A%20'pnpm'%0A%60%60%60%0A%0A&pr=296&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-react%22%20on%20the%20existing%20branch%20%22bdh%2Fstorybook-github-pages%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22bdh%2Fstorybook-github-pages%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fdeploy-storybook.yml%3A37-39%0AThe%20%60setup-node%60%20step%20is%20missing%20%60cache%3A%20'pnpm'%60%2C%20which%20every%20other%20workflow%20in%20this%20repo%20includes%20%28see%20%60ci.yml%60%29.%20Without%20it%2C%20pnpm's%20module%20store%20is%20not%20cached%20between%20runs%2C%20so%20every%20deploy%20does%20a%20full%20network%20re-download%20of%20all%20dependencies.%20Adding%20it%20keeps%20this%20workflow%20consistent%20and%20meaningfully%20cuts%20wall-clock%20time.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20uses%3A%20actions%2Fsetup-node%40v6%0A%20%20%20%20%20%20%20%20with%3A%0A%20%20%20%20%20%20%20%20%20%20node-version%3A%2024%0A%20%20%20%20%20%20%20%20%20%20cache%3A%20'pnpm'%0A%60%60%60%0A%0A&repo=youversion%2Fplatform-sdk-react&pr=296&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/deploy-storybook.yml:37-39
The `setup-node` step is missing `cache: 'pnpm'`, which every other workflow in this repo includes (see `ci.yml`). Without it, pnpm's module store is not cached between runs, so every deploy does a full network re-download of all dependencies. Adding it keeps this workflow consistent and meaningfully cuts wall-clock time.

```suggestion
      - uses: actions/setup-node@v6
        with:
          node-version: 24
          cache: 'pnpm'
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: deploy Storybook to GitHub Pages on ..."](https://github.com/youversion/platform-sdk-react/commit/7886a0038f3f421799580be417d261dd5e0d519c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45760587)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->