### PR TITLE
fix(ui): YPE-3871 - secondary buttons no longer read as disabled

### DIFF
--- a/.changeset/biblecard-version-button-foreground.md
+++ b/.changeset/biblecard-version-button-foreground.md
@@ -1,0 +1,5 @@
+---
+'@youversion/platform-react-ui': patch
+---
+
+Fix secondary buttons rendering their label in the muted text color, which made active controls read as disabled. The `secondary` variant now pairs `bg-muted` with the normal foreground color in both light and dark themes. This is most visible on the BibleCard version picker button, and also affects the secondary buttons in BibleReader, BibleChapterPicker, BibleVersionPicker, and the highlight permission dialog.

--- a/examples/vite-react/src/pages/BibleCardPage.tsx
+++ b/examples/vite-react/src/pages/BibleCardPage.tsx
@@ -2,7 +2,7 @@ import { BibleCard } from '@youversion/platform-react-ui';
 
 export function BibleCardPage() {
   return (
-    <div className="flex justify-center p-6 md:p-12">
+    <div className="flex justify-center p-6 max-w-screen-sm mx-auto md:p-12">
       <BibleCard reference="JHN.3.16" versionId={3034} showVersionPicker />
     </div>
   );

--- a/examples/vite-react/src/pages/VotdPage.tsx
+++ b/examples/vite-react/src/pages/VotdPage.tsx
@@ -2,7 +2,7 @@ import { VerseOfTheDay } from '@youversion/platform-react-ui';
 
 export function VotdPage() {
   return (
-    <div className="flex flex-col grow items-center gap-8 w-full p-6 md:p-12">
+    <div className="flex flex-col max-w-screen-sm mx-auto grow items-center gap-8 w-full p-6 md:p-12">
       <VerseOfTheDay size="default" versionId={3034} />
       <VerseOfTheDay size="lg" versionId={3034} />
     </div>

--- a/packages/ui/src/components/bible-card.tsx
+++ b/packages/ui/src/components/bible-card.tsx
@@ -79,10 +79,7 @@ function BibleCardVersionPicker({
             data-yv-theme={theme}
           >
             {loading ? (
-              <LoaderIcon
-                className="yv:size-4 yv:animate-spin yv:text-muted-foreground"
-                aria-hidden="true"
-              />
+              <LoaderIcon className="yv:size-4 yv:animate-spin" aria-hidden="true" />
             ) : (
               version?.localized_abbreviation || t('selectVersion')
             )}

--- a/packages/ui/src/components/ui/button.test.tsx
+++ b/packages/ui/src/components/ui/button.test.tsx
@@ -18,15 +18,4 @@ describe('Button — default variant colors', () => {
     expect(className).toContain('yv:text-primary-foreground');
     expect(className).not.toContain('yv:bg-background');
   });
-
-  it('paints the secondary label with the foreground color, not the muted one (regression: reads as disabled)', () => {
-    // `bg-muted` + `text-muted-foreground` made active secondary buttons — most
-    // visibly the BibleCard version picker — read as disabled controls.
-    const { getByRole } = render(<Button variant="secondary">NIV</Button>);
-    const className = getByRole('button').className;
-
-    expect(className).toContain('yv:bg-muted');
-    expect(className).toContain('yv:text-foreground');
-    expect(className).not.toContain('yv:text-muted-foreground');
-  });
 });

--- a/packages/ui/src/components/ui/button.test.tsx
+++ b/packages/ui/src/components/ui/button.test.tsx
@@ -18,4 +18,15 @@ describe('Button — default variant colors', () => {
     expect(className).toContain('yv:text-primary-foreground');
     expect(className).not.toContain('yv:bg-background');
   });
+
+  it('paints the secondary label with the foreground color, not the muted one (regression: reads as disabled)', () => {
+    // `bg-muted` + `text-muted-foreground` made active secondary buttons — most
+    // visibly the BibleCard version picker — read as disabled controls.
+    const { getByRole } = render(<Button variant="secondary">NIV</Button>);
+    const className = getByRole('button').className;
+
+    expect(className).toContain('yv:bg-muted');
+    expect(className).toContain('yv:text-foreground');
+    expect(className).not.toContain('yv:text-muted-foreground');
+  });
 });

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -14,7 +14,7 @@ const buttonVariants = cva(
           'yv:bg-destructive yv:text-white yv:hover:bg-destructive/90 yv:focus-visible:ring-destructive/20 yv:dark:focus-visible:ring-destructive/40 yv:dark:bg-destructive/60',
         outline:
           'yv:border yv:border-border yv:bg-background yv:shadow-xs yv:hover:bg-accent yv:hover:text-accent-foreground yv:dark:bg-input/30 yv:dark:border-input yv:dark:hover:bg-input/50',
-        secondary: 'yv:bg-muted yv:text-muted-foreground yv:hover:bg-muted/80',
+        secondary: 'yv:bg-muted yv:text-foreground yv:hover:bg-muted/80',
         ghost: 'yv:hover:bg-accent yv:hover:text-accent-foreground yv:dark:hover:bg-accent/50',
         link: 'yv:text-primary yv:underline-offset-4 yv:hover:underline',
       },


### PR DESCRIPTION


https://github.com/user-attachments/assets/8e4e821d-601f-428f-a9fd-24bdb6bcef7f



## Summary

Secondary buttons paired `bg-muted` with `text-muted-foreground`, so active controls like the BibleCard version picker read as disabled. The variant now uses the normal foreground color, taking the light-theme label from 5.6:1 to 17.1:1 against the button surface.

YPE-3871 - https://lifechurch.atlassian.net/browse/YPE-3871

## Changes

1. Secondary buttons read as active controls — the variant pairs `bg-muted` with the normal foreground color instead of the muted one.
2. The BibleCard version picker's loading spinner inherits the button label color rather than forcing its own muted one.
3. The BibleCard and Verse of the Day demo pages cap their width, so the cards render in a realistic container instead of stretching to the viewport.

**Start here:** change 1 — it repaints every secondary button, not just BibleCard's.

## Test plan

- `pnpm typecheck` — passed
- `pnpm lint` — passed
- `pnpm --filter @youversion/platform-react-ui test` — 401 passed
- `pnpm --filter @youversion/platform-react-hooks test` — 289 passed
- `@youversion/platform-core` tests not run: `.env.local` is absent locally, and no core files changed
- **Needs manual check:** the version button in light and dark themes, and the RN Expo SDK's BibleCard — the dark theme's `muted-foreground` is near-white, so it hid this bug, and the Expo SDK lives in another repo.
