### PR TITLE
ci: deploy Vite demo to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,0 +1,65 @@
+name: Deploy Demo App
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'examples/vite-react/**'
+      - 'packages/core/**'
+      - 'packages/hooks/**'
+      - 'packages/ui/**'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'turbo.json'
+      - '.github/workflows/deploy-demo.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build and Deploy
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build demo app
+        run: pnpm turbo build --filter vite-react
+        env:
+          VITE_BASE_PATH: /platform-sdk-react/
+          VITE_YVP_APP_KEY: ${{ vars.YVP_DEMO_APP_KEY }}
+          VITE_YVP_API_HOST: api.youversion.com
+          VITE_YVP_AUTH_REDIRECT_URL: https://youversion.github.io/platform-sdk-react/
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: examples/vite-react/dist
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -3,15 +3,6 @@ name: Deploy Demo App
 on:
   push:
     branches: [main]
-    paths:
-      - 'examples/vite-react/**'
-      - 'packages/core/**'
-      - 'packages/hooks/**'
-      - 'packages/ui/**'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
-      - 'turbo.json'
-      - '.github/workflows/deploy-demo.yml'
   workflow_dispatch:
 
 permissions:
@@ -43,6 +34,15 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Validate demo configuration
+        env:
+          YVP_DEMO_APP_KEY: ${{ vars.YVP_DEMO_APP_KEY }}
+        run: |
+          if [[ -z "$YVP_DEMO_APP_KEY" ]]; then
+            echo "::error title=Missing repository variable::Set YVP_DEMO_APP_KEY before deploying the demo."
+            exit 1
+          fi
 
       - name: Build demo app
         run: pnpm turbo build --filter vite-react

--- a/examples/vite-react/README.md
+++ b/examples/vite-react/README.md
@@ -2,6 +2,8 @@
 
 A demo app showcasing `@youversion/platform-react-ui` components.
 
+**Hosted demo:** https://youversion.github.io/platform-sdk-react/
+
 ## Setup
 
 ```bash

--- a/examples/vite-react/vite.config.ts
+++ b/examples/vite-react/vite.config.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+  base: process.env.VITE_BASE_PATH ?? '/',
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {

--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,14 @@
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**", ".next/", "lib/**"],
-      "env": ["NODE_ENV", "YVP_PUBLISH_BUILD"],
+      "env": [
+        "NODE_ENV",
+        "YVP_PUBLISH_BUILD",
+        "VITE_BASE_PATH",
+        "VITE_YVP_APP_KEY",
+        "VITE_YVP_API_HOST",
+        "VITE_YVP_AUTH_REDIRECT_URL"
+      ],
       "cache": true
     },
     "dev": {


### PR DESCRIPTION
## Summary
- deploy the standalone Vite React SDK demo to GitHub Pages on changes to the example or SDK packages
- configure the `/platform-sdk-react/` asset base and include Vite build variables in Turbo's cache key
- document the hosted demo URL
- supersede #296; Storybook is intentionally excluded from Pages

## Setup after merge
- enable GitHub Pages with **GitHub Actions** as the source
- set the `YVP_DEMO_APP_KEY` repository variable
- register `https://youversion.github.io/platform-sdk-react/` as a callback URL for that Platform app

## Test plan
- [x] `pnpm --filter vite-react lint`
- [x] Pages-targeted `pnpm turbo build --filter vite-react`
- [x] verify generated asset URLs use `/platform-sdk-react/`
- [x] serve and load the production artifact under `/platform-sdk-react/`

YPE-1434

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR deploys the Vite React SDK demo to GitHub Pages. The main changes are:

- Adds a Pages build and deployment workflow for pushes to `main`.
- Validates the demo app key before building.
- Configures the `/platform-sdk-react/` Vite base path.
- Adds Vite variables to the Turbo build cache key.
- Documents the hosted demo URL.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The workflow now fails before deployment when the app key is missing.
- Removing the path filter ensures shared tooling changes on `main` trigger a fresh deployment workflow.
- No remaining blocking issue meets the scope for this follow-up review.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/deploy-demo.yml | Adds the Pages workflow, rejects a missing app key, and runs for every push to main. |
| examples/vite-react/vite.config.ts | Uses a configurable Vite base path with `/` as the default. |
| turbo.json | Includes the deployment-specific Vite variables in build cache keys. |
| examples/vite-react/README.md | Adds the hosted GitHub Pages demo URL. |

<sub>Reviews (2): Last reviewed commit: ["ci: harden Pages demo deployment (YPE-14..."](https://github.com/youversion/platform-sdk-react/commit/9564ccd7e48559a2c1902a036c13cdbdab9d76e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45991553)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/youversion/github/youversion/platform-sdk-react/-/custom-context?memory=1d4229ea-7afd-4a57-9bfe-5a95b4452b46))
- Context used - AGENTS.md ([source](https://app.greptile.com/youversion/github/youversion/platform-sdk-react/-/custom-context?memory=37f8a741-f912-4c06-b454-a491395588fc))
- File used - docs/review-guidelines.md ([source](docs/review-guidelines.md))
- Context used - Enforce project-specific review guidelines - see d... ([source](greptile.json))
</details>

<!-- /greptile_comment -->