### PR TITLE
fix(ui): collapse BibleChapterPicker book on the first tap (YPE-3867)

### DIFF
--- a/.changeset/chapter-picker-accordion-single-tap-collapse.md
+++ b/.changeset/chapter-picker-accordion-single-tap-collapse.md
@@ -1,0 +1,7 @@
+---
+'@youversion/platform-react-ui': patch
+---
+
+Fix BibleChapterPicker requiring two taps to collapse an expanded book. The book
+accordion now stays controlled for its whole lifetime instead of flipping to
+uncontrolled when a book is collapsed.

--- a/packages/ui/src/components/bible-chapter-picker.test.tsx
+++ b/packages/ui/src/components/bible-chapter-picker.test.tsx
@@ -16,7 +16,10 @@ class ResizeObserverMock {
 globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
 
 import { BibleChapterPicker } from './bible-chapter-picker';
-import type { BibleChapterPickerSelectData } from './bible-chapter-picker';
+import type {
+  BibleChapterPickerRootProps,
+  BibleChapterPickerSelectData,
+} from './bible-chapter-picker';
 import { useBooks, useTheme } from '@youversion/platform-react-hooks';
 import type { BibleBook } from '@youversion/platform-core';
 
@@ -35,6 +38,17 @@ const mockBooks: BibleBook[] = [
       { id: '2', title: '2', passage_id: 'GEN.2' },
     ],
   },
+  {
+    id: 'EXO',
+    title: 'Exodus',
+    full_title: 'The Second Book of Moses, Commonly Called Exodus',
+    canon: 'old_testament',
+    abbreviation: 'Exo',
+    chapters: [
+      { id: '1', title: '1', passage_id: 'EXO.1' },
+      { id: '2', title: '2', passage_id: 'EXO.2' },
+    ],
+  },
 ];
 
 function setupDefaultMocks() {
@@ -45,6 +59,28 @@ function setupDefaultMocks() {
     error: null,
     refetch: vi.fn(),
   });
+}
+
+function findAccordionTrigger(name: RegExp): HTMLElement | undefined {
+  return screen
+    .queryAllByRole('button', { name })
+    .find((button) => button.getAttribute('data-slot') === 'accordion-trigger');
+}
+
+// Render Content inline (onChapterPickerPress path renders children without the popover portal).
+function renderContent(props: Partial<BibleChapterPickerRootProps> = {}) {
+  render(
+    <BibleChapterPicker.Root
+      versionId={3034}
+      book="GEN"
+      chapter="1"
+      onChapterPickerPress={vi.fn()}
+      {...props}
+    >
+      <BibleChapterPicker.Trigger />
+      <BibleChapterPicker.Content />
+    </BibleChapterPicker.Root>,
+  );
 }
 
 describe('BibleChapterPicker - onChapterPickerPress override', () => {
@@ -203,27 +239,6 @@ describe('BibleChapterPicker - typography (matches Figma sizing; sans inherited)
     setupDefaultMocks();
   });
 
-  function findAccordionTrigger(name: RegExp): HTMLElement | undefined {
-    return screen
-      .queryAllByRole('button', { name })
-      .find((button) => button.getAttribute('data-slot') === 'accordion-trigger');
-  }
-
-  // Render Content inline (onChapterPickerPress path renders children without the popover portal).
-  function renderContent() {
-    render(
-      <BibleChapterPicker.Root
-        versionId={3034}
-        book="GEN"
-        chapter="1"
-        onChapterPickerPress={vi.fn()}
-      >
-        <BibleChapterPicker.Trigger />
-        <BibleChapterPicker.Content />
-      </BibleChapterPicker.Root>,
-    );
-  }
-
   it('book row uses 16px, regular collapsed and bold when expanded', () => {
     renderContent();
 
@@ -247,5 +262,71 @@ describe('BibleChapterPicker - typography (matches Figma sizing; sans inherited)
     renderContent();
 
     expect(screen.getByPlaceholderText('Search')).toHaveClass('yv:text-base');
+  });
+});
+
+describe('BibleChapterPicker - accordion expand/collapse', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDefaultMocks();
+  });
+
+  // Scenario A: the selected book is expanded on mount; one click must close it.
+  it('collapses the initially expanded book on the first click', async () => {
+    const user = userEvent.setup();
+    renderContent();
+
+    expect(findAccordionTrigger(/Genesis/i)).toHaveAttribute('data-state', 'open');
+
+    await user.click(findAccordionTrigger(/Genesis/i)!);
+
+    expect(findAccordionTrigger(/Genesis/i)).toHaveAttribute('data-state', 'closed');
+  });
+
+  // Scenario B: collapsing a book other than the selected one must not re-open the selected book.
+  it('collapses a different expanded book on the first click without re-opening the selected book', async () => {
+    const user = userEvent.setup();
+    renderContent();
+
+    await user.click(findAccordionTrigger(/Exodus/i)!);
+
+    expect(findAccordionTrigger(/Genesis/i)).toHaveAttribute('data-state', 'closed');
+    expect(findAccordionTrigger(/Exodus/i)).toHaveAttribute('data-state', 'open');
+
+    await user.click(findAccordionTrigger(/Exodus/i)!);
+
+    expect(findAccordionTrigger(/Exodus/i)).toHaveAttribute('data-state', 'closed');
+    expect(findAccordionTrigger(/Genesis/i)).toHaveAttribute('data-state', 'closed');
+  });
+
+  // Scenario C: with no book selected, an expanded book must still close on the first click.
+  it('collapses an expanded book on the first click when no book prop is provided', async () => {
+    const user = userEvent.setup();
+    renderContent({ book: undefined });
+
+    await user.click(findAccordionTrigger(/Exodus/i)!);
+    expect(findAccordionTrigger(/Exodus/i)).toHaveAttribute('data-state', 'open');
+
+    await user.click(findAccordionTrigger(/Exodus/i)!);
+
+    expect(findAccordionTrigger(/Exodus/i)).toHaveAttribute('data-state', 'closed');
+  });
+
+  it('never flips the accordion between controlled and uncontrolled', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const user = userEvent.setup();
+    renderContent();
+
+    // Full expand/collapse sequence across both books.
+    await user.click(findAccordionTrigger(/Genesis/i)!);
+    await user.click(findAccordionTrigger(/Exodus/i)!);
+    await user.click(findAccordionTrigger(/Exodus/i)!);
+    await user.click(findAccordionTrigger(/Genesis/i)!);
+
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('changing from controlled to uncontrolled'),
+    );
+
+    warnSpy.mockRestore();
   });
 });

--- a/packages/ui/src/components/bible-chapter-picker.tsx
+++ b/packages/ui/src/components/bible-chapter-picker.tsx
@@ -44,11 +44,11 @@ type BibleChapterPickerContextType = {
   versionId: number;
   background: 'light' | 'dark';
   scrollToCurrentBook: () => void;
-  defaultBook: string;
   searchQuery: string;
   setSearchQuery: (query: string) => void;
-  expandedBook: string | null;
-  setExpandedBook: (bookId: string | null) => void;
+  /** The currently expanded book id. `''` means no book is expanded. */
+  expandedBook: string;
+  setExpandedBook: (bookId: string) => void;
   filteredBooks: BibleBook[] | null;
   registerBookElement: (bookId: string, node: HTMLDivElement | null) => void;
   onChapterPickerPress?: (data: BibleChapterPickerPressData) => void;
@@ -110,7 +110,9 @@ function Root({
   const [isPopoverOpenRaw, setIsPopoverOpenRaw] = useState(false);
   const isPopoverOpen = onChapterPickerPress ? false : isPopoverOpenRaw;
   const [searchQuery, setSearchQuery] = useState('');
-  const [expandedBook, setExpandedBook] = useState<string | null>(book || null);
+  // Non-nullable so the Accordion below stays controlled for its whole lifetime.
+  // `''` means collapsed; passing `undefined` would flip Radix back to uncontrolled.
+  const [expandedBook, setExpandedBook] = useState<string>(book || 'GEN');
 
   const { books } = useBooks(versionId);
 
@@ -186,7 +188,6 @@ function Root({
     versionId,
     background: theme,
     scrollToCurrentBook,
-    defaultBook,
     searchQuery,
     setSearchQuery,
     expandedBook,
@@ -297,8 +298,6 @@ function Trigger({ asChild = true, children, ...props }: TriggerProps) {
 function Content({ onRequestClose, onSelect }: BibleChapterPickerContentProps) {
   const { t } = useTranslation(undefined, { i18n });
   const {
-    book,
-    defaultBook,
     filteredBooks,
     expandedBook,
     setExpandedBook,
@@ -327,9 +326,8 @@ function Content({ onRequestClose, onSelect }: BibleChapterPickerContentProps) {
         className="yv:relative yv:overflow-y-auto yv:bg-background yv:px-6"
         type="single"
         collapsible
-        defaultValue={defaultBook || book || 'GEN'}
-        value={expandedBook ?? undefined}
-        onValueChange={(value) => setExpandedBook(value || null)}
+        value={expandedBook}
+        onValueChange={setExpandedBook}
       >
         {filteredBooks && filteredBooks.length > 0 ? (
           filteredBooks.map((bookItem) => (


### PR DESCRIPTION
[YPE-3867](https://lifechurch.atlassian.net/browse/YPE-3867) | [Artifacts](https://cloud.humanlayer.com/tasks/019faa16-7787-748b-a2ba-16368d9198f3/artifacts) | [Task](https://cloud.humanlayer.com/deep/tasks/019faa16-7787-748b-a2ba-16368d9198f3)

## What problems was I solving

Collapsing an expanded book in `BibleChapterPicker` took two taps — the first tap did nothing. The picker felt broken everywhere the Web SDK renders it, including inside the RN Expo SDK's DOM wrapper (originally reported on iPad, but not platform-specific).

Root cause: the book-list Accordion (Radix, `type="single" collapsible`) alternated between controlled and uncontrolled. `Root` held `expandedBook: string | null` and `Content` rendered `value={expandedBook ?? undefined}` with `onValueChange={(v) => setExpandedBook(v || null)}`. When the user tapped an open item, Radix emitted `''`, which got coerced to `null`, so `value` became `undefined` and the Accordion fell back to its own internal state — which still held the same book. The item stayed open. The next tap toggled the now-uncontrolled internal state and finally closed it. `@radix-ui/react-use-controllable-state` never syncs internal state while controlled, and warns about exactly this switch in dev builds.

Three distinct visible failures came out of that one mechanism, all reproduced before the fix:

1. Book passed via `book` prop and expanded on mount → first tap is a no-op, second collapses.
2. A different book expanded while `book` is set → collapsing it closes that book but snaps the seeded book back open.
3. No `book` prop at all → the row never collapses.

Shipped, all three collapse on the first tap and the Radix controlled/uncontrolled warning is gone.

## What user-facing changes did I ship

- [packages/ui/src/components/bible-chapter-picker.tsx](https://github.com/youversion/platform-sdk-react/pull/303/files#diff-e043264b9f899a4de37d94040a118dc908407b5f063091e4f0d7bbb433a4eb2f) - Tapping an expanded book collapses it on the first tap, in all three scenarios above. Single-open behavior and the initially-expanded book are unchanged.
- [.changeset/chapter-picker-accordion-single-tap-collapse.md](https://github.com/youversion/platform-sdk-react/pull/303/files#diff-a2bd488498736e30e850a68857883893d99b3210ee2b38156a827d885a4306c0) - Patch release for `@youversion/platform-react-ui`.

No public prop, type, or export changes. Purely internal state handling.

## How I implemented it

Keep the Accordion controlled for its whole lifetime. `expandedBook` becomes a non-nullable `string` where `''` means collapsed, so `value` is never `undefined`.

### UI package

- [bible-chapter-picker.tsx R50](https://github.com/youversion/platform-sdk-react/pull/303/files#diff-e043264b9f899a4de37d94040a118dc908407b5f063091e4f0d7bbb433a4eb2fR50) - Context type narrows to `expandedBook: string` / `setExpandedBook: (bookId: string) => void`. Module-private type, not exported from `components/index.ts`.
- [bible-chapter-picker.tsx R115](https://github.com/youversion/platform-sdk-react/pull/303/files#diff-e043264b9f899a4de37d94040a118dc908407b5f063091e4f0d7bbb433a4eb2fR115) - State seed becomes `useState<string>(book || 'GEN')`. The `'GEN'` literal relocated here from the old `defaultValue` expression, so the book that is open when the picker first appears is unchanged.
- [bible-chapter-picker.tsx R329](https://github.com/youversion/platform-sdk-react/pull/303/files#diff-e043264b9f899a4de37d94040a118dc908407b5f063091e4f0d7bbb433a4eb2fR329) - Accordion drops `defaultValue` and passes state through unmapped: `value={expandedBook}`, `onValueChange={setExpandedBook}`. Pairing `value` with `defaultValue` was itself part of the problem.
- Removing `defaultValue` left `defaultBook` and `book` unread inside `Content`, so both came out of the context destructure. `defaultBook` also came out of the context type and provider value entirely — nothing else consumed it. It remains a public `Root` prop feeding `useControllableState({ defaultProp: defaultBook })` at `bible-chapter-picker.tsx:97`, unchanged.

Everything downstream keeps working because `''` is falsy exactly where `null` was: the scroll effect's `if (!expandedBook) return` still no-ops when collapsed, `scrollToCurrentBook` is already guarded by `if (book)` so it never writes an empty value, and Radix's `AccordionItem` open check is `value.includes(itemValue)` — `''` matches no book id.

### Tests

- [bible-chapter-picker.test.tsx](https://github.com/youversion/platform-sdk-react/pull/303/files#diff-f744764a5ece99e81b1b80128b3a6e82dbfca5919e98a35619775a188f1eaa03) - New `describe('BibleChapterPicker - accordion expand/collapse')` block with one click-driven test per reproduced scenario, plus a `console.warn` spy asserting no `changing from controlled to uncontrolled` message across a full expand/collapse sequence. `findAccordionTrigger()` and `renderContent()` lifted to module scope so both describe blocks share them, and `renderContent()` gained an optional props argument so scenario C can render without a `book` prop. Added Exodus to `mockBooks` — the fixture had only Genesis, and scenarios B and C need two books.

Tests were written first and confirmed red for the expected reason before the source edits: A and B failed the single-click assertion, C never closed, and the warn spy caught the Radix message.

## Deviations from the plan

Compared against the structure outline in `.humanlayer/tasks/.../04-structure-outline-chapter-picker-accordion.md`. No separate plan file exists.

### Implemented as planned

- Context type narrowed to non-nullable `string`.
- State seed changed to `useState<string>(book || 'GEN')`.
- Accordion `defaultValue` dropped; `value` / `onValueChange` passed through unmapped.
- `defaultBook` and `book` removed from the `Content` context destructure.
- All four tests (A, B, C, warn spy), with `mockBooks` extended and the shared helpers lifted to module scope.
- Patch changeset for `@youversion/platform-react-ui`, verbatim from the outline.
- `BibleVersionPicker` audit closed with no code change.

### Deviations/surprises

- None. The outline's diffs applied as written.

### Additions not in plan

- `defaultBook` was also removed from the `BibleChapterPickerContextType` and from the provider's `value` object, not just from the `Content` destructure. With `Content` no longer reading it, nothing consumed the context copy. The public `Root` prop is untouched.
- Two short explanatory comments on the context field and the state seed, so the `''`-means-collapsed invariant is not silently re-broken.

### Items planned but not implemented

- None.

## Acceptance criteria

- [x] Tapping an expanded book collapses it on the first tap.
- [x] Expanding a different book while one is open still works (single-open behavior preserved).
- [x] Dev console no longer logs Radix's "changing from controlled to uncontrolled" warning when collapsing.
- [x] `BibleVersionPicker` audited for the same `?? undefined` controlled/uncontrolled pattern. **No bug present, no change needed.** `bible-version-picker.tsx` drives Popover with `useState(false)` (`:277-278, 447`) and Tabs with `useState('suggested')` (`:877, 930-931`) — both non-nullable, no coercion, no `value` + `defaultValue` pairing. A grep for `?? undefined` across `packages/ui/src` returns only two hits, both in the `packages/ui/src/test/utils.ts` fixture builder (`avatar_url: options.avatarUrl ?? undefined`, `:24` and `:31`), neither a Radix prop.

## How to verify it

```bash
git fetch origin ype-3867-react-sdk-biblechapterpicker-accordion-requires-two-taps-to-collapse-an-expanded-book-first-tap-is-a-no-op
git worktree add ../ype-3867 ype-3867-react-sdk-biblechapterpicker-accordion-requires-two-taps-to-collapse-an-expanded-book-first-tap-is-a-no-op
cd ../ype-3867 && pnpm install
```

### Manual Testing

- [ ] `pnpm --filter @youversion/platform-react-ui storybook` → `BibleChapterPicker / LightBackground`
- [ ] Open the picker, tap the expanded book once — it collapses immediately.
- [ ] Tap a different book to expand it, then tap it again — it collapses, and the originally selected book stays closed.
- [ ] Browser console logs no Radix controlled/uncontrolled warning through that sequence.
- [ ] The book that is open when the picker first appears matches `main`'s behavior.

### Automated Tests

```bash
pnpm --filter @youversion/platform-react-ui test
pnpm --filter @youversion/platform-react-ui typecheck
pnpm --filter @youversion/platform-react-ui lint

# Full repo. Core's suite needs these env vars, and turbo's strict env mode filters
# them, so run locally with --env-mode=loose. CI is unaffected: its test job runs
# pnpm test:coverage, which bypasses turbo.
YVP_API_HOST=api.youversion.com YVP_APP_KEY=<any> pnpm turbo test --env-mode=loose
pnpm typecheck && pnpm lint
pnpm build --force
pnpm --filter @youversion/platform-react-ui test:integration
```

All of the above were run green locally: 6/6 turbo test tasks, and 37 files / 405 tests in Chromium for the integration suite, including `bible-chapter-picker.stories.tsx > Light Background`.

## Description for the changelog

Fix `BibleChapterPicker` requiring two taps to collapse an expanded book — the book accordion now stays controlled for its whole lifetime instead of flipping to uncontrolled on collapse.

[YPE-3867]: https://lifechurch.atlassian.net/browse/YPE-3867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes BibleChapterPicker accordion collapse behavior by keeping its expanded state controlled throughout the component lifecycle.
- Represents the collapsed state with an empty string instead of switching to an uncontrolled value.
- Adds coverage for initial, alternate-book, and no-selection collapse flows.
- Adds a patch changeset for `@youversion/platform-react-ui`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The accordion remains controlled while preserving selected-book initialization, collapse behavior, and existing popover synchronization, with tests covering the reported regression and relevant edge cases.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/bible-chapter-picker.tsx | Keeps the single-select accordion controlled by using a non-nullable expanded-book state and an empty-string collapsed value. |
| packages/ui/src/components/bible-chapter-picker.test.tsx | Adds focused interaction tests covering first-click collapse and controlled-state stability. |
| .changeset/chapter-picker-accordion-single-tap-collapse.md | Correctly records the user-facing accordion fix as a patch release. |

<sub>Reviews (1): Last reviewed commit: ["chore: add changeset for chapter picker ..."](https://github.com/youversion/platform-sdk-react/commit/41980a72824de0b9144124e08764e36787c4e744) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48089873)</sub>

**Context used:**

- Knowledge Base — [packages/ui](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/ui-package.md)

<!-- /greptile_comment -->