### PR TITLE
fix(ui): YPE-3870 - drop font-mono from the version picker language count badge

### DIFF
--- a/.changeset/version-count-no-slashed-zero.md
+++ b/.changeset/version-count-no-slashed-zero.md
@@ -1,0 +1,5 @@
+---
+'@youversion/platform-react-ui': patch
+---
+
+Fix the version count badge in the version picker's language trigger rendering with a monospace, slashed-zero font. The badge now inherits the picker's font and keeps `tabular-nums` for stable digit widths.

--- a/packages/ui/src/components/bible-version-picker.test.tsx
+++ b/packages/ui/src/components/bible-version-picker.test.tsx
@@ -291,20 +291,6 @@ describe('BibleVersionPicker', () => {
       });
     });
 
-    it('should render the version count with the inherited font, not a monospace one', async () => {
-      setupDefaultMocks({ versionsLoading: false, filteredVersions: mockVersions });
-      renderPicker();
-      await openPicker();
-
-      await waitFor(() => {
-        const languageButton = screen.getByRole('button', { name: /select language/i });
-        const badge = languageButton.querySelector('[data-slot="badge"]');
-        expect(badge).not.toBeNull();
-        expect(badge!.className).not.toContain('font-mono');
-        expect(badge!.className).toContain('yv:tabular-nums');
-      });
-    });
-
     it('should render version items when loaded', async () => {
       setupDefaultMocks({ versionsLoading: false, filteredVersions: mockVersions });
       renderPicker();

--- a/packages/ui/src/components/bible-version-picker.test.tsx
+++ b/packages/ui/src/components/bible-version-picker.test.tsx
@@ -291,6 +291,20 @@ describe('BibleVersionPicker', () => {
       });
     });
 
+    it('should render the version count with the inherited font, not a monospace one', async () => {
+      setupDefaultMocks({ versionsLoading: false, filteredVersions: mockVersions });
+      renderPicker();
+      await openPicker();
+
+      await waitFor(() => {
+        const languageButton = screen.getByRole('button', { name: /select language/i });
+        const badge = languageButton.querySelector('[data-slot="badge"]');
+        expect(badge).not.toBeNull();
+        expect(badge!.className).not.toContain('font-mono');
+        expect(badge!.className).toContain('yv:tabular-nums');
+      });
+    });
+
     it('should render version items when loaded', async () => {
       setupDefaultMocks({ versionsLoading: false, filteredVersions: mockVersions });
       renderPicker();

--- a/packages/ui/src/components/bible-version-picker.tsx
+++ b/packages/ui/src/components/bible-version-picker.tsx
@@ -558,7 +558,7 @@ export function BibleVersionPickerLanguageTrigger({
       </span>
       <Badge
         variant="secondary"
-        className="yv:h-5 yv:min-w-5 yv:rounded-full yv:px-1 yv:font-mono yv:tabular-nums"
+        className="yv:h-5 yv:min-w-5 yv:rounded-full yv:px-1 yv:tabular-nums"
       >
         {versionsLoading ? (
           <LoaderIcon className="yv:size-3 yv:animate-spin" />


### PR DESCRIPTION

<img width="427" height="488" alt="image" src="https://github.com/user-attachments/assets/a02635f0-0212-4082-b7bc-931dc25f412a" />


[YPE-3870](https://lifechurch.atlassian.net/browse/YPE-3870) | [Artifacts](https://cloud.humanlayer.com/tasks/019fce4c-7ebe-7513-b02e-9c29a539e89e/artifacts) | [Task](https://cloud.humanlayer.com/deep/tasks/019fce4c-7ebe-7513-b02e-9c29a539e89e)

## What problems was I solving

The version picker's language trigger shows a count badge, for example the number of Bible versions available in the selected language. That badge carried `yv:font-mono`, so its digits rendered in the monospace stack instead of the picker's font. The monospace zero has a slash through it. Next to the language name in Inter, the badge looked like a different design.

David flagged this in the RN Expo SDK launch review. It shows up on both surfaces: the Web SDK and the RN Expo SDK's WebView version picker sheet.

After this ships, the badge digits match the rest of the picker. Success is visual: zeros render without a slash, and the badge no longer reads as a separate font.

## What user-facing changes did I ship

- [packages/ui/src/components/bible-version-picker.tsx](https://github.com/youversion/platform-sdk-react/pull/316/files#diff-0c0833df720c4698491de0ed46fc355f179eca40cd2cbe9484a527b3175919ef) - The language trigger's count badge inherits the picker font (Inter) instead of the monospace stack. Slashed zeros are gone.

This is a two-file PR: one class removed, plus a changeset.

No API change. No prop change. Consumers get the fix on upgrade with no code edits.


### Changeset

- [.changeset/version-count-no-slashed-zero.md](https://github.com/youversion/platform-sdk-react/pull/316/files#diff-98136cd4f47a9de2afeadcdbf12513686d4f3144ff9acd5801b721aaaaed8f81) - Patch bump for `@youversion/platform-react-ui`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes the monospace font utility from the Bible version picker’s language-count badge while retaining tabular numerals, and adds a patch changeset for the UI package.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/bible-version-picker.tsx | Removes `yv:font-mono` from the count badge so it inherits the picker’s sans-serif font while preserving `yv:tabular-nums`. |
| .changeset/version-count-no-slashed-zero.md | Adds an appropriate patch changeset documenting the corrected badge typography. |

<sub>Reviews (2): Last reviewed commit: ["test(ui): remove the version count badge..."](https://github.com/youversion/platform-sdk-react/commit/e602dcfa2fe6bf9f71e4ecbaf24d31559e140c73) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50195043)</sub>

**Context used:**

- Knowledge Base — [packages/ui](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/ui-package.md)

<!-- /greptile_comment -->

[YPE-3870]: https://lifechurch.atlassian.net/browse/YPE-3870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ