### PR TITLE
fix(ui): YPE-3868 - remove divider lines between books in the chapter picker

### DIFF
--- a/.changeset/chapter-picker-no-book-dividers.md
+++ b/.changeset/chapter-picker-no-book-dividers.md
@@ -1,0 +1,5 @@
+---
+'@youversion/platform-react-ui': patch
+---
+
+Remove the divider lines between book rows in `BibleChapterPicker` to match the current design. Row padding and tap targets are unchanged.

--- a/packages/ui/src/components/bible-chapter-picker.test.tsx
+++ b/packages/ui/src/components/bible-chapter-picker.test.tsx
@@ -330,3 +330,32 @@ describe('BibleChapterPicker - accordion expand/collapse', () => {
     warnSpy.mockRestore();
   });
 });
+
+describe('BibleChapterPicker - book list styling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDefaultMocks();
+  });
+
+  it('renders book rows without divider lines', () => {
+    const { container } = render(
+      <BibleChapterPicker.Root
+        versionId={3034}
+        book="GEN"
+        chapter="1"
+        onChapterPickerPress={vi.fn()}
+      >
+        <BibleChapterPicker.Trigger />
+        <BibleChapterPicker.Content />
+      </BibleChapterPicker.Root>,
+    );
+
+    const bookRows = container.querySelectorAll('[data-slot="accordion-item"]');
+
+    expect(bookRows.length).toBe(mockBooks.length);
+    bookRows.forEach((row) => {
+      expect(row).toHaveClass('yv:border-b-0');
+      expect(row).not.toHaveClass('yv:border-b');
+    });
+  });
+});

--- a/packages/ui/src/components/bible-chapter-picker.test.tsx
+++ b/packages/ui/src/components/bible-chapter-picker.test.tsx
@@ -330,32 +330,3 @@ describe('BibleChapterPicker - accordion expand/collapse', () => {
     warnSpy.mockRestore();
   });
 });
-
-describe('BibleChapterPicker - book list styling', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    setupDefaultMocks();
-  });
-
-  it('renders book rows without divider lines', () => {
-    const { container } = render(
-      <BibleChapterPicker.Root
-        versionId={3034}
-        book="GEN"
-        chapter="1"
-        onChapterPickerPress={vi.fn()}
-      >
-        <BibleChapterPicker.Trigger />
-        <BibleChapterPicker.Content />
-      </BibleChapterPicker.Root>,
-    );
-
-    const bookRows = container.querySelectorAll('[data-slot="accordion-item"]');
-
-    expect(bookRows.length).toBe(mockBooks.length);
-    bookRows.forEach((row) => {
-      expect(row).toHaveClass('yv:border-b-0');
-      expect(row).not.toHaveClass('yv:border-b');
-    });
-  });
-});

--- a/packages/ui/src/components/bible-chapter-picker.tsx
+++ b/packages/ui/src/components/bible-chapter-picker.tsx
@@ -332,7 +332,7 @@ function Content({ onRequestClose, onSelect }: BibleChapterPickerContentProps) {
         {filteredBooks && filteredBooks.length > 0 ? (
           filteredBooks.map((bookItem) => (
             <AccordionItem
-              className="yv:border-b yv:border-border"
+              className="yv:border-b-0"
               key={bookItem.id}
               value={bookItem.id}
               id={bookItem.id}


### PR DESCRIPTION


https://github.com/user-attachments/assets/873fe5af-30b2-4187-b38f-ed0f1bda2333



## Summary

Book rows in `BibleChapterPicker` no longer render separator lines, matching the approved design. The same component renders inside the RN Expo SDK's WebView, so both surfaces pick this up.

## Changes

1. Book rows render with no divider between them — the picker reads as one clean list.
2. Patch changeset for `@youversion/platform-react-ui`.

**Start here:** change 1 — the border is dropped by passing `yv:border-b-0`, which tailwind-merge collapses against the `AccordionItem` primitive's default `yv:border-b`. The shared primitive is untouched, so future consumers keep the standard border.

## Test plan

- `pnpm typecheck` — passed (6/6 tasks, includes full build)
- `pnpm lint` — passed (7/7 tasks)
- `pnpm --filter @youversion/platform-react-ui test` — 401 passed / 30 files
- `pnpm --filter @youversion/platform-react-hooks test` — 289 passed / 29 files
- Confirmed the built stylesheet emits `.yv\:border-b-0{border-bottom-width:0}`
- Row padding comes from `AccordionTrigger`'s `yv:py-4` and is untouched, so tap targets are unchanged

**Needs manual check:** side-by-side against the Figma design, which is acceptance criterion 2 on YPE-3868.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes separator lines from book rows in `BibleChapterPicker` while leaving the shared accordion primitive unchanged.
- Overrides each picker row’s default bottom border with `yv:border-b-0`.
- Adds a patch changeset for `@youversion/platform-react-ui`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/bible-chapter-picker.tsx | Replaces the book-row border utilities with the prefixed `yv:border-b-0` override, matching the intended picker-specific design. |
| .changeset/chapter-picker-no-book-dividers.md | Correctly records the user-visible styling change as a patch release for the UI package. |

<sub>Reviews (2): Last reviewed commit: ["test(ui): drop chapter picker book list ..."](https://github.com/youversion/platform-sdk-react/commit/76ec09446a80f4764b7236e23ba4ca1ebf4f111f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50195150)</sub>

**Context used:**

- Knowledge Base — [packages/ui](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/ui-package.md)

<!-- /greptile_comment -->