### PR TITLE
fix(ui): collapse the BibleCard error state into one alert region

### DIFF
--- a/.changeset/biblecard-single-error-alert.md
+++ b/.changeset/biblecard-single-error-alert.md
@@ -1,0 +1,7 @@
+---
+'@youversion/platform-react-ui': patch
+---
+
+Fix the `BibleCard` error state announcing two alerts, and keep the version picker usable while an error is showing. The "Error" label stays in the header slot but drops its `role="alert"` and `aria-live`, leaving the message block in the card body as the only alert region. The picker no longer disappears on error, so a 404 has an in-card fix: switch to a version that carries the passage.
+
+The shared message block also drops a redundant `aria-live` and hides its icon with `aria-hidden`, so `VerseOfTheDay` and standalone `BibleTextView` pick up the same accessibility fixes. Their visible text is unchanged, and neither gains an "Error" label. The eight status-aware messages, their six locales, and how errors are derived are untouched.

--- a/.changeset/biblecard-single-error-alert.md
+++ b/.changeset/biblecard-single-error-alert.md
@@ -4,4 +4,4 @@
 
 Fix the `BibleCard` error state announcing two alerts, and keep the version picker usable while an error is showing. The "Error" label stays in the header slot but drops its `role="alert"` and `aria-live`, leaving the message block in the card body as the only alert region. The picker no longer disappears on error, so a 404 has an in-card fix: switch to a version that carries the passage.
 
-The shared message block also drops a redundant `aria-live` and hides its icon with `aria-hidden`, so `VerseOfTheDay` and standalone `BibleTextView` pick up the same accessibility fixes. Their visible text is unchanged, and neither gains an "Error" label. The eight status-aware messages, their six locales, and how errors are derived are untouched.
+The shared message block now hides its icon with `aria-hidden`, so `VerseOfTheDay` and standalone `BibleTextView` pick up that fix too. Their announcement stays polite and their visible text is unchanged, and neither gains an "Error" label. The eight status-aware messages, their six locales, and how errors are derived are untouched.

--- a/packages/ui/src/components/bible-card.stories.tsx
+++ b/packages/ui/src/components/bible-card.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { within, expect, userEvent, screen, waitFor } from 'storybook/test';
 import { http, HttpResponse } from 'msw';
 import { BibleCard } from './bible-card';
+import { globalHandlers } from '../test/mocks/handlers';
 
 const meta = {
   title: 'Components/BibleCard',
@@ -191,16 +192,22 @@ export const Error: Story = {
   tags: ['integration'],
   parameters: {
     msw: {
+      /*
+        A story-level `handlers` array replaces the preview-level `globalHandlers`
+        rather than merging with it, so `globalHandlers` is spread back in.
+        Without it the version picker's `useLanguages`/`useVersions` calls fall
+        through to the live API, because `onUnhandledRequest` is 'warn'.
+
+        The 500 override comes first: MSW takes the first matching handler, so it
+        wins over the successful NIV passage handler in `globalHandlers`. Version
+        1588 (AMP) is left on `globalHandlers` and still resolves, which is what
+        makes the recovery path below testable.
+      */
       handlers: [
-        http.get('*/v1/bibles/111', () => {
-          return HttpResponse.json({
-            id: 111,
-            localized_abbreviation: 'NIV',
-          });
-        }),
         http.get('*/v1/bibles/111/passages/LUK.1.39-45', () => {
           return new HttpResponse(null, { status: 500 });
         }),
+        ...globalHandlers,
       ],
     },
   },
@@ -218,6 +225,9 @@ export const Error: Story = {
     await expect(alerts[0]).toHaveTextContent(
       'The Bible service is having trouble right now. Please try again in a moment.',
     );
+    // role="alert" implies assertive. The explicit polite value holds the
+    // announcement down, so a failed load does not interrupt the reader.
+    await expect(alerts[0]).toHaveAttribute('aria-live', 'polite');
 
     // The picker is the in-card recovery path: a 404 is fixed by switching versions.
     const versionPickerButton = await canvas.findByRole('button', {
@@ -228,5 +238,32 @@ export const Error: Story = {
       await expect(versionPickerButton).toBeEnabled();
       await expect(versionPickerButton).toHaveTextContent(/NIV/i);
     });
+
+    // Walk the recovery path: switch to a version whose passage resolves.
+    await userEvent.click(versionPickerButton);
+
+    const dialog = await screen.findByRole('dialog');
+    const searchInput = within(dialog).getByRole('textbox', { name: /search bible versions/i });
+
+    await userEvent.type(searchInput, 'amplified bible');
+
+    await waitFor(async () => {
+      const versionList = within(dialog).getByTestId('version-list');
+      const versionItems = within(versionList).getAllByRole('listitem');
+      await expect(versionItems).toHaveLength(1);
+      await expect(versionItems[0]).toHaveTextContent(/amplified bible/i);
+    });
+
+    await userEvent.click(within(dialog).getByRole('listitem', { name: /amplified bible/i }));
+
+    // The error clears: no alert, and the passage replaces the "Error" heading.
+    await waitFor(async () => {
+      await expect(canvas.queryByRole('alert')).toBeNull();
+      await expect(canvas.getByText(/at that time mary got ready/i)).toBeInTheDocument();
+    });
+
+    await expect(
+      canvas.getByRole('heading', { level: 2, name: /luke 1:39-45/i }),
+    ).toHaveTextContent(/amp/i);
   },
 };

--- a/packages/ui/src/components/bible-card.stories.tsx
+++ b/packages/ui/src/components/bible-card.stories.tsx
@@ -206,12 +206,16 @@ export const Error: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
+    // The header slot carries the "Error" label; the body block is the one alert.
     await waitFor(async () => {
       await expect(canvas.getByRole('heading', { level: 2, name: /error/i })).toBeInTheDocument();
-      const errorMessages = canvas.getAllByText(
-        'The Bible service is having trouble right now. Please try again in a moment.',
-      );
-      await expect(errorMessages.length).toBeGreaterThan(0);
     });
+
+    const alerts = canvas.getAllByRole('alert');
+
+    await expect(alerts).toHaveLength(1);
+    await expect(alerts[0]).toHaveTextContent(
+      'The Bible service is having trouble right now. Please try again in a moment.',
+    );
   },
 };

--- a/packages/ui/src/components/bible-card.stories.tsx
+++ b/packages/ui/src/components/bible-card.stories.tsx
@@ -186,6 +186,7 @@ export const Error: Story = {
   args: {
     reference: 'LUK.1.39-45',
     versionId: 111,
+    showVersionPicker: true,
   },
   tags: ['integration'],
   parameters: {
@@ -217,5 +218,15 @@ export const Error: Story = {
     await expect(alerts[0]).toHaveTextContent(
       'The Bible service is having trouble right now. Please try again in a moment.',
     );
+
+    // The picker is the in-card recovery path: a 404 is fixed by switching versions.
+    const versionPickerButton = await canvas.findByRole('button', {
+      name: /change bible version/i,
+    });
+
+    await waitFor(async () => {
+      await expect(versionPickerButton).toBeEnabled();
+      await expect(versionPickerButton).toHaveTextContent(/NIV/i);
+    });
   },
 };

--- a/packages/ui/src/components/bible-card.test.tsx
+++ b/packages/ui/src/components/bible-card.test.tsx
@@ -6,17 +6,9 @@ import { render, act, within, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BibleCard } from './bible-card';
 import type { FootnoteData } from './verse';
-import {
-  useFilteredVersions,
-  useLanguage,
-  useLanguages,
-  useOrganizations,
-  usePassage,
-  useTheme,
-  useVersion,
-  useVersions,
-} from '@youversion/platform-react-hooks';
-import type { BiblePassage, BibleVersion, Language } from '@youversion/platform-core';
+import { usePassage, useTheme, useVersion } from '@youversion/platform-react-hooks';
+import type { BiblePassage, BibleVersion } from '@youversion/platform-core';
+import { createBibleTextError as createError } from '../test/errors';
 
 vi.mock('@youversion/platform-react-hooks');
 
@@ -166,10 +158,6 @@ describe('BibleCard - Delayed spinner', () => {
 });
 
 describe('BibleCard - Error state', () => {
-  function createError(message: string, status?: number): Error {
-    return Object.assign(new Error(message), status === undefined ? {} : { status });
-  }
-
   beforeEach(() => {
     vi.mocked(useTheme).mockReturnValue('light');
     vi.mocked(useVersion).mockReturnValue({
@@ -213,40 +201,10 @@ describe('BibleCard - Error state', () => {
     expect(within(container).queryByRole('status')).toBeNull();
   });
 
-  it('should keep the version picker usable so a bad version can be swapped', () => {
-    // The version picker mounts its own hook tree. The file-level auto-mock
-    // returns undefined for each one, so give them values here.
-    vi.mocked(useLanguages).mockReturnValue({
-      languages: { data: [] as Language[], next_page_token: null },
-      loading: false,
-      error: null,
-      refetch: vi.fn(),
-    });
-    vi.mocked(useLanguage).mockReturnValue({
-      language: { id: 'en', language: 'English', display_names: { en: 'English' } } as Language,
-      loading: false,
-      error: null,
-      refetch: vi.fn(),
-    });
-    vi.mocked(useVersions).mockReturnValue({
-      versions: { data: [], next_page_token: null },
-      loading: false,
-      error: null,
-      refetch: vi.fn(),
-    });
-    vi.mocked(useFilteredVersions).mockReturnValue([]);
-    vi.mocked(useOrganizations).mockReturnValue({ organizations: new Map() });
-
-    const { container } = render(
-      <BibleCard reference="JHN.3.16" versionId={3034} showVersionPicker />,
-    );
-
-    const picker = within(container).getByRole('button', { name: /change bible version/i });
-
-    expect(picker).toBeInTheDocument();
-    expect(picker).toBeEnabled();
-    expect(picker).toHaveTextContent('BSB');
-  });
+  // The version picker staying usable during an error is covered by the `Error`
+  // story's play function. A jsdom test would have to hand-mock the five hooks
+  // that BibleVersionPicker.Root reads, which couples this file to that
+  // component's internals. See packages/ui/CLAUDE.md → TESTING.
 });
 
 describe('BibleCard - onFootnotePress callback', () => {

--- a/packages/ui/src/components/bible-card.test.tsx
+++ b/packages/ui/src/components/bible-card.test.tsx
@@ -6,8 +6,17 @@ import { render, act, within, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BibleCard } from './bible-card';
 import type { FootnoteData } from './verse';
-import { usePassage, useVersion, useTheme } from '@youversion/platform-react-hooks';
-import type { BiblePassage, BibleVersion } from '@youversion/platform-core';
+import {
+  useFilteredVersions,
+  useLanguage,
+  useLanguages,
+  useOrganizations,
+  usePassage,
+  useTheme,
+  useVersion,
+  useVersions,
+} from '@youversion/platform-react-hooks';
+import type { BiblePassage, BibleVersion, Language } from '@youversion/platform-core';
 
 vi.mock('@youversion/platform-react-hooks');
 
@@ -202,6 +211,41 @@ describe('BibleCard - Error state', () => {
     const { container } = render(<BibleCard reference="JHN.3.16" versionId={3034} />);
 
     expect(within(container).queryByRole('status')).toBeNull();
+  });
+
+  it('should keep the version picker usable so a bad version can be swapped', () => {
+    // The version picker mounts its own hook tree. The file-level auto-mock
+    // returns undefined for each one, so give them values here.
+    vi.mocked(useLanguages).mockReturnValue({
+      languages: { data: [] as Language[], next_page_token: null },
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    vi.mocked(useLanguage).mockReturnValue({
+      language: { id: 'en', language: 'English', display_names: { en: 'English' } } as Language,
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    vi.mocked(useVersions).mockReturnValue({
+      versions: { data: [], next_page_token: null },
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    vi.mocked(useFilteredVersions).mockReturnValue([]);
+    vi.mocked(useOrganizations).mockReturnValue({ organizations: new Map() });
+
+    const { container } = render(
+      <BibleCard reference="JHN.3.16" versionId={3034} showVersionPicker />,
+    );
+
+    const picker = within(container).getByRole('button', { name: /change bible version/i });
+
+    expect(picker).toBeInTheDocument();
+    expect(picker).toBeEnabled();
+    expect(picker).toHaveTextContent('BSB');
   });
 });
 

--- a/packages/ui/src/components/bible-card.test.tsx
+++ b/packages/ui/src/components/bible-card.test.tsx
@@ -8,7 +8,6 @@ import { BibleCard } from './bible-card';
 import type { FootnoteData } from './verse';
 import { usePassage, useTheme, useVersion } from '@youversion/platform-react-hooks';
 import type { BiblePassage, BibleVersion } from '@youversion/platform-core';
-import { createBibleTextError as createError } from '../test/errors';
 
 vi.mock('@youversion/platform-react-hooks');
 
@@ -169,7 +168,7 @@ describe('BibleCard - Error state', () => {
     vi.mocked(usePassage).mockReturnValue({
       passage: null,
       loading: false,
-      error: createError('Request failed with status 503', 503),
+      error: Object.assign(new Error('Request failed with status 503'), { status: 503 }),
       refetch: vi.fn(),
     });
   });

--- a/packages/ui/src/components/bible-card.test.tsx
+++ b/packages/ui/src/components/bible-card.test.tsx
@@ -156,6 +156,55 @@ describe('BibleCard - Delayed spinner', () => {
   });
 });
 
+describe('BibleCard - Error state', () => {
+  function createError(message: string, status?: number): Error {
+    return Object.assign(new Error(message), status === undefined ? {} : { status });
+  }
+
+  beforeEach(() => {
+    vi.mocked(useTheme).mockReturnValue('light');
+    vi.mocked(useVersion).mockReturnValue({
+      version: mockVersion,
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    vi.mocked(usePassage).mockReturnValue({
+      passage: null,
+      loading: false,
+      error: createError('Request failed with status 503', 503),
+      refetch: vi.fn(),
+    });
+  });
+
+  it('should render exactly one alert region', () => {
+    const { container } = render(<BibleCard reference="JHN.3.16" versionId={3034} />);
+
+    expect(within(container).getAllByRole('alert')).toHaveLength(1);
+  });
+
+  it('should show the status message in that one alert region', () => {
+    const { container } = render(<BibleCard reference="JHN.3.16" versionId={3034} />);
+    const alert = within(container).getByRole('alert');
+
+    expect(alert).toHaveTextContent(
+      'The Bible service is having trouble right now. Please try again in a moment.',
+    );
+  });
+
+  it('should render the error heading in the header slot', () => {
+    const { container } = render(<BibleCard reference="JHN.3.16" versionId={3034} />);
+
+    expect(within(container).getByRole('heading', { level: 2 })).toHaveTextContent('Error');
+  });
+
+  it('should not render a loading spinner while an error is set', () => {
+    const { container } = render(<BibleCard reference="JHN.3.16" versionId={3034} />);
+
+    expect(within(container).queryByRole('status')).toBeNull();
+  });
+});
+
 describe('BibleCard - onFootnotePress callback', () => {
   const mockPassageWithFootnote: BiblePassage = {
     id: 'JHN.1',

--- a/packages/ui/src/components/bible-card.tsx
+++ b/packages/ui/src/components/bible-card.tsx
@@ -175,7 +175,11 @@ export function BibleCard({
             <LoaderIcon className="yv:size-3 yv:animate-spin yv:text-muted-foreground" />
           )}
 
-          {showVersionPicker && !passageError ? (
+          {/*
+            The picker stays available during an error. A 404 means the passage
+            is not in the selected version, so switching versions is the fix.
+          */}
+          {showVersionPicker ? (
             <BibleCardVersionPicker
               versionId={versionNum}
               onVersionChange={setVersionNum}

--- a/packages/ui/src/components/bible-card.tsx
+++ b/packages/ui/src/components/bible-card.tsx
@@ -26,14 +26,21 @@ export type BibleCardProps = {
   onFootnotePress?: (data: FootnoteData) => void;
 };
 
+/**
+ * The "Error" label for the header slot.
+ *
+ * It matches `BibleCardHeaderReference` exactly. The card already renders an
+ * `<h2>` in this slot for the passage reference, so this injects no new heading
+ * level into the host page's outline. It carries no `role="alert"` and no
+ * `aria-live`: the body block stays the single alert region, so screen readers
+ * announce one alert.
+ */
 function BibleCardHeaderError(): React.ReactNode {
   const { t } = useTranslation(undefined, { i18n });
   return (
-    <div className="yv:flex yv:flex-col yv:gap-2" role="alert" aria-live="polite">
-      <h2 className="yv:font-bold yv:tracking-widest yv:text-xs yv:uppercase yv:text-foreground">
-        {t('errorHeading')}
-      </h2>
-    </div>
+    <h2 className="yv:font-bold yv:tracking-widest yv:text-xs yv:uppercase yv:text-foreground">
+      {t('errorHeading')}
+    </h2>
   );
 }
 
@@ -151,6 +158,10 @@ export function BibleCard({
     >
       <div className="yv:card-content">
         <div className="yv:flex yv:w-full yv:justify-between yv:items-center yv:mb-4">
+          {/*
+            The error branch stays separate rather than folding into the loading
+            branch, which would spin forever on error.
+          */}
           {passage && !passageError ? (
             <div className="yv:grow yv:flex yv:items-center yv:gap-1.5">
               <BibleCardHeaderReference passage={passage} version={version} />

--- a/packages/ui/src/components/verse.test.tsx
+++ b/packages/ui/src/components/verse.test.tsx
@@ -7,7 +7,6 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Verse, BibleTextView, type BibleTextViewPassageState, type FootnoteData } from './verse';
-import { createBibleTextError as createError } from '../test/errors';
 
 // BibleTextView always calls usePassage/useTheme internally (even when passageState
 // is provided), so we must mock the hooks to avoid requiring YouVersionProvider.
@@ -885,6 +884,10 @@ describe('BibleTextView - Refetch loading behavior', () => {
 
 describe('BibleTextView - Error messaging', () => {
   const originalNavigator = globalThis.navigator;
+
+  function createError(message: string, status?: number): Error {
+    return Object.assign(new Error(message), status === undefined ? {} : { status });
+  }
 
   afterEach(() => {
     Object.defineProperty(globalThis, 'navigator', {

--- a/packages/ui/src/components/verse.test.tsx
+++ b/packages/ui/src/components/verse.test.tsx
@@ -1044,6 +1044,34 @@ describe('BibleTextView - Error messaging', () => {
     });
   });
 
+  it('should render one alert region with a hidden icon and no heading line', async () => {
+    const { getAllByRole, getByRole } = render(
+      <BibleTextView
+        reference="JHN.3.16"
+        versionId={3034}
+        passageState={{
+          passage: null,
+          loading: false,
+          error: createError('Request failed with status 503', 503),
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getByRole('alert')).toHaveTextContent(
+        'The Bible service is having trouble right now. Please try again in a moment.',
+      );
+    });
+
+    const alert = getByRole('alert');
+
+    expect(getAllByRole('alert')).toHaveLength(1);
+    expect(alert).not.toHaveAttribute('aria-live');
+    expect(alert.querySelector('svg')).toHaveAttribute('aria-hidden', 'true');
+    // Standalone BibleTextView has no header slot, so no "Error" label renders.
+    expect(alert).not.toHaveTextContent('Error');
+  });
+
   it('should prioritize 5xx errors over "not found" text in the message', async () => {
     const { getByRole } = render(
       <BibleTextView

--- a/packages/ui/src/components/verse.test.tsx
+++ b/packages/ui/src/components/verse.test.tsx
@@ -7,6 +7,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Verse, BibleTextView, type BibleTextViewPassageState, type FootnoteData } from './verse';
+import { createBibleTextError as createError } from '../test/errors';
 
 // BibleTextView always calls usePassage/useTheme internally (even when passageState
 // is provided), so we must mock the hooks to avoid requiring YouVersionProvider.
@@ -885,10 +886,6 @@ describe('BibleTextView - Refetch loading behavior', () => {
 describe('BibleTextView - Error messaging', () => {
   const originalNavigator = globalThis.navigator;
 
-  function createError(message: string, status?: number): Error {
-    return Object.assign(new Error(message), status === undefined ? {} : { status });
-  }
-
   afterEach(() => {
     Object.defineProperty(globalThis, 'navigator', {
       configurable: true,
@@ -1044,7 +1041,7 @@ describe('BibleTextView - Error messaging', () => {
     });
   });
 
-  it('should render one alert region with a hidden icon and no heading line', async () => {
+  it('should render one polite alert region with a hidden icon and no heading line', async () => {
     const { getAllByRole, getByRole } = render(
       <BibleTextView
         reference="JHN.3.16"
@@ -1066,7 +1063,9 @@ describe('BibleTextView - Error messaging', () => {
     const alert = getByRole('alert');
 
     expect(getAllByRole('alert')).toHaveLength(1);
-    expect(alert).not.toHaveAttribute('aria-live');
+    // role="alert" implies assertive, so this attribute is what keeps the
+    // announcement polite. Removing it would be a behavior change.
+    expect(alert).toHaveAttribute('aria-live', 'polite');
     expect(alert.querySelector('svg')).toHaveAttribute('aria-hidden', 'true');
     // Standalone BibleTextView has no header slot, so no "Error" label renders.
     expect(alert).not.toHaveTextContent('Error');

--- a/packages/ui/src/components/verse.tsx
+++ b/packages/ui/src/components/verse.tsx
@@ -251,17 +251,20 @@ const VerseFootnoteButton = memo(function VerseFootnoteButton({
 });
 
 /**
- * Displays a verse-unavailable error message with a circular exclamation
- * icon and descriptive text.
+ * Displays a verse-unavailable error message as one alert region: a circular
+ * exclamation icon and the status-aware message.
+ *
+ * The "Error" label lives in the BibleCard header slot, not here, so this block
+ * stays a single sentence. `role="alert"` already implies an assertive live
+ * region, so no `aria-live` is set, and the icon is hidden from screen readers.
  */
 function VerseUnavailableMessage({ message }: { message: string }): React.ReactElement {
   return (
     <div
       role="alert"
-      aria-live="polite"
       className="yv:flex yv:items-center yv:justify-center yv:gap-2.5 yv:px-3 yv:py-2.5 yv:text-foreground"
     >
-      <ExclamationCircle className="yv:size-5 yv:shrink-0 yv:text-foreground" />
+      <ExclamationCircle className="yv:size-5 yv:shrink-0 yv:text-foreground" aria-hidden="true" />
       <p className="yv:m-0 yv:text-[13px] yv:font-medium yv:leading-tight">{message}</p>
     </div>
   );

--- a/packages/ui/src/components/verse.tsx
+++ b/packages/ui/src/components/verse.tsx
@@ -255,13 +255,19 @@ const VerseFootnoteButton = memo(function VerseFootnoteButton({
  * exclamation icon and the status-aware message.
  *
  * The "Error" label lives in the BibleCard header slot, not here, so this block
- * stays a single sentence. `role="alert"` already implies an assertive live
- * region, so no `aria-live` is set, and the icon is hidden from screen readers.
+ * stays a single sentence.
+ *
+ * `role="alert"` implies `aria-live="assertive"`, so the explicit
+ * `aria-live="polite"` is not redundant: it holds the announcement down to
+ * polite. Keep it. `VerseOfTheDay` renders this block on page load, and an
+ * assertive announcement would interrupt whatever the screen reader is saying.
+ * The icon is decorative, so it is hidden from screen readers.
  */
 function VerseUnavailableMessage({ message }: { message: string }): React.ReactElement {
   return (
     <div
       role="alert"
+      aria-live="polite"
       className="yv:flex yv:items-center yv:justify-center yv:gap-2.5 yv:px-3 yv:py-2.5 yv:text-foreground"
     >
       <ExclamationCircle className="yv:size-5 yv:shrink-0 yv:text-foreground" aria-hidden="true" />

--- a/packages/ui/src/test/errors.ts
+++ b/packages/ui/src/test/errors.ts
@@ -1,8 +1,0 @@
-/**
- * Builds the shape that `getBibleTextErrorMessage` reads: an `Error` with an
- * optional numeric `status`. Shared by `verse.test.tsx` and
- * `bible-card.test.tsx` so the two files cannot drift.
- */
-export function createBibleTextError(message: string, status?: number): Error {
-  return Object.assign(new Error(message), status === undefined ? {} : { status });
-}

--- a/packages/ui/src/test/errors.ts
+++ b/packages/ui/src/test/errors.ts
@@ -1,0 +1,8 @@
+/**
+ * Builds the shape that `getBibleTextErrorMessage` reads: an `Error` with an
+ * optional numeric `status`. Shared by `verse.test.tsx` and
+ * `bible-card.test.tsx` so the two files cannot drift.
+ */
+export function createBibleTextError(message: string, status?: number): Error {
+  return Object.assign(new Error(message), status === undefined ? {} : { status });
+}


### PR DESCRIPTION
[YPE-2360](https://lifechurch.atlassian.net/browse/YPE-2360) | [Artifacts](https://cloud.humanlayer.com/tasks/019fd33b-12c6-7175-a3ba-88a05aa2ae96/artifacts) | [Task](https://cloud.humanlayer.com/deep/tasks/019fd33b-12c6-7175-a3ba-88a05aa2ae96)

## What problems was I solving

The `BibleCard` component shows an error state when a Bible passage does not load. This error state had two faults. 

**Fault 1. A screen reader announced two alerts for one failure.**

The card showed two separate regions with `role="alert"`. The first region was the word "ERROR" in the header slot. The second region was an icon plus a sentence that explains the error. Both regions were live regions. A screen reader therefore announced the word "Error" first, and then announced the sentence as a second alert.

**Fault 2. An error was a dead end.**

The card hid the version picker when `passageError` was set. A 404 error means the passage is not in the selected Bible version. The fix is to select a different version. The card removed that control at the moment the reader needed it.

After this change, a failed request announces one alert. That alert carries the sentence that explains the error. The reader can also select a different version without leaving the card.

## What user-facing changes did I ship

- [packages/ui/src/components/bible-card.tsx](https://github.com/youversion/platform-sdk-react/pull/321/files#diff-506f3c33aef2f8facad99741d19d40d9816ee354ed2662981bf2e61449f67f03) - The word "ERROR" keeps its position and its style. It loses `role="alert"` and `aria-live`, so a screen reader no longer announces it as a second alert. The version picker now shows during an error.
- [packages/ui/src/components/verse.tsx](https://github.com/youversion/platform-sdk-react/pull/321/files#diff-8e04cc5cbe013338272cbb26b436c9a1e0e4f5b9ff8ddbb05e355b50eae9e2bf) - The icon now has `aria-hidden`, so a screen reader skips it. The block keeps `role="alert"` and `aria-live="polite"`. Both attributes are load bearing, and the section below explains why.

`VerseOfTheDay` and standalone `BibleTextView` show the same message block. Both components get the icon fix. Their announcement stays polite and their visible text does not change. Neither component gets an "ERROR" label, because that label belongs to the `BibleCard` header slot.

This change adds no new i18n keys. The eight status-aware messages, their six locales, and the code that derives errors are all unchanged. This PR does not rewrite the error copy. See "Scope: the copy work is a separate ticket" below.

## How I implemented it

### One alert region

In [bible-card.tsx](https://github.com/youversion/platform-sdk-react/pull/321/files#diff-506f3c33aef2f8facad99741d19d40d9816ee354ed2662981bf2e61449f67f03), `BibleCardHeaderError` was a `div` with `role="alert"` and `aria-live="polite"` around one `<h2>`. It is now the `<h2>` alone. The `div` held no classes that changed the layout, so the card looks the same.

The `<h2>` uses the same classes as `BibleCardHeaderReference`. This reuse is deliberate. The card already puts an `<h2>` in that slot for the passage reference. The error label therefore adds no new heading level to the outline of the host page.

In [verse.tsx](https://github.com/youversion/platform-sdk-react/pull/321/files#diff-8e04cc5cbe013338272cbb26b436c9a1e0e4f5b9ff8ddbb05e355b50eae9e2bf), `VerseUnavailableMessage` keeps `role="alert"` and becomes the only alert region. It marks its icon `aria-hidden`. It also keeps `aria-live="polite"`.

That `aria-live="polite"` is not redundant. In WAI-ARIA, `role="alert"` carries an implicit `aria-live="assertive"`. An explicit `aria-live="polite"` on the same element overrides the implicit value downward. Deleting the attribute would therefore make the announcement assertive, which is a behavior change and not a cleanup. `VerseOfTheDay` renders this block on page load, and an assertive announcement would interrupt whatever the screen reader is already saying. An earlier commit on this branch deleted the attribute; review caught it and it is restored.

The header ternary keeps three branches instead of two. Two branches would fall through to the loading spinner during an error. The spinner would then turn forever.

### The version picker during an error

In [bible-card.tsx](https://github.com/youversion/platform-sdk-react/pull/321/files#diff-506f3c33aef2f8facad99741d19d40d9816ee354ed2662981bf2e61449f67f03), the condition changed from `showVersionPicker && !passageError` to `showVersionPicker`. This is the whole source change. The picker reads `versionNum` and not the passage, so it works while `passageError` is set.

The header row needs no layout change. The word "ERROR" still sits on the left and the picker on the right. The class `yv:justify-between` is still correct.

### Tests and the Storybook story

[bible-card.test.tsx](https://github.com/youversion/platform-sdk-react/pull/321/files#diff-b17426d490b9d6c31e48fa1932908584a3ace57d98d43e0979c226cafca95501) gets a new `BibleCard - Error state` block with four tests:

- Exactly one `role="alert"` region shows.
- That region carries the 503 sentence.
- The header shows an `<h2>` that reads "Error".
- No `role="status"` spinner shows during an error.

The version picker is covered by the `Error` story instead of by a fifth jsdom test. That jsdom test would have to hand-mock the five hooks that `BibleVersionPicker.Root` reads: `useLanguages`, `useLanguage`, `useVersions`, `useFilteredVersions`, and `useOrganizations`. Those mocks couple this file to the internals of a component it does not test. `packages/ui/CLAUDE.md` also says to prefer Storybook for UI component tests.

[verse.test.tsx](https://github.com/youversion/platform-sdk-react/pull/321/files#diff-fd631f9f3bbee3060da9f36971ff9e2e8848b0d911fa1e5851dd6e40c3c52958) gets one test. One alert region shows. That region carries `aria-live="polite"`. The icon has `aria-hidden`. The alert holds no "Error" text, because a standalone `BibleTextView` has no header slot.

Each test file builds its own error objects. `verse.test.tsx` keeps a local three-line `createError` and calls it nine times. `bible-card.test.tsx` needs one error object, so it writes that `Object.assign` inline.

[bible-card.stories.tsx](https://github.com/youversion/platform-sdk-react/pull/321/files#diff-478d8a8451a958841c5ebeabb8b64f929f420feb3721ec8a118f035d71027462) gets `showVersionPicker: true` on the `Error` story. Its `play` function asserts one alert region, `aria-live="polite"` on that region, and an enabled picker. It then walks the whole recovery path: open the picker, search for the Amplified Bible, select it, and assert that the alert clears and the passage renders.

That story also spreads `globalHandlers` back into its own `msw.handlers` array. A story-level `handlers` array replaces the preview-level array instead of merging with it. Without the spread, the picker's `useLanguages` and `useVersions` calls fell through to the live API, silently, because `onUnhandledRequest` is `'warn'`. The 500 override is listed first, because MSW takes the first matching handler. Version 1588 (AMP) stays on `globalHandlers` and still resolves, which is what makes the recovery path testable.

[.changeset/biblecard-single-error-alert.md](https://github.com/youversion/platform-sdk-react/pull/321/files#diff-ccb6db3c9a04ed4721e8feccd2f16d92256dff2223a443ec334e1db60f89cbb1) is a patch that names `@youversion/platform-react-ui`.

## Deviations from the plan

The plan artifact is a structure outline, not a plan file. It changed twice during the work, so it already describes the final direction. The code and the outline now agree on every phase.

### Implemented as planned

- `VerseUnavailableMessage` keeps `role="alert"` and marks its icon `aria-hidden`. It also keeps `aria-live="polite"`, which is a correction to the outline. See "Review feedback" below.
- `BibleCardHeaderError` is now a bare `<h2>` with the classes of `BibleCardHeaderReference`.
- The header ternary keeps three branches.
- The version picker condition loses `&& !passageError`.
- The tests and the story cover every case that the outline listed.
- No new i18n keys. The `errorHeading` key comes from the existing locale files.

### Deviations and surprises

1. The outline said that the story must test that the picker shows and is enabled. The story also tests that the button text matches `/NIV/i`. This test is stricter than the outline, and it does not conflict with it.
2. The changeset names one package. The outline asked for three. `.changeset/config.json` already puts the three packages in a `fixed` group, so a changeset that names `platform-react-ui` alone still bumps all three. `pnpm changeset status` shows this result. A changeset that names all three would also copy this UI-only text into `packages/core/CHANGELOG.md` and `packages/hooks/CHANGELOG.md`. The three most recent UI fixes on `main` (`b592e72`, `9c2e8e4`, `9a2b3e9`) each name only the package that changed. The outline records this deviation in its Phase 3 section.

### Scope: the copy work is a separate ticket

YPE-2360 asks for two things. It asks for clear error text, and it asks for a review of that text against Figma. This PR delivers neither. It fixes the alert semantics and the recovery path instead, and it changes no strings.

This split is deliberate, for two reasons.

1. The two jobs have different reviewers. The a11y and recovery fix is an engineering review. New copy needs a design and content review against the Figma web error states, and it lands in six locale files.
2. The a11y fix is already correct and tested. Holding it behind a copy review would keep a real double-announcement bug in `main`.

Two claims in the ticket are already true in the code on `main`, before this PR. The message block uses `yv:text-foreground`, not a red destructive token, so the state is not styled as an alarm. The library also already picks from eight status-aware messages in `packages/ui/src/lib/bible-text-error.ts`, so a 404 and a 503 do not read the same. What is still open is whether those eight strings are the right strings.

The follow-up ticket for the copy work is [YPE-4856](https://lifechurch.atlassian.net/browse/YPE-4856). It is linked to YPE-2360.

### Review feedback

Commit `9ba2dc2` responds to the review on this PR. Four changes:

1. **`aria-live="polite"` is restored on `VerseUnavailableMessage`.** The earlier commit removed it as redundant. It is not redundant, because `role="alert"` implies `aria-live="assertive"`. The removal would have moved `VerseOfTheDay` and standalone `BibleTextView` from a polite announcement to an assertive one. The changeset, the doc comment, and this body all now say the same thing.
2. **The `Error` story spreads `globalHandlers` back into its `msw.handlers` array.** Mounting the picker under the old array sent the languages and versions requests to the live API.
3. **The `Error` story's `play` function walks the recovery path end to end.** It switches to a version whose passage resolves and asserts that the alert clears. Before this, the story asserted only that the picker was enabled, which is a weaker claim than the one the PR makes.
4. **`createError` moved into `packages/ui/src/test/errors.ts`.** Two test files declared the same helper. **Commit `d2abe0d` reverses this one.** Outside `verse.test.tsx` the shared module had exactly one caller, so it was an abstraction ahead of a second real consumer. `verse.test.tsx` keeps the local helper it started with. `bible-card.test.tsx` inlines its single call. The file is deleted.

### Additions that are not in the plan

Doc comments above `BibleCardHeaderError`, the header ternary, the version picker condition, and `VerseUnavailableMessage`. They put the reasoning of the outline into the source. They change no behavior.

### Items that were planned but not implemented

The jsdom test for the version picker during an error. The `Error` story covers that behavior, and it covers it better, because the story renders the real picker instead of five mocked hooks.

### How the outline changed during the work

The outline changed shape twice. This history matters only if you read the artifacts next to the diff.

1. The design discussion decided to remove the header label completely.
2. A later outline revision put the word "Error" back, but inside the message block, above the sentence.
3. On 2026-08-07, Cam reviewed the result in Storybook and reversed that decision. The label stays in the header slot. Only its alert semantics change. The code does this.

That reversal made two planned Phase 2 changes unnecessary. Both changes assumed an empty header slot. The header slot always has a child during an error. The `justify-end` change and the empty-row check therefore left the outline before Phase 2 started.

## How to verify it

Run these commands first:

```bash
git fetch origin ype-2360-react-biblecard-error-state-needs-better-text
git checkout ype-2360-react-biblecard-error-state-needs-better-text
pnpm install
pnpm --filter @youversion/platform-core --filter @youversion/platform-react-hooks build
pnpm --filter @youversion/platform-react-ui storybook
```

### Manual tests

- [ ] Open **Components/BibleCard → Error**. Make sure that "ERROR" is in the header slot, above one block with the icon and the sentence.
- [ ] Set the Storybook theme global to dark. Make sure that the story still reads correctly.
- [ ] Start VoiceOver. Make sure that it announces one alert, and that this alert is the sentence.
- [ ] Open **Components/VerseOfTheDay** with VoiceOver running. Make sure that the error announcement waits its turn instead of interrupting.
- [ ] In the **Error** story, open the version picker and select a different version.
- [ ] Make sure that the card recovers when the new version returns the passage.
- [ ] Open **Components/VerseOfTheDay** and **Components/BibleTextView**. Both show the icon and the sentence, with no label.

### Automated tests

```bash
pnpm typecheck
pnpm lint
pnpm test
pnpm --filter @youversion/platform-react-ui test:integration
```

If you use a fresh worktree, do these two steps before you run the commands above:

1. Copy `packages/core/.env.example` to `packages/core/.env.local`. Without this file, `YVP_API_HOST` is empty and all 16 core suites fail to collect. The core tests use MSW mocks, so placeholder values are enough. CI supplies both values as secrets.
2. Run `pnpm --filter @youversion/platform-react-ui build:css`. Without `dist/tailwind.css`, two `WideContainer` stories fail on the missing `yv:card-content` cap. This failure is not related to this branch.

Results on this branch, at commit `9ba2dc2`: `pnpm test` passes 1064 tests (core 369, hooks 289, ui 406). `test:integration` passes 451 tests across 39 files. `pnpm typecheck` and `pnpm lint` both pass. Each count is one lower than the count before the review, which is the one removed jsdom picker test.

## Description for the changelog

Fix the `BibleCard` error state that announced two alerts instead of one, and keep the version picker usable during an error.

[YPE-2360]: https://lifechurch.atlassian.net/browse/YPE-2360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[YPE-4856]: https://lifechurch.atlassian.net/browse/YPE-4856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR consolidates BibleCard failures into one polite alert while preserving the separate visual error heading and exposing the version picker as an in-card recovery path.
- Removes live-region semantics from the BibleCard error heading.
- Hides the decorative error icon from assistive technology.
- Keeps the version picker available during passage errors.
- Adds unit and Storybook coverage for alert semantics and version-switch recovery.
- Adds a patch changeset for the UI package.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/bible-card.tsx | Separates the visual error heading from the sole live alert and keeps the controlled version picker rendered during passage failures. |
| packages/ui/src/components/verse.tsx | Preserves the polite alert behavior and removes the decorative icon from the accessibility tree. |
| packages/ui/src/components/bible-card.stories.tsx | Restores global MSW handlers and verifies the complete transition from a failed NIV passage to a successful AMP passage. |
| packages/ui/src/components/bible-card.test.tsx | Adds focused coverage for one alert, the separate error heading, status-aware copy, and absence of an error-state spinner. |
| packages/ui/src/components/verse.test.tsx | Verifies the shared unavailable-message block remains one polite alert with a hidden icon. |
| .changeset/biblecard-single-error-alert.md | Records the user-facing accessibility and recovery fixes as a UI package patch. |

<sub>Reviews (4): Last reviewed commit: ["chore: re-trigger the storybook test run"](https://github.com/youversion/platform-sdk-react/commit/e719bbce4903fdb6845d655aa3d49f13fe84cd24) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51241657)</sub>

**Context used:**

- Knowledge Base — [packages/ui](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/ui-package.md)

<!-- /greptile_comment -->