### PR TITLE
fix(core,hooks,ui): make a failed Bible text load recoverable and cut cold-load fanout

### DIFF
--- a/.changeset/bible-reader-initial-load-resilience.md
+++ b/.changeset/bible-reader-initial-load-resilience.md
@@ -1,0 +1,41 @@
+---
+'@youversion/platform-core': minor
+'@youversion/platform-react-hooks': minor
+'@youversion/platform-react-ui': minor
+---
+
+Make a failed Bible text load recoverable instead of terminal, and cut the
+cold-load request fanout.
+
+A first-load network failure used to leave the Bible Reader, Verse of the Day,
+and Bible Card on a permanent "The Bible server couldn't be reached" message.
+Nothing retried, and there was no button to press. Four changes fix that.
+
+**Automatic retry.** `useApiData` now retries a failed request on its own, so
+most transient failures never reach the user. It retries a timeout, a transport
+failure, a 429, and a 5xx. It does not retry a 401, a 403, a 404, or a Zod
+validation error. The budget is at most 2 extra attempts and a fixed 20-second
+wall clock, whichever runs out first, with jittered backoff. `loading` stays
+`true` for the whole chain, so the reader spinner does not flicker between
+attempts. Pass `retry: false` to `useApiData` to restore single-shot behavior.
+
+**A "Try again" button.** When automatic retry does not recover, the error
+message now renders a retry button. The button appears only for failures a retry
+can fix. A 401, 403, or 404 stays a plain final message. `packages/ui` exports
+`isRetryableBibleTextError` for the same classification.
+
+**Fewer requests on mount.** `ApiClient.get` now shares one in-flight request
+between concurrent callers asking for the same URL and headers. The entry is
+dropped when the request settles, so this is in-flight sharing, not a response
+cache. `post` and `delete` are unchanged. `YouVersionProvider` now builds the one
+`ApiClient` its tree shares, which is what makes that sharing reach sibling
+components. Separately, `BibleVersionPicker` waits until its popover opens before
+it loads the language and version lists. A cold `BibleReader` mount now issues 3
+API requests, down from 18, measured against a production build of
+`examples/vite-react`. The 15 it drops are 3 duplicate version and book fetches,
+2 language lists, 2 version lists, and 8 publisher lookups the version list
+triggered.
+
+**A configurable request timeout.** `YouVersionProvider` accepts a `timeout`
+prop in milliseconds. The default is still 10000, so no existing integrator sees
+a change.

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -46,6 +46,25 @@ See `docs/adding-a-core-endpoint.md`.
 - `YouVersionAPI` is a separate static header helper, not a base client. Do not
   build a new client on it.
 
+### In-flight GET deduplication
+
+`ApiClient.get` shares one request between concurrent callers. A second `get`
+for a key already in flight receives the promise the first caller is waiting on.
+The key is the built URL plus the per-call headers, lowercased and sorted, so two
+users with different Bearer tokens never share a promise.
+
+- `post` and `delete` are **not** deduplicated. Only GET is idempotent.
+- The map entry is deleted when the promise settles. This shares concurrency; it
+  never caches a result. A GET issued after the first settles sends a new
+  request.
+- A shared rejection reaches every caller. Siblings fail together rather than
+  independently. That is an accepted consequence, pinned by a test.
+- The map is a **private per-instance field, by design**. Sharing therefore
+  depends on callers holding one client. A module-level or static map was
+  rejected: it would share in-flight state across independently configured
+  clients and break test isolation. In React, `YouVersionProvider` owns the one
+  client; see `packages/hooks/AGENTS.md`.
+
 ## CONVENTIONS
 - Schema-first: All types defined in schemas/*.ts using Zod
 - Zero React: Pure TypeScript, no React dependencies

--- a/packages/core/src/__tests__/client.test.ts
+++ b/packages/core/src/__tests__/client.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, beforeEach, beforeAll, afterEach, afterAll } from 'vitest';
+import { describe, it, expect, beforeEach, beforeAll, afterEach, afterAll, vi } from 'vitest';
 import { ApiClient, getHttpStatus } from '../client';
-import { http, HttpResponse } from 'msw';
+import { delay, http, HttpResponse } from 'msw';
 import { server } from './setup';
 
 // We always want this test to hit msw since this is only testing
@@ -125,6 +125,214 @@ describe('ApiClient', () => {
       });
 
       expect(result).toEqual({ params: ['one', 'two'] });
+    });
+  });
+
+  describe('in-flight GET deduplication', () => {
+    it('should issue one request when two GETs for the same URL overlap', async () => {
+      let requestCount = 0;
+      server.use(
+        http.get('https://test_placeholder.youversion.com/books', async () => {
+          requestCount += 1;
+          await delay(20);
+          return HttpResponse.json({ message: 'shared' });
+        }),
+      );
+
+      const [first, second] = await Promise.all([
+        apiClient.get<{ message: string }>('/books'),
+        apiClient.get<{ message: string }>('/books'),
+      ]);
+
+      expect(requestCount).toBe(1);
+      expect(first).toEqual({ message: 'shared' });
+      expect(second).toEqual({ message: 'shared' });
+    });
+
+    it('should not share a request between two GETs with different query parameters', async () => {
+      let requestCount = 0;
+      server.use(
+        http.get('https://test_placeholder.youversion.com/books', async ({ request }) => {
+          requestCount += 1;
+          await delay(20);
+          const url = new URL(request.url);
+          return HttpResponse.json({ param: url.searchParams.get('param') });
+        }),
+      );
+
+      const [first, second] = await Promise.all([
+        apiClient.get<{ param: string }>('/books', { param: 'one' }),
+        apiClient.get<{ param: string }>('/books', { param: 'two' }),
+      ]);
+
+      expect(requestCount).toBe(2);
+      expect(first).toEqual({ param: 'one' });
+      expect(second).toEqual({ param: 'two' });
+    });
+
+    it('should not share a request between two GETs with different Authorization headers', async () => {
+      const seenTokens: (string | null)[] = [];
+      server.use(
+        http.get('https://test_placeholder.youversion.com/highlights', async ({ request }) => {
+          seenTokens.push(request.headers.get('authorization'));
+          await delay(20);
+          return HttpResponse.json({ token: request.headers.get('authorization') });
+        }),
+      );
+
+      const [first, second] = await Promise.all([
+        apiClient.get<{ token: string }>('/highlights', undefined, {
+          Authorization: 'Bearer user-a',
+        }),
+        apiClient.get<{ token: string }>('/highlights', undefined, {
+          Authorization: 'Bearer user-b',
+        }),
+      ]);
+
+      expect(seenTokens).toHaveLength(2);
+      expect(seenTokens).toContain('Bearer user-a');
+      expect(seenTokens).toContain('Bearer user-b');
+      expect(first).toEqual({ token: 'Bearer user-a' });
+      expect(second).toEqual({ token: 'Bearer user-b' });
+    });
+
+    it('should issue a second request for a GET made after the first one settled', async () => {
+      let requestCount = 0;
+      server.use(
+        http.get('https://test_placeholder.youversion.com/books', () => {
+          requestCount += 1;
+          return HttpResponse.json({ count: requestCount });
+        }),
+      );
+
+      // Sharing is in-flight only. Once the first promise settles its entry is
+      // gone, so a later GET hits the network again — this is not a cache.
+      const first = await apiClient.get<{ count: number }>('/books');
+      const second = await apiClient.get<{ count: number }>('/books');
+
+      expect(requestCount).toBe(2);
+      expect(first).toEqual({ count: 1 });
+      expect(second).toEqual({ count: 2 });
+    });
+
+    it('should share a rejection with every caller waiting on it', async () => {
+      let requestCount = 0;
+      server.use(
+        http.get('https://test_placeholder.youversion.com/books', async () => {
+          requestCount += 1;
+          await delay(20);
+          return HttpResponse.json({ message: 'nope' }, { status: 503 });
+        }),
+      );
+
+      const [first, second] = await Promise.allSettled([
+        apiClient.get('/books'),
+        apiClient.get('/books'),
+      ]);
+
+      expect(requestCount).toBe(1);
+      expect(first.status).toBe('rejected');
+      expect(second.status).toBe('rejected');
+      expect(getHttpStatus((first as PromiseRejectedResult).reason)).toBe(503);
+      expect(getHttpStatus((second as PromiseRejectedResult).reason)).toBe(503);
+    });
+
+    it('should not deduplicate POST requests', async () => {
+      let requestCount = 0;
+      server.use(
+        http.post('https://test_placeholder.youversion.com/highlights', async () => {
+          requestCount += 1;
+          await delay(20);
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+
+      await Promise.all([
+        apiClient.post('/highlights', { color: 'fffe00' }),
+        apiClient.post('/highlights', { color: 'fffe00' }),
+      ]);
+
+      expect(requestCount).toBe(2);
+    });
+  });
+
+  describe('request timeout', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should abort and reject when a dispatched request is never answered', async () => {
+      server.use(
+        http.get('https://test_placeholder.youversion.com/hangs', async () => {
+          await delay('infinite');
+          return HttpResponse.json({});
+        }),
+      );
+
+      vi.useFakeTimers();
+
+      // Capture the rejection before advancing so nothing is ever unhandled.
+      const settled = apiClient.get('/hangs').catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      const error = await settled;
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe('Request timeout after 10000ms');
+    });
+
+    it('should report the configured timeout rather than the default', async () => {
+      server.use(
+        http.get('https://test_placeholder.youversion.com/hangs', async () => {
+          await delay('infinite');
+          return HttpResponse.json({});
+        }),
+      );
+
+      const client = new ApiClient({
+        apiHost: 'test_placeholder.youversion.com',
+        appKey: 'test-app',
+        timeout: 2000,
+      });
+
+      vi.useFakeTimers();
+
+      const settled = client.get('/hangs').catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(2000);
+
+      const error = await settled;
+      expect((error as Error).message).toBe('Request timeout after 2000ms');
+    });
+
+    it('should keep the request pending until the timeout elapses', async () => {
+      server.use(
+        http.get('https://test_placeholder.youversion.com/hangs', async () => {
+          await delay('infinite');
+          return HttpResponse.json({});
+        }),
+      );
+
+      const client = new ApiClient({
+        apiHost: 'test_placeholder.youversion.com',
+        appKey: 'test-app',
+        timeout: 2000,
+      });
+
+      vi.useFakeTimers();
+
+      let settled = false;
+      const pending = client.get('/hangs').catch((error: unknown) => {
+        settled = true;
+        return error;
+      });
+
+      await vi.advanceTimersByTimeAsync(1999);
+      expect(settled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await pending;
+      expect(settled).toBe(true);
     });
   });
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -35,6 +35,13 @@ export class ApiClient {
   public config: ApiConfig;
 
   /**
+   * GET requests currently in flight, keyed by URL plus the per-call headers.
+   * An entry is removed as soon as its promise settles, so this shares
+   * concurrency and never caches a result.
+   */
+  private inFlight = new Map<string, Promise<unknown>>();
+
+  /**
    * Creates an instance of ApiClient.
    *
    * @param config - The API configuration object containing baseUrl, timeout, and appKey.
@@ -153,19 +160,60 @@ export class ApiClient {
   }
 
   /**
+   * Builds the deduplication key for a GET request.
+   *
+   * The per-call headers are part of the key, not just the URL. Highlights GETs
+   * carry a Bearer token, and two different users must never share one promise.
+   * Header names are lowercased and sorted so two semantically identical header
+   * objects produce one key.
+   */
+  private dedupeKey(url: string, headers?: RequestHeaders): string {
+    if (!headers) return url;
+
+    const entries = Object.entries(headers)
+      .map(([name, value]): [string, string] => [name.toLowerCase(), value])
+      .sort(([a], [b]) => a.localeCompare(b));
+
+    if (entries.length === 0) return url;
+
+    return `${url}\u0000${JSON.stringify(entries)}`;
+  }
+
+  /**
    * Sends a GET request to the specified API path with optional query parameters.
+   *
+   * Concurrent GETs for the same URL and headers share a single request: the
+   * second caller receives the promise the first one is already waiting on. The
+   * entry is dropped when that promise settles, so a later GET issues a fresh
+   * request — this is in-flight sharing, not a response cache. One consequence
+   * to be aware of: a shared rejection reaches every caller, so siblings fail
+   * together rather than independently.
+   *
+   * `post` and `delete` are deliberately not deduplicated. Only GET is
+   * idempotent.
    *
    * @typeParam T - The expected response type.
    * @param path - The API endpoint path (relative to baseURL).
    * @param params - Optional query parameters to include in the request.
+   * @param headers - Optional headers merged over the default headers.
    * @returns A promise resolving to the response data of type T.
    */
   async get<T>(path: string, params?: QueryParams, headers?: RequestHeaders): Promise<T> {
     const url = `${this.baseURL}${path}${this.buildQueryString(params)}`;
-    return this.request<T>(url, {
+    const key = this.dedupeKey(url, headers);
+
+    const existing = this.inFlight.get(key);
+    if (existing) return existing as Promise<T>;
+
+    const promise = this.request<T>(url, {
       method: 'GET',
       headers,
+    }).finally(() => {
+      this.inFlight.delete(key);
     });
+
+    this.inFlight.set(key, promise);
+    return promise;
   }
 
   /**

--- a/packages/hooks/AGENTS.md
+++ b/packages/hooks/AGENTS.md
@@ -17,6 +17,9 @@ providers and contexts in `src/context/`, helpers in `src/utility/`.
 - **YouVersionProvider**
   - Holds core SDK configuration (API base URL, clients)
   - Wrap this around your app before using any data hooks
+  - Optional `timeout` prop, in milliseconds, sets the per-request timeout on
+    `ApiClient`. It defaults to 10000. A request that passes it rejects with
+    `Request timeout after {timeout}ms`.
 
 - **YouVersionAuthProvider**
   - Manages authentication state (userInfo, tokens, isLoading, error)
@@ -37,8 +40,53 @@ providers and contexts in `src/context/`, helpers in `src/utility/`.
 
 Hooks use a custom React Query-like pattern via `useApiData`:
 - Returns `{ data, loading, error, refetch }`
-- Provides caching and refetch capability
+- Holds no response cache. Concurrent GETs for the same URL share one request in
+  core; see `packages/core/AGENTS.md`.
 - New hooks should follow this same pattern
+
+### Automatic retry
+
+`useApiData` retries a failed request on its own. The policy lives in
+`src/internal/retry-policy.ts`.
+
+- Retries a timeout, a transport failure, a 429, and a 5xx.
+- Does not retry a 401, a 403, a 404, or a `ZodError`.
+- Budget: at most `DEFAULT_MAX_RETRIES` (2) extra attempts **and** a
+  `DEFAULT_RETRY_BUDGET_MS` (20 seconds) wall clock, whichever runs out first.
+- Backoff is jittered (`Math.random() * base`, base 500 then 1500), so a fanout
+  of siblings that failed together does not retry in lockstep.
+- `loading` stays `true` for the whole chain. It settles on success or on final
+  failure only. Do not add a `.finally()` that settles it per attempt, or the
+  two-tier reader spinner flickers.
+- Every attempt re-checks the `requestSeqRef` ticket before it writes state, and
+  again inside the backoff timer. A chapter change or an unmount mid-backoff
+  cancels the chain.
+- `retry: false` restores single-shot behavior for a poll or a
+  fire-and-forget read.
+
+The 20-second budget is **fixed on purpose**. It is not derived from the
+provider `timeout`. An integrator who sets `timeout` at or above 20000 gets
+single-shot behavior, which is what the SDK did before retry existed, so nothing
+regresses. Do not couple the two values.
+
+### One `ApiClient` per `YouVersionProvider`
+
+`YouVersionProvider` builds the single `ApiClient` for its tree and puts it on
+the context. `useApiClient` reads it from there. **Never build the `ApiClient`
+inside `useApiClient` or inside a data hook.**
+
+The reason: `ApiClient` deduplicates concurrent GETs through a `Map` that is a
+private per-instance field. A `useMemo` inside `useApiClient` runs per hook
+instance, so every component calling `useBooks` gets its own client, its own map,
+and no sharing. That defect shipped once and is easy to reintroduce, because the
+core tests pass either way — they exercise one client instance directly, which is
+the wrong altitude to see it. `src/internal/useApiClient.dedupe.test.tsx` is the
+regression guard: sibling hooks under one provider must produce one `fetch` call.
+
+One deliberate exception. `useApiClient` keeps a `useMemo` fallback that builds a
+per-hook client when the context carries none, because a consumer may render the
+exported `YouVersionContext.Provider` by hand. That path works but shares no
+in-flight requests. Removing it would be a breaking change.
 
 ## CONVENTIONS
 - Context and Provider in separate files

--- a/packages/hooks/AGENTS.md
+++ b/packages/hooks/AGENTS.md
@@ -51,8 +51,9 @@ Hooks use a custom React Query-like pattern via `useApiData`:
 
 - Retries a timeout, a transport failure, a 429, and a 5xx.
 - Does not retry a 401, a 403, a 404, or a `ZodError`.
-- Budget: at most `DEFAULT_MAX_RETRIES` (2) extra attempts **and** a
-  `DEFAULT_RETRY_BUDGET_MS` (20 seconds) wall clock, whichever runs out first.
+- Budget: at most `DEFAULT_MAX_RETRIES` (2) extra attempts **and** no new
+  attempt once `DEFAULT_RETRY_BUDGET_MS` (20 seconds) has elapsed, whichever
+  runs out first.
 - Backoff is jittered (`Math.random() * base`, base 500 then 1500), so a fanout
   of siblings that failed together does not retry in lockstep.
 - `loading` stays `true` for the whole chain. It settles on success or on final
@@ -67,7 +68,17 @@ Hooks use a custom React Query-like pattern via `useApiData`:
 The 20-second budget is **fixed on purpose**. It is not derived from the
 provider `timeout`. An integrator who sets `timeout` at or above 20000 gets
 single-shot behavior, which is what the SDK did before retry existed, so nothing
-regresses. Do not couple the two values.
+regresses. Do not couple the two values — deriving the budget from the timeout
+would also suppress the retry at the default 10000, which is the case the chain
+exists for.
+
+The budget gates the **start** of an attempt, not its completion. A request
+already in flight is never cut short, so a chain can finish after the budget:
+worst case `budget + one request timeout + one backoff`. A 15000 timeout can
+therefore hold `loading` true for roughly 30 seconds. Raising `timeout` above
+the default trades a longer worst-case spinner for more patience per request;
+that is the integrator's call, so the budget stays a start-gate rather than a
+hard deadline that would need an `AbortSignal` to enforce.
 
 ### One `ApiClient` per `YouVersionProvider`
 

--- a/packages/hooks/src/__tests__/mocks/core-mock-factory.ts
+++ b/packages/hooks/src/__tests__/mocks/core-mock-factory.ts
@@ -53,6 +53,21 @@ class MockYouVersionUserInfo {
   }
 }
 
+/**
+ * `YouVersionProvider` constructs one `ApiClient` and puts it on the context, so
+ * every core mock that replaces the whole module has to export a constructible
+ * `ApiClient` — otherwise any test rendering the provider dies with
+ * "ApiClient is not a constructor". These tests exercise auth, not HTTP, so the
+ * stub only needs to be `new`-able and to hold its config.
+ */
+class MockApiClient {
+  readonly config: Record<string, unknown>;
+
+  constructor(config: Record<string, unknown>) {
+    this.config = config;
+  }
+}
+
 class MockSignInWithYouVersionResult {
   readonly accessToken: string | undefined;
   readonly expiryDate: Date | undefined;
@@ -99,6 +114,7 @@ interface SimpleCoreMockFactory {
   SignInWithYouVersionPermission: Record<string, string>;
   YouVersionUserInfo: typeof MockYouVersionUserInfo;
   SignInWithYouVersionResult: typeof MockSignInWithYouVersionResult;
+  ApiClient: typeof MockApiClient;
 }
 
 interface GetterCoreMockFactory {
@@ -123,6 +139,7 @@ interface GetterCoreMockFactory {
   };
   YouVersionUserInfo: typeof MockYouVersionUserInfo;
   SignInWithYouVersionResult: typeof MockSignInWithYouVersionResult;
+  ApiClient: typeof MockApiClient;
 }
 
 export function createSimpleCoreMockFactory(): SimpleCoreMockFactory {
@@ -167,6 +184,7 @@ export function createSimpleCoreMockFactory(): SimpleCoreMockFactory {
     },
     YouVersionUserInfo: MockYouVersionUserInfo,
     SignInWithYouVersionResult: MockSignInWithYouVersionResult,
+    ApiClient: MockApiClient,
   };
 }
 
@@ -220,5 +238,6 @@ export function createGetterCoreMockFactory(): GetterCoreMockFactory {
     },
     YouVersionUserInfo: MockYouVersionUserInfo,
     SignInWithYouVersionResult: MockSignInWithYouVersionResult,
+    ApiClient: MockApiClient,
   };
 }

--- a/packages/hooks/src/__tests__/mocks/errors.ts
+++ b/packages/hooks/src/__tests__/mocks/errors.ts
@@ -1,0 +1,15 @@
+/**
+ * Builds an error `useApiData` will not retry.
+ *
+ * A bare `new Error(...)` carries no HTTP status, and the retry policy reads a
+ * missing status as a timeout or a transport failure — both worth another
+ * attempt. A hook test that asserts an error reaches the consumer wants a final
+ * failure, not a transient one, so it attaches a status the policy treats as
+ * terminal.
+ *
+ * The retry chain itself has its own coverage in `useApiData.test.tsx`, which
+ * is the one place the retry code lives.
+ */
+export function createFinalError(message: string, status = 404): Error & { status: number } {
+  return Object.assign(new Error(message), { status });
+}

--- a/packages/hooks/src/context/YouVersionContext.tsx
+++ b/packages/hooks/src/context/YouVersionContext.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { createContext } from 'react';
+import type { ApiClient } from '@youversion/platform-core';
 
 type YouVersionContextData = {
   appKey: string;
@@ -9,6 +10,24 @@ type YouVersionContextData = {
   theme?: 'light' | 'dark';
   authEnabled?: boolean;
   additionalHeaders?: Record<string, string>;
+  /**
+   * Per-request timeout in milliseconds, passed to `ApiClient`. Undefined keeps
+   * the client's own 10000 ms default.
+   */
+  timeout?: number;
+  /**
+   * The one `ApiClient` every hook under this provider shares.
+   *
+   * `ApiClient` deduplicates concurrent GETs through a private per-instance map,
+   * so sibling components only collapse their requests when they hold the *same*
+   * instance. `YouVersionProvider` builds it once and puts it here.
+   *
+   * Optional because this context is public API: a consumer may render
+   * `YouVersionContext.Provider` by hand. `useApiClient` falls back to building
+   * a per-hook client in that case, which still works but does not share
+   * in-flight requests between siblings.
+   */
+  apiClient?: ApiClient;
 };
 
 export const YouVersionContext = createContext<YouVersionContextData | null>(null);

--- a/packages/hooks/src/context/YouVersionProvider.tsx
+++ b/packages/hooks/src/context/YouVersionProvider.tsx
@@ -4,6 +4,7 @@ import type { PropsWithChildren, ReactNode } from 'react';
 import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
 import { YouVersionContext } from './YouVersionContext';
 import {
+  ApiClient,
   YouVersionPlatformConfiguration,
   type YouVersionUserInfoJSON,
 } from '@youversion/platform-core';
@@ -34,6 +35,18 @@ interface YouVersionProviderPropsBase {
    * to replace `X-YVP-Sdk` with their own identifier.
    */
   additionalHeaders?: Record<string, string>;
+  /**
+   * Per-request timeout in milliseconds. Defaults to 10000.
+   *
+   * A request that gets no response within this window is aborted and rejects
+   * with `Request timeout after {timeout}ms`. Raise it for integrators on slow
+   * networks; lower it to surface a failure sooner.
+   *
+   * Note that the automatic retry in `useApiData` keeps a fixed 20-second wall
+   * clock. A timeout at or above that figure leaves no room for a retry, which
+   * is the SDK's pre-retry, single-shot behavior.
+   */
+  timeout?: number;
 }
 
 interface YouVersionProviderPropsWithAuth extends YouVersionProviderPropsBase {
@@ -115,6 +128,7 @@ function YouVersionProviderInner(
     additionalHeaders,
     appName,
     signInPromptMessage,
+    timeout,
     children,
   } = props;
 
@@ -144,13 +158,35 @@ function YouVersionProviderInner(
     YouVersionPlatformConfiguration.signInPromptMessage = signInPromptMessage;
   }, [appKey, apiHost, appName, signInPromptMessage]);
 
+  const installationId = YouVersionPlatformConfiguration.installationId;
+
+  // One ApiClient for the whole tree. It has to be built here, not in
+  // useApiClient: ApiClient deduplicates concurrent GETs through a private
+  // per-instance map, and a useMemo inside useApiClient runs once per hook
+  // instance, so every sibling component would get its own map and its own
+  // duplicate request. Rebuilt only when a value the client is configured
+  // with changes.
+  const apiClient = useMemo(
+    () =>
+      new ApiClient({
+        appKey,
+        apiHost,
+        installationId,
+        additionalHeaders: stableAdditionalHeaders,
+        timeout,
+      }),
+    [appKey, apiHost, installationId, stableAdditionalHeaders, timeout],
+  );
+
   const contextValue = {
     appKey,
     apiHost,
-    installationId: YouVersionPlatformConfiguration.installationId,
+    installationId,
     theme: resolvedTheme,
     authEnabled: !!includeAuth,
     additionalHeaders: stableAdditionalHeaders,
+    timeout,
+    apiClient,
   };
 
   if (includeAuth) {

--- a/packages/hooks/src/internal/retry-policy.test.ts
+++ b/packages/hooks/src/internal/retry-policy.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  backoffMs,
+  DEFAULT_MAX_RETRIES,
+  DEFAULT_RETRY_BUDGET_MS,
+  isRetryableRequestError,
+} from './retry-policy';
+
+/** The shape `ApiClient` throws for a non-2xx response. */
+function httpError(status: number, message = `Request failed with status ${status}`): Error {
+  return Object.assign(new Error(message), { status });
+}
+
+describe('isRetryableRequestError', () => {
+  it('retries a request timeout, which carries no status', () => {
+    expect(isRetryableRequestError(new Error('Request timeout after 10000ms'))).toBe(true);
+  });
+
+  it('retries a transport failure, which carries no status', () => {
+    expect(isRetryableRequestError(new TypeError('Failed to fetch'))).toBe(true);
+  });
+
+  it('retries a 429', () => {
+    expect(isRetryableRequestError(httpError(429))).toBe(true);
+  });
+
+  it('retries a 500', () => {
+    expect(isRetryableRequestError(httpError(500))).toBe(true);
+  });
+
+  it('retries a 503', () => {
+    expect(isRetryableRequestError(httpError(503))).toBe(true);
+  });
+
+  it('does not retry a 401', () => {
+    expect(isRetryableRequestError(httpError(401))).toBe(false);
+  });
+
+  it('does not retry a 403', () => {
+    expect(isRetryableRequestError(httpError(403))).toBe(false);
+  });
+
+  it('does not retry a 404', () => {
+    expect(isRetryableRequestError(httpError(404))).toBe(false);
+  });
+
+  it('does not retry a 400, since the request itself is the problem', () => {
+    expect(isRetryableRequestError(httpError(400))).toBe(false);
+  });
+
+  it('does not retry a ZodError, even though it carries no status', () => {
+    // Input validation throws before any request goes out. Sending the same
+    // invalid input again produces the same error.
+    const zodError = Object.assign(new Error('Invalid input'), {
+      name: 'ZodError',
+      issues: [{ code: 'invalid_type', path: ['versionId'], message: 'Expected number' }],
+    });
+
+    expect(isRetryableRequestError(zodError)).toBe(false);
+  });
+
+  it('retries an error whose name only looks like a ZodError without issues', () => {
+    // Guards against a plain Error being renamed; the issues array is what
+    // makes it a real validation failure.
+    const impostor = Object.assign(new Error('Failed to fetch'), { name: 'ZodError' });
+
+    expect(isRetryableRequestError(impostor)).toBe(true);
+  });
+
+  it('retries a non-Error rejection with no status', () => {
+    expect(isRetryableRequestError('something went wrong')).toBe(true);
+  });
+});
+
+describe('backoffMs', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('stays inside the 500ms window on the first attempt', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.999);
+    expect(backoffMs(0)).toBeLessThan(500);
+
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    expect(backoffMs(0)).toBe(0);
+  });
+
+  it('stays inside the 1500ms window on the second attempt', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.999);
+    expect(backoffMs(1)).toBeLessThan(1500);
+
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    expect(backoffMs(1)).toBe(0);
+  });
+
+  it('applies full jitter rather than a fixed delay', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    expect(backoffMs(0)).toBe(250);
+    expect(backoffMs(1)).toBe(750);
+  });
+
+  it('clamps an attempt index past the last window', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    expect(backoffMs(7)).toBe(750);
+    expect(backoffMs(-1)).toBe(250);
+  });
+
+  it('never returns a negative delay across many draws', () => {
+    for (let i = 0; i < 100; i++) {
+      expect(backoffMs(i % 3)).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+describe('retry budget constants', () => {
+  it('allows two extra attempts inside a 20 second wall clock', () => {
+    expect(DEFAULT_MAX_RETRIES).toBe(2);
+    expect(DEFAULT_RETRY_BUDGET_MS).toBe(20_000);
+  });
+});

--- a/packages/hooks/src/internal/retry-policy.ts
+++ b/packages/hooks/src/internal/retry-policy.ts
@@ -6,17 +6,25 @@ import { getHttpStatus } from '@youversion/platform-core';
 export const DEFAULT_MAX_RETRIES = 2;
 
 /**
- * Wall-clock ceiling for a whole retry chain, measured from the first attempt.
+ * Wall-clock cutoff for *starting* a new attempt, measured from the first one.
  *
- * The attempt cap and this budget bound two different failure shapes. A
+ * Read the guarantee precisely: no attempt begins after the budget is spent. An
+ * attempt already in flight is not cancelled, so the chain can finish later than
+ * the budget. The worst case is `budget + one request timeout + one backoff`.
+ * With the default 10s timeout that is roughly 20s; an integrator who sets a
+ * 15s timeout can see roughly 30s of `loading` before the final error.
+ *
+ * The attempt cap and this cutoff bound two different failure shapes. A
  * transport failure at 200ms exhausts the attempt cap long before the clock. A
- * request that times out at 10s exhausts the clock after one retry. Whichever
+ * request that times out at 10s spends the clock after one retry. Whichever
  * runs out first ends the chain.
  *
  * The figure is fixed on purpose. It is not derived from the configured request
- * timeout, so an integrator who sets a timeout above 20 seconds gets
+ * timeout, so an integrator who sets a timeout at or above 20 seconds gets
  * single-shot behavior — which is exactly what the SDK did before retry
- * existed, so nothing regresses.
+ * existed, so nothing regresses. Deriving it from the timeout would also
+ * suppress the retry at the default 10s, which is the case the chain exists
+ * for; the two values stay uncoupled.
  */
 export const DEFAULT_RETRY_BUDGET_MS = 20_000;
 

--- a/packages/hooks/src/internal/retry-policy.ts
+++ b/packages/hooks/src/internal/retry-policy.ts
@@ -1,0 +1,89 @@
+import { getHttpStatus } from '@youversion/platform-core';
+
+/**
+ * Extra attempts after the first one. Two retries means at most three requests.
+ */
+export const DEFAULT_MAX_RETRIES = 2;
+
+/**
+ * Wall-clock ceiling for a whole retry chain, measured from the first attempt.
+ *
+ * The attempt cap and this budget bound two different failure shapes. A
+ * transport failure at 200ms exhausts the attempt cap long before the clock. A
+ * request that times out at 10s exhausts the clock after one retry. Whichever
+ * runs out first ends the chain.
+ *
+ * The figure is fixed on purpose. It is not derived from the configured request
+ * timeout, so an integrator who sets a timeout above 20 seconds gets
+ * single-shot behavior — which is exactly what the SDK did before retry
+ * existed, so nothing regresses.
+ */
+export const DEFAULT_RETRY_BUDGET_MS = 20_000;
+
+/**
+ * Backoff bases in milliseconds, one per attempt index. Attempt 0 waits out of
+ * a 500ms window, attempt 1 out of a 1500ms window.
+ */
+const BACKOFF_BASES_MS = [500, 1500];
+
+function isZodError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as { name?: unknown }).name === 'ZodError' &&
+    Array.isArray((error as { issues?: unknown }).issues)
+  );
+}
+
+/**
+ * Decides whether a failed request is worth sending again.
+ *
+ * Status is read through `getHttpStatus`, the same duck-type check the rest of
+ * the SDK uses. Only a non-2xx HTTP response carries one; a timeout, a
+ * transport failure, and a Zod validation error all report `undefined`.
+ *
+ * | Failure | status | Retry? |
+ * | --- | --- | --- |
+ * | Request timeout | `undefined` | yes |
+ * | Transport failure (`TypeError`) | `undefined` | yes |
+ * | 429 rate limited | 429 | yes |
+ * | 5xx server error | >= 500 | yes |
+ * | 401 invalid app key | 401 | no |
+ * | 403 forbidden | 403 | no |
+ * | 404 not found | 404 | no |
+ * | Zod input validation | `undefined` | no |
+ *
+ * A Zod error is excluded explicitly, because it carries no status and would
+ * otherwise fall into the retryable `undefined` bucket. The input is invalid;
+ * sending it again produces the same error.
+ */
+export function isRetryableRequestError(error: unknown): boolean {
+  if (isZodError(error)) {
+    return false;
+  }
+
+  const status = getHttpStatus(error);
+
+  // No status: a timeout or a transport failure, both worth another attempt.
+  if (status === undefined) {
+    return true;
+  }
+
+  if (status === 429) {
+    return true;
+  }
+
+  return status >= 500;
+}
+
+/**
+ * Backoff before the attempt after `attempt`, in milliseconds.
+ *
+ * Full jitter (`random() * base`) rather than a fixed delay, so a fanout of
+ * sibling requests that failed together does not retry in lockstep and
+ * reproduce the same burst.
+ */
+export function backoffMs(attempt: number): number {
+  const index = Math.min(Math.max(attempt, 0), BACKOFF_BASES_MS.length - 1);
+  return Math.random() * BACKOFF_BASES_MS[index]!;
+}

--- a/packages/hooks/src/internal/useApiClient.dedupe.test.tsx
+++ b/packages/hooks/src/internal/useApiClient.dedupe.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { YouVersionProvider } from '../context/YouVersionProvider';
+import { useBooks } from '../useBooks';
+import { useVersion } from '../useVersion';
+
+/**
+ * The end-to-end guard for in-flight GET deduplication.
+ *
+ * Core owns a unit test for the dedup map, but it exercises one `ApiClient`
+ * directly, so it could not see the real defect: `useApiClient` built its client
+ * in a `useMemo`, which runs once per hook instance. Every sibling component got
+ * its own client, its own private in-flight map, and its own duplicate request.
+ * A production build of `examples/vite-react` showed `/v1/bibles/3034` fired
+ * twice and `/v1/bibles/3034/books` three times on one `BibleReader` mount.
+ *
+ * This test uses the real core client with `fetch` stubbed, which is the lowest
+ * level at which the sharing is observable from the hooks package.
+ */
+
+const BOOKS_URL = 'https://api.youversion.com/v1/bibles/111/books';
+const VERSION_URL = 'https://api.youversion.com/v1/bibles/111';
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function BooksSibling({ label }: { label: string }) {
+  const { books, loading, error } = useBooks(111);
+  if (loading) return <div>{label}:loading</div>;
+  if (error) return <div>{label}:error</div>;
+  return <div>{`${label}:${books?.data?.length ?? 0}`}</div>;
+}
+
+function VersionSibling({ label }: { label: string }) {
+  const { version, loading } = useVersion(111);
+  if (loading) return <div>{label}:loading</div>;
+  return <div>{`${label}:${version?.abbreviation ?? 'none'}`}</div>;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('shared ApiClient deduplicates sibling requests', () => {
+  it('issues one request when two siblings ask for the same endpoint concurrently', async () => {
+    const deferred = Promise.withResolvers<Response>();
+    const fetchStub = vi.fn((_url: string) => deferred.promise);
+    vi.stubGlobal('fetch', fetchStub);
+
+    render(
+      <YouVersionProvider appKey="test-app-key">
+        <BooksSibling label="a" />
+        <BooksSibling label="b" />
+      </YouVersionProvider>,
+    );
+
+    await waitFor(() => expect(fetchStub).toHaveBeenCalled());
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+    expect(fetchStub.mock.calls[0]?.[0]).toBe(BOOKS_URL);
+
+    deferred.resolve(jsonResponse({ data: [{ usfm: 'GEN' }, { usfm: 'EXO' }] }));
+
+    expect(await screen.findByText('a:2')).toBeInTheDocument();
+    expect(await screen.findByText('b:2')).toBeInTheDocument();
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+  });
+
+  it('issues one request per distinct endpoint across a mixed sibling set', async () => {
+    const booksDeferred = Promise.withResolvers<Response>();
+    const versionDeferred = Promise.withResolvers<Response>();
+
+    const fetchStub = vi.fn((url: string) =>
+      url === BOOKS_URL ? booksDeferred.promise : versionDeferred.promise,
+    );
+    vi.stubGlobal('fetch', fetchStub);
+
+    render(
+      <YouVersionProvider appKey="test-app-key">
+        <BooksSibling label="a" />
+        <VersionSibling label="b" />
+        <BooksSibling label="c" />
+        <VersionSibling label="d" />
+      </YouVersionProvider>,
+    );
+
+    await waitFor(() => expect(fetchStub).toHaveBeenCalledTimes(2));
+
+    const requestedUrls = fetchStub.mock.calls.map(([url]) => url).sort();
+    expect(requestedUrls).toEqual([VERSION_URL, BOOKS_URL].sort());
+
+    booksDeferred.resolve(jsonResponse({ data: [{ usfm: 'GEN' }] }));
+    versionDeferred.resolve(jsonResponse({ id: 111, abbreviation: 'NIV' }));
+
+    expect(await screen.findByText('a:1')).toBeInTheDocument();
+    expect(await screen.findByText('c:1')).toBeInTheDocument();
+    expect(await screen.findByText('b:NIV')).toBeInTheDocument();
+    expect(await screen.findByText('d:NIV')).toBeInTheDocument();
+    expect(fetchStub).toHaveBeenCalledTimes(2);
+  });
+
+  it('shares in flight only — a sibling mounted after the first settles refetches', async () => {
+    const fetchStub = vi.fn(() => Promise.resolve(jsonResponse({ data: [{ usfm: 'GEN' }] })));
+    vi.stubGlobal('fetch', fetchStub);
+
+    const { rerender } = render(
+      <YouVersionProvider appKey="test-app-key">
+        <BooksSibling label="a" />
+      </YouVersionProvider>,
+    );
+
+    expect(await screen.findByText('a:1')).toBeInTheDocument();
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <YouVersionProvider appKey="test-app-key">
+        <BooksSibling label="a" />
+        <BooksSibling label="b" />
+      </YouVersionProvider>,
+    );
+
+    expect(await screen.findByText('b:1')).toBeInTheDocument();
+    expect(fetchStub).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/hooks/src/internal/useApiClient.test.tsx
+++ b/packages/hooks/src/internal/useApiClient.test.tsx
@@ -1,0 +1,193 @@
+import { render, renderHook } from '@testing-library/react';
+import { ApiClient } from '@youversion/platform-core';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { YouVersionContext } from '../context';
+import { YouVersionProvider } from '../context/YouVersionProvider';
+import { useApiClient } from './useApiClient';
+
+vi.mock('@youversion/platform-core', async () => {
+  const actual = await vi.importActual('@youversion/platform-core');
+  return {
+    ...actual,
+    ApiClient: vi.fn(function () {
+      return { isApiClient: true };
+    }),
+  };
+});
+
+const wrapperWith = (value: { appKey: string; timeout?: number }) => {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <YouVersionContext.Provider value={value}>{children}</YouVersionContext.Provider>
+  );
+  return Wrapper;
+};
+
+describe('useApiClient', () => {
+  it('leaves timeout undefined when the provider sets none, so ApiClient keeps its own default', () => {
+    renderHook(() => useApiClient(), { wrapper: wrapperWith({ appKey: 'test-app-key' }) });
+
+    expect(ApiClient).toHaveBeenCalledWith(
+      expect.objectContaining({ appKey: 'test-app-key', timeout: undefined }),
+    );
+  });
+
+  it('passes the context timeout into the ApiClient constructor', () => {
+    renderHook(() => useApiClient(), {
+      wrapper: wrapperWith({ appKey: 'test-app-key', timeout: 2500 }),
+    });
+
+    expect(ApiClient).toHaveBeenCalledWith(expect.objectContaining({ timeout: 2500 }));
+  });
+
+  it('builds a new client when the timeout changes', () => {
+    let currentTimeout = 2500;
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <YouVersionContext.Provider value={{ appKey: 'test-app-key', timeout: currentTimeout }}>
+        {children}
+      </YouVersionContext.Provider>
+    );
+
+    const { result, rerender } = renderHook(() => useApiClient(), { wrapper });
+    const firstClient = result.current;
+    expect(ApiClient).toHaveBeenCalledTimes(1);
+
+    currentTimeout = 7500;
+    rerender();
+
+    expect(ApiClient).toHaveBeenCalledTimes(2);
+    expect(ApiClient).toHaveBeenLastCalledWith(expect.objectContaining({ timeout: 7500 }));
+    expect(result.current).not.toBe(firstClient);
+  });
+
+  it('keeps the same client when the timeout is unchanged', () => {
+    const wrapper = wrapperWith({ appKey: 'test-app-key', timeout: 2500 });
+
+    const { result, rerender } = renderHook(() => useApiClient(), { wrapper });
+    const firstClient = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(firstClient);
+    expect(ApiClient).toHaveBeenCalledTimes(1);
+  });
+
+  it('carries the YouVersionProvider timeout prop through to the constructor', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <YouVersionProvider appKey="test-app-key" timeout={4000}>
+        {children}
+      </YouVersionProvider>
+    );
+
+    renderHook(() => useApiClient(), { wrapper });
+
+    expect(ApiClient).toHaveBeenCalledWith(
+      expect.objectContaining({ appKey: 'test-app-key', timeout: 4000 }),
+    );
+  });
+
+  it('returns null for the optional variant when no provider is mounted', () => {
+    const { result } = renderHook(() => useApiClient({ optional: true }));
+
+    expect(result.current).toBeNull();
+    expect(ApiClient).not.toHaveBeenCalled();
+  });
+
+  it('throws for the non-optional variant when no provider is mounted', () => {
+    // React logs the render error before rethrowing it; silence that, not the throw.
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    expect(() => renderHook(() => useApiClient())).toThrow(/YouVersion context not found/);
+
+    consoleError.mockRestore();
+  });
+
+  it('throws for the non-optional variant when the context carries no app key', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    expect(() =>
+      renderHook(() => useApiClient(), { wrapper: wrapperWith({ appKey: '' }) }),
+    ).toThrow(/YouVersion context not found/);
+
+    consoleError.mockRestore();
+  });
+});
+
+describe('useApiClient sharing across siblings', () => {
+  // The defect this guards: building the ApiClient in a useMemo inside
+  // useApiClient gives every hook instance its own client, and the in-flight GET
+  // dedup map is a private per-instance field. Siblings never shared a map, so
+  // they never shared a request.
+  function Sibling({ onClient }: { onClient: (client: unknown) => void }) {
+    onClient(useApiClient());
+    return null;
+  }
+
+  it('hands every sibling under one provider the same client instance', () => {
+    const clients: unknown[] = [];
+
+    render(
+      <YouVersionProvider appKey="test-app-key">
+        <Sibling onClient={(client) => clients.push(client)} />
+        <Sibling onClient={(client) => clients.push(client)} />
+        <Sibling onClient={(client) => clients.push(client)} />
+      </YouVersionProvider>,
+    );
+
+    expect(ApiClient).toHaveBeenCalledTimes(1);
+    expect(clients).toHaveLength(3);
+    expect(clients[1]).toBe(clients[0]);
+    expect(clients[2]).toBe(clients[0]);
+  });
+
+  it.each([
+    ['appKey', { appKey: 'other-app-key' }],
+    ['apiHost', { apiHost: 'staging.youversion.com' }],
+    ['timeout', { timeout: 2500 }],
+    ['additionalHeaders', { additionalHeaders: { 'X-YVP-Sdk': 'expo' } }],
+  ])('rebuilds the shared client when %s changes', (_label, changedProps) => {
+    const baseProps = {
+      appKey: 'test-app-key',
+      apiHost: 'api.youversion.com',
+      timeout: 9000,
+      additionalHeaders: { 'X-Trace': 'a' },
+    };
+    const clients: unknown[] = [];
+
+    const { rerender } = render(
+      <YouVersionProvider {...baseProps}>
+        <Sibling onClient={(client) => clients.push(client)} />
+      </YouVersionProvider>,
+    );
+    expect(ApiClient).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <YouVersionProvider {...baseProps} {...changedProps}>
+        <Sibling onClient={(client) => clients.push(client)} />
+      </YouVersionProvider>,
+    );
+
+    expect(ApiClient).toHaveBeenCalledTimes(2);
+    expect(clients.at(-1)).not.toBe(clients[0]);
+  });
+
+  it('keeps the shared client when the provider re-renders with equivalent props', () => {
+    const clients: unknown[] = [];
+    const tree = (
+      <YouVersionProvider appKey="test-app-key" additionalHeaders={{ 'X-Trace': 'a' }}>
+        <Sibling onClient={(client) => clients.push(client)} />
+      </YouVersionProvider>
+    );
+
+    const { rerender } = render(tree);
+    rerender(
+      <YouVersionProvider appKey="test-app-key" additionalHeaders={{ 'X-Trace': 'a' }}>
+        <Sibling onClient={(client) => clients.push(client)} />
+      </YouVersionProvider>,
+    );
+
+    expect(ApiClient).toHaveBeenCalledTimes(1);
+    expect(clients.at(-1)).toBe(clients[0]);
+  });
+});

--- a/packages/hooks/src/internal/useApiClient.ts
+++ b/packages/hooks/src/internal/useApiClient.ts
@@ -5,9 +5,19 @@ import { ApiClient } from '@youversion/platform-core';
 import { YouVersionContext } from '../context';
 
 /**
- * Reads {@link YouVersionContext} and returns a memoized {@link ApiClient} built
- * from its config. Shared by the per-service client hooks so the client
- * construction (and its dependency array) lives in one place.
+ * Returns the {@link ApiClient} every hook under a `YouVersionProvider` shares.
+ *
+ * The instance is built by `YouVersionProvider` and read off the context. It has
+ * to be one instance for the whole tree: `ApiClient` deduplicates concurrent
+ * GETs through a private per-instance map, so two sibling components asking for
+ * the same endpoint in the same tick only collapse into one request when they
+ * hold the same client. Building the client here in a `useMemo` gave every hook
+ * instance its own map, which is why the dedup never fired in a real app.
+ *
+ * When the context carries no client — a consumer rendering
+ * `YouVersionContext.Provider` by hand, which the exported context allows — this
+ * falls back to a per-hook client built from the same config. That path works
+ * but does not share in-flight requests between siblings.
  *
  * By default it throws when no app key is configured (the contract every data
  * hook relies on). Pass `{ optional: true }` for the no-provider-tolerant
@@ -20,25 +30,35 @@ export function useApiClient(options: { optional?: boolean } = {}): ApiClient | 
   const context = useContext(YouVersionContext);
   const optional = options.optional ?? false;
 
-  return useMemo(() => {
-    if (!context?.appKey) {
-      if (optional) return null;
-      throw new Error(
-        'YouVersion context not found. Make sure your component is wrapped with YouVersionProvider and an API key is provided.',
-      );
-    }
+  const providedClient = context?.apiClient ?? null;
+
+  const fallbackClient = useMemo(() => {
+    if (providedClient || !context?.appKey) return null;
 
     return new ApiClient({
       appKey: context.appKey,
       apiHost: context.apiHost,
       installationId: context.installationId,
       additionalHeaders: context.additionalHeaders,
+      timeout: context.timeout,
     });
   }, [
+    providedClient,
     context?.appKey,
     context?.apiHost,
     context?.installationId,
     context?.additionalHeaders,
-    optional,
+    context?.timeout,
   ]);
+
+  const client = providedClient ?? fallbackClient;
+
+  if (!client) {
+    if (optional) return null;
+    throw new Error(
+      'YouVersion context not found. Make sure your component is wrapped with YouVersionProvider and an API key is provided.',
+    );
+  }
+
+  return client;
 }

--- a/packages/hooks/src/useApiData.test.tsx
+++ b/packages/hooks/src/useApiData.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { useApiData, type UseApiDataOptions } from './useApiData';
 
 describe('useApiData — enabled transitions', () => {
@@ -196,5 +196,234 @@ describe('useApiData — existing behavior', () => {
       expect(result.current.data).toBe('second');
     });
     expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('useApiData — automatic retry', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** The error shape `ApiClient` throws for a non-2xx response. */
+  function httpError(status: number): Error {
+    return Object.assign(new Error(`Request failed with status ${status}`), { status });
+  }
+
+  /**
+   * A `fetchFn` handing out one deferred per call, so each attempt can be
+   * settled independently. Same approach as the stale-response tests above,
+   * with fake timers added to step through the backoff.
+   */
+  function deferredFetchFn() {
+    const deferreds: PromiseWithResolvers<string>[] = [];
+    const fetchFn = vi.fn(() => {
+      const deferred = Promise.withResolvers<string>();
+      deferreds.push(deferred);
+      return deferred.promise;
+    });
+    return { deferreds, fetchFn };
+  }
+
+  /** Drains the microtask queue so a settled promise reaches its handlers. */
+  async function flush(): Promise<void> {
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  /** Runs out the backoff timer scheduled after `attempt`. */
+  async function runBackoff(attempt: number): Promise<void> {
+    await act(async () => {
+      // Full jitter means the delay is somewhere inside the window, so advance
+      // past the whole window: 500ms for attempt 0, 1500ms for attempt 1.
+      await vi.advanceTimersByTimeAsync(attempt === 0 ? 500 : 1500);
+    });
+  }
+
+  it('retries a 503 and commits the second attempt result', async () => {
+    vi.useFakeTimers();
+    const { deferreds, fetchFn } = deferredFetchFn();
+
+    const { result } = renderHook(() => useApiData(fetchFn, ['dep']));
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    deferreds[0]!.reject(httpError(503));
+    await flush();
+
+    // The failure is swallowed while a retry is pending.
+    expect(result.current.error).toBeNull();
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    await runBackoff(0);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+
+    deferreds[1]!.resolve('recovered');
+    await flush();
+
+    expect(result.current.data).toBe('recovered');
+    expect(result.current.error).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('keeps loading true across the backoff', async () => {
+    vi.useFakeTimers();
+    const { deferreds, fetchFn } = deferredFetchFn();
+
+    const { result } = renderHook(() => useApiData(fetchFn, ['dep']));
+
+    deferreds[0]!.reject(httpError(503));
+    await flush();
+
+    // A spinner that settles between attempts would flicker.
+    expect(result.current.loading).toBe(true);
+
+    await runBackoff(0);
+    expect(result.current.loading).toBe(true);
+
+    deferreds[1]!.resolve('recovered');
+    await flush();
+
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('does not retry a 401; the error surfaces on the first failure', async () => {
+    vi.useFakeTimers();
+    const { deferreds, fetchFn } = deferredFetchFn();
+
+    const { result } = renderHook(() => useApiData(fetchFn, ['dep']));
+
+    deferreds[0]!.reject(httpError(401));
+    await flush();
+
+    expect(result.current.error?.message).toBe('Request failed with status 401');
+    expect(result.current.loading).toBe(false);
+
+    await runBackoff(0);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops at the attempt cap and surfaces the last error', async () => {
+    vi.useFakeTimers();
+    const { deferreds, fetchFn } = deferredFetchFn();
+
+    const { result } = renderHook(() => useApiData(fetchFn, ['dep']));
+
+    deferreds[0]!.reject(new TypeError('Failed to fetch'));
+    await flush();
+    await runBackoff(0);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+
+    deferreds[1]!.reject(new TypeError('Failed to fetch'));
+    await flush();
+    await runBackoff(1);
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+
+    deferreds[2]!.reject(new TypeError('final failure'));
+    await flush();
+
+    // Two extra attempts is the cap: three requests in total.
+    expect(result.current.error?.message).toBe('final failure');
+    expect(result.current.loading).toBe(false);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+  });
+
+  it('stops when the wall-clock budget runs out before the attempt cap', async () => {
+    vi.useFakeTimers();
+    const { deferreds, fetchFn } = deferredFetchFn();
+
+    const { result } = renderHook(() => useApiData(fetchFn, ['dep']));
+
+    // A request that hangs until the 10 second client timeout fires.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    deferreds[0]!.reject(new Error('Request timeout after 10000ms'));
+    await flush();
+
+    // 10s elapsed, still inside the 20s budget, so one retry goes out.
+    await runBackoff(0);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_500);
+    });
+    deferreds[1]!.reject(new Error('Request timeout after 10000ms'));
+    await flush();
+
+    // Past 20s now. The attempt cap still had one attempt left; the clock did not.
+    expect(result.current.error?.message).toBe('Request timeout after 10000ms');
+    expect(result.current.loading).toBe(false);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('cancels the retry chain when deps change during the backoff', async () => {
+    vi.useFakeTimers();
+    const { deferreds, fetchFn } = deferredFetchFn();
+
+    const { result, rerender } = renderHook(
+      ({ scope }: { scope: string }) => useApiData(fetchFn, [scope]),
+      { initialProps: { scope: 'JHN.3' } },
+    );
+
+    deferreds[0]!.reject(httpError(503));
+    await flush();
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    // The user changes chapter while the backoff is still pending.
+    rerender({ scope: 'JHN.4' });
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+
+    // The pending backoff fires and finds it no longer holds the ticket.
+    await runBackoff(0);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(result.current.error).toBeNull();
+
+    deferreds[1]!.resolve('JHN.4 data');
+    await flush();
+
+    expect(result.current.data).toBe('JHN.4 data');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('does not write state from a retry chain abandoned at unmount', async () => {
+    vi.useFakeTimers();
+    const { deferreds, fetchFn } = deferredFetchFn();
+
+    const { unmount } = renderHook(() => useApiData(fetchFn, ['dep']));
+
+    deferreds[0]!.reject(httpError(503));
+    await flush();
+
+    unmount();
+
+    await runBackoff(0);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('makes a single attempt when retry is false', async () => {
+    vi.useFakeTimers();
+    const { deferreds, fetchFn } = deferredFetchFn();
+    const options: UseApiDataOptions = { retry: false };
+
+    const { result } = renderHook(() => useApiData(fetchFn, ['dep'], options));
+
+    deferreds[0]!.reject(httpError(503));
+    await flush();
+
+    expect(result.current.error?.message).toBe('Request failed with status 503');
+    expect(result.current.loading).toBe(false);
+
+    await runBackoff(0);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/hooks/src/useApiData.ts
+++ b/packages/hooks/src/useApiData.ts
@@ -1,9 +1,27 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef } from 'react';
+import {
+  backoffMs,
+  DEFAULT_MAX_RETRIES,
+  DEFAULT_RETRY_BUDGET_MS,
+  isRetryableRequestError,
+} from './internal/retry-policy';
 
 export type UseApiDataOptions = {
   enabled?: boolean;
+  /**
+   * Retry a failed request automatically. Defaults to `true`.
+   *
+   * A retryable failure (timeout, transport failure, 429, 5xx) gets up to
+   * {@link DEFAULT_MAX_RETRIES} extra attempts within a
+   * {@link DEFAULT_RETRY_BUDGET_MS} wall clock, whichever runs out first.
+   * `loading` stays `true` for the whole chain.
+   *
+   * Set `false` for a poll or a fire-and-forget read that owns its own
+   * cadence and should fail fast instead.
+   */
+  retry?: boolean;
 };
 
 type UseApiDataResult<T> = {
@@ -18,7 +36,7 @@ export function useApiData<T>(
   deps: React.DependencyList,
   options: UseApiDataOptions = {},
 ): UseApiDataResult<T> {
-  const { enabled = true } = options;
+  const { enabled = true, retry = true } = options;
 
   const [data, setData] = useState<T | null>(null);
   const [loading, setLoading] = useState(true);
@@ -56,24 +74,43 @@ export function useApiData<T>(
     setLoading(true);
     setError(null);
 
-    fetchFnRef
-      .current()
-      .then((result) => {
-        if (requestSeq === requestSeqRef.current) {
+    // One wall clock for the whole chain, started here rather than per attempt.
+    const startedAt = Date.now();
+
+    const isCurrent = (): boolean => requestSeq === requestSeqRef.current;
+
+    // `loading` deliberately stays true across the whole chain: it settles only
+    // on success or on final failure, never between attempts, so the two-tier
+    // spinner in the reader does not flicker while a retry is pending.
+    const attempt = (attemptIndex: number): void => {
+      fetchFnRef
+        .current()
+        .then((result) => {
+          if (!isCurrent()) return;
           setData(result);
-        }
-      })
-      .catch((err) => {
-        if (requestSeq === requestSeqRef.current) {
-          setError(err as Error);
-        }
-      })
-      .finally(() => {
-        if (requestSeq === requestSeqRef.current) {
           setLoading(false);
-        }
-      });
-  }, [enabled]);
+        })
+        .catch((err: unknown) => {
+          if (!isCurrent()) return;
+
+          const budgetLeft = Date.now() - startedAt < DEFAULT_RETRY_BUDGET_MS;
+          const attemptsLeft = attemptIndex < DEFAULT_MAX_RETRIES;
+
+          if (retry && attemptsLeft && budgetLeft && isRetryableRequestError(err)) {
+            setTimeout(() => {
+              // Re-check: the chapter may have changed during the backoff.
+              if (isCurrent()) attempt(attemptIndex + 1);
+            }, backoffMs(attemptIndex));
+            return;
+          }
+
+          setError(err as Error);
+          setLoading(false);
+        });
+    };
+
+    attempt(0);
+  }, [enabled, retry]);
 
   const refetch = useCallback(() => {
     fetchData();

--- a/packages/hooks/src/useApiData.ts
+++ b/packages/hooks/src/useApiData.ts
@@ -14,9 +14,11 @@ export type UseApiDataOptions = {
    * Retry a failed request automatically. Defaults to `true`.
    *
    * A retryable failure (timeout, transport failure, 429, 5xx) gets up to
-   * {@link DEFAULT_MAX_RETRIES} extra attempts within a
-   * {@link DEFAULT_RETRY_BUDGET_MS} wall clock, whichever runs out first.
-   * `loading` stays `true` for the whole chain.
+   * {@link DEFAULT_MAX_RETRIES} extra attempts, and no attempt starts once
+   * {@link DEFAULT_RETRY_BUDGET_MS} has elapsed — whichever runs out first.
+   * The budget gates the *start* of an attempt, so a request already in flight
+   * still runs to its own timeout; see {@link DEFAULT_RETRY_BUDGET_MS} for the
+   * worst case. `loading` stays `true` for the whole chain.
    *
    * Set `false` for a poll or a fire-and-forget read that owns its own
    * cadence and should fail fast instead.
@@ -93,6 +95,9 @@ export function useApiData<T>(
         .catch((err: unknown) => {
           if (!isCurrent()) return;
 
+          // Gates the *start* of the next attempt. An attempt already running
+          // is never cut short, so the chain can outlast the budget by one
+          // request timeout. See DEFAULT_RETRY_BUDGET_MS.
           const budgetLeft = Date.now() - startedAt < DEFAULT_RETRY_BUDGET_MS;
           const attemptsLeft = attemptIndex < DEFAULT_MAX_RETRIES;
 

--- a/packages/hooks/src/useBook.test.tsx
+++ b/packages/hooks/src/useBook.test.tsx
@@ -5,6 +5,7 @@ import { type BibleClient } from '@youversion/platform-core';
 import { useBibleClient } from './useBibleClient';
 import { createYVWrapper } from './test/utils';
 import { createMockBook } from './__tests__/mocks/bibles';
+import { createFinalError } from './__tests__/mocks/errors';
 
 vi.mock('./useBibleClient');
 
@@ -97,7 +98,7 @@ describe('useBook', () => {
 
     it('should handle fetch errors', async () => {
       const wrapper = createYVWrapper();
-      const error = new Error('Failed to fetch book');
+      const error = createFinalError('Failed to fetch book');
       mockGetBook.mockRejectedValueOnce(error);
 
       const { result } = renderHook(() => useBook(1, 'GEN'), { wrapper });
@@ -112,7 +113,7 @@ describe('useBook', () => {
 
     it('should clear error on successful refetch', async () => {
       const wrapper = createYVWrapper();
-      const error = new Error('Failed to fetch book');
+      const error = createFinalError('Failed to fetch book');
       mockGetBook.mockRejectedValueOnce(error).mockResolvedValueOnce(mockBook);
 
       const { result } = renderHook(() => useBook(1, 'GEN'), { wrapper });

--- a/packages/hooks/src/useBooks.test.tsx
+++ b/packages/hooks/src/useBooks.test.tsx
@@ -5,6 +5,7 @@ import { type BibleClient, type BibleBook, type Collection } from '@youversion/p
 import { useBibleClient } from './useBibleClient';
 import { createYVWrapper } from './test/utils';
 import { createMockBook } from './__tests__/mocks/bibles';
+import { createFinalError } from './__tests__/mocks/errors';
 
 vi.mock('./useBibleClient');
 
@@ -87,7 +88,7 @@ describe('useBooks', () => {
 
     it('should handle fetch errors', async () => {
       const wrapper = createYVWrapper();
-      const error = new Error('Failed to fetch books');
+      const error = createFinalError('Failed to fetch books');
       mockGetBooks.mockRejectedValueOnce(error);
 
       const { result } = renderHook(() => useBooks(111), { wrapper });
@@ -102,7 +103,7 @@ describe('useBooks', () => {
 
     it('should clear error on successful refetch', async () => {
       const wrapper = createYVWrapper();
-      const error = new Error('Failed to fetch books');
+      const error = createFinalError('Failed to fetch books');
       mockGetBooks.mockRejectedValueOnce(error).mockResolvedValueOnce(mockBooks);
 
       const { result } = renderHook(() => useBooks(111), { wrapper });

--- a/packages/hooks/src/useChapter.test.tsx
+++ b/packages/hooks/src/useChapter.test.tsx
@@ -4,6 +4,7 @@ import { useChapter } from './useChapter';
 import { type BibleClient, type BibleChapter } from '@youversion/platform-core';
 import { useBibleClient } from './useBibleClient';
 import { createYVWrapper } from './test/utils';
+import { createFinalError } from './__tests__/mocks/errors';
 
 vi.mock('./useBibleClient');
 
@@ -109,7 +110,7 @@ describe('useChapter', () => {
 
     it('should handle fetch errors', async () => {
       const wrapper = createYVWrapper();
-      const error = new Error('Failed to fetch chapter');
+      const error = createFinalError('Failed to fetch chapter');
       mockGetChapter.mockRejectedValueOnce(error);
 
       const { result } = renderHook(() => useChapter(1, 'MAT', 1), { wrapper });
@@ -124,7 +125,7 @@ describe('useChapter', () => {
 
     it('should clear error on successful refetch', async () => {
       const wrapper = createYVWrapper();
-      const error = new Error('Failed to fetch chapter');
+      const error = createFinalError('Failed to fetch chapter');
       mockGetChapter.mockRejectedValueOnce(error).mockResolvedValueOnce(mockChapter);
 
       const { result } = renderHook(() => useChapter(1, 'MAT', 1), { wrapper });

--- a/packages/hooks/src/useChapters.test.tsx
+++ b/packages/hooks/src/useChapters.test.tsx
@@ -4,6 +4,7 @@ import { useChapters } from './useChapters';
 import { type BibleClient, type BibleChapter, type Collection } from '@youversion/platform-core';
 import { useBibleClient } from './useBibleClient';
 import { createYVWrapper } from './test/utils';
+import { createFinalError } from './__tests__/mocks/errors';
 
 vi.mock('./useBibleClient');
 
@@ -104,7 +105,7 @@ describe('useChapters', () => {
 
     it('should handle fetch errors', async () => {
       const wrapper = createYVWrapper();
-      const error = new Error('Failed to fetch chapters');
+      const error = createFinalError('Failed to fetch chapters');
       mockGetChapters.mockRejectedValueOnce(error);
 
       const { result } = renderHook(() => useChapters(1, 'MAT'), { wrapper });
@@ -119,7 +120,7 @@ describe('useChapters', () => {
 
     it('should clear error on successful refetch', async () => {
       const wrapper = createYVWrapper();
-      const error = new Error('Failed to fetch chapters');
+      const error = createFinalError('Failed to fetch chapters');
       mockGetChapters.mockRejectedValueOnce(error).mockResolvedValueOnce(mockChapters);
 
       const { result } = renderHook(() => useChapters(1, 'MAT'), { wrapper });

--- a/packages/hooks/src/useHighlights.test.tsx
+++ b/packages/hooks/src/useHighlights.test.tsx
@@ -12,6 +12,7 @@ import {
   type CreateHighlight,
 } from '@youversion/platform-core';
 import { createYVWrapper } from './test/utils';
+import { createFinalError } from './__tests__/mocks/errors';
 
 vi.mock('@youversion/platform-core', async () => {
   const actual = await vi.importActual('@youversion/platform-core');
@@ -186,7 +187,7 @@ describe('useHighlights', () => {
 
     it('should handle fetch errors', async () => {
       const wrapper = createYVWrapper();
-      const error = new Error('Failed to fetch highlights');
+      const error = createFinalError('Failed to fetch highlights');
       mockGetHighlights.mockRejectedValueOnce(error);
 
       const { result } = renderHook(() => useHighlights(defaultOptions), { wrapper });

--- a/packages/hooks/src/useLanguage.test.tsx
+++ b/packages/hooks/src/useLanguage.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useLanguage } from './useLanguage';
 import { type LanguagesClient } from '@youversion/platform-core';
 import { useLanguagesClient } from './useLanguageClient';
+import { createFinalError } from './__tests__/mocks/errors';
 
 vi.mock('./useLanguageClient');
 
@@ -80,7 +81,7 @@ describe('useLanguage', () => {
     });
 
     it('should handle fetch errors', async () => {
-      const error = new Error('Failed to fetch language');
+      const error = createFinalError('Failed to fetch language');
       mockGetLanguage.mockRejectedValueOnce(error);
 
       const { result } = renderHook(() => useLanguage('en'));

--- a/packages/hooks/src/useLanguages.test.tsx
+++ b/packages/hooks/src/useLanguages.test.tsx
@@ -9,6 +9,7 @@ import {
 } from '@youversion/platform-core';
 import { useLanguagesClient } from './useLanguageClient';
 import { createYVWrapper } from './test/utils';
+import { createFinalError } from './__tests__/mocks/errors';
 
 vi.mock('./useLanguageClient');
 
@@ -152,7 +153,7 @@ describe('useLanguages', () => {
 
     it('should handle fetch errors', async () => {
       const wrapper = createYVWrapper();
-      const error = new Error('Failed to fetch languages');
+      const error = createFinalError('Failed to fetch languages');
       mockGetLanguages.mockRejectedValueOnce(error);
 
       const { result } = renderHook(() => useLanguages({ country: 'US' }), { wrapper });

--- a/packages/hooks/src/useOrganization.test.tsx
+++ b/packages/hooks/src/useOrganization.test.tsx
@@ -4,6 +4,7 @@ import { useOrganization } from './useOrganization';
 import { type Organization, type OrganizationsClient } from '@youversion/platform-core';
 import { useOrganizationsClient } from './useOrganizationsClient';
 import { createYVWrapper } from './test/utils';
+import { createFinalError } from './__tests__/mocks/errors';
 
 vi.mock('./useOrganizationsClient');
 
@@ -98,7 +99,7 @@ describe('useOrganization', () => {
   describe('error handling', () => {
     it('should handle fetch errors', async () => {
       const wrapper = createYVWrapper();
-      const error = new Error('Failed to fetch organization');
+      const error = createFinalError('Failed to fetch organization');
       mockGetOrganization.mockRejectedValueOnce(error);
 
       const { result } = renderHook(() => useOrganization('798d8fa4-f640-4155-8cfb-fa91d1d8a06c'), {

--- a/packages/hooks/src/usePassage.test.tsx
+++ b/packages/hooks/src/usePassage.test.tsx
@@ -5,6 +5,7 @@ import { type BibleClient } from '@youversion/platform-core';
 import { useBibleClient } from './useBibleClient';
 import { createYVWrapper } from './test/utils';
 import { createMockPassage } from './__tests__/mocks/bibles';
+import { createFinalError } from './__tests__/mocks/errors';
 
 vi.mock('./useBibleClient');
 
@@ -235,7 +236,7 @@ describe('usePassage', () => {
   describe('error handling', () => {
     it('should surface fetch errors', async () => {
       const wrapper = createYVWrapper();
-      const error = new Error('Failed to fetch passage');
+      const error = createFinalError('Failed to fetch passage');
       mockGetPassage.mockRejectedValueOnce(error);
 
       const { result } = renderHook(() => usePassage({ versionId: 3034, usfm: 'JHN.3.16' }), {
@@ -252,7 +253,7 @@ describe('usePassage', () => {
 
     it('should clear error on successful refetch', async () => {
       const wrapper = createYVWrapper();
-      const error = new Error('Failed to fetch passage');
+      const error = createFinalError('Failed to fetch passage');
       mockGetPassage.mockRejectedValueOnce(error).mockResolvedValueOnce(mockPassage);
 
       const { result } = renderHook(() => usePassage({ versionId: 3034, usfm: 'JHN.3.16' }), {

--- a/packages/hooks/src/useVOTD.test.tsx
+++ b/packages/hooks/src/useVOTD.test.tsx
@@ -5,6 +5,7 @@ import { useVerseOfTheDay } from './useVOTD';
 import { YouVersionContext } from './context';
 import { BibleClient, ApiClient, type VOTD } from '@youversion/platform-core';
 import { createYVWrapper } from './test/utils';
+import { createFinalError } from './__tests__/mocks/errors';
 
 vi.mock('@youversion/platform-core', async () => {
   const actual = await vi.importActual('@youversion/platform-core');
@@ -189,7 +190,7 @@ describe('useVerseOfTheDay', () => {
 
     it('should handle fetch errors', async () => {
       const wrapper = createYVWrapper();
-      const error = new Error('Failed to fetch VOTD');
+      const error = createFinalError('Failed to fetch VOTD');
       mockGetVOTD.mockRejectedValueOnce(error);
 
       const { result } = renderHook(() => useVerseOfTheDay(1), { wrapper });

--- a/packages/hooks/src/useVerse.test.tsx
+++ b/packages/hooks/src/useVerse.test.tsx
@@ -4,6 +4,7 @@ import { useVerse } from './useVerse';
 import { type BibleClient, type BibleVerse } from '@youversion/platform-core';
 import { useBibleClient } from './useBibleClient';
 import { createYVWrapper } from './test/utils';
+import { createFinalError } from './__tests__/mocks/errors';
 
 vi.mock('./useBibleClient');
 
@@ -117,7 +118,7 @@ describe('useVerse', () => {
 
     it('should handle fetch errors', async () => {
       const wrapper = createYVWrapper();
-      const error = new Error('Failed to fetch verse');
+      const error = createFinalError('Failed to fetch verse');
       mockGetVerse.mockRejectedValueOnce(error);
 
       const { result } = renderHook(() => useVerse(1, 'MAT', 1, 1), { wrapper });

--- a/packages/hooks/src/useVerses.test.tsx
+++ b/packages/hooks/src/useVerses.test.tsx
@@ -4,6 +4,7 @@ import { useVerses } from './useVerses';
 import { type BibleClient, type BibleVerse, type Collection } from '@youversion/platform-core';
 import { useBibleClient } from './useBibleClient';
 import { createYVWrapper } from './test/utils';
+import { createFinalError } from './__tests__/mocks/errors';
 
 vi.mock('./useBibleClient');
 
@@ -100,7 +101,7 @@ describe('useVerses', () => {
 
     it('should handle fetch errors', async () => {
       const wrapper = createYVWrapper();
-      const error = new Error('Failed to fetch verses');
+      const error = createFinalError('Failed to fetch verses');
       mockGetVerses.mockRejectedValueOnce(error);
 
       const { result } = renderHook(() => useVerses(1, 'MAT', 1), { wrapper });

--- a/packages/hooks/src/useVersion.test.tsx
+++ b/packages/hooks/src/useVersion.test.tsx
@@ -4,6 +4,7 @@ import { useVersion } from './useVersion';
 import { type BibleClient, type BibleVersion } from '@youversion/platform-core';
 import { useBibleClient } from './useBibleClient';
 import { createYVWrapper } from './test/utils';
+import { createFinalError } from './__tests__/mocks/errors';
 
 vi.mock('./useBibleClient');
 
@@ -141,7 +142,7 @@ describe('useVersion', () => {
   describe('error handling', () => {
     it('should handle fetch errors', async () => {
       const wrapper = createYVWrapper();
-      const error = new Error('Failed to fetch version');
+      const error = createFinalError('Failed to fetch version');
       mockGetVersion.mockRejectedValueOnce(error);
 
       const { result } = renderHook(() => useVersion(111), { wrapper });
@@ -156,7 +157,7 @@ describe('useVersion', () => {
 
     it('should clear error on successful refetch', async () => {
       const wrapper = createYVWrapper();
-      const error = new Error('Failed to fetch version');
+      const error = createFinalError('Failed to fetch version');
       mockGetVersion.mockRejectedValueOnce(error).mockResolvedValueOnce(mockVersion);
 
       const { result } = renderHook(() => useVersion(111), { wrapper });

--- a/packages/hooks/src/useVersions.test.tsx
+++ b/packages/hooks/src/useVersions.test.tsx
@@ -4,6 +4,7 @@ import { useVersions } from './useVersions';
 import { type BibleClient, type Collection, type BibleVersion } from '@youversion/platform-core';
 import { useBibleClient } from './useBibleClient';
 import { createYVWrapper } from './test/utils';
+import { createFinalError } from './__tests__/mocks/errors';
 
 vi.mock('./useBibleClient');
 
@@ -495,7 +496,7 @@ describe('useVersions', () => {
   describe('error handling', () => {
     it('should handle fetch errors', async () => {
       const wrapper = createYVWrapper();
-      const error = new Error('Failed to fetch versions');
+      const error = createFinalError('Failed to fetch versions');
       mockGetVersions.mockRejectedValueOnce(error);
 
       const { result } = renderHook(() => useVersions('en'), { wrapper });
@@ -510,7 +511,7 @@ describe('useVersions', () => {
 
     it('should clear error on successful refetch', async () => {
       const wrapper = createYVWrapper();
-      const error = new Error('Failed to fetch versions');
+      const error = createFinalError('Failed to fetch versions');
       mockGetVersions.mockRejectedValueOnce(error).mockResolvedValueOnce(mockVersions);
 
       const { result } = renderHook(() => useVersions('en'), { wrapper });

--- a/packages/ui/.storybook/preview.tsx
+++ b/packages/ui/.storybook/preview.tsx
@@ -8,6 +8,16 @@ function getTheme(value: unknown): 'light' | 'dark' | 'system' {
   return 'light';
 }
 
+/**
+ * Per-request timeout for the provider, in milliseconds. Set
+ * `parameters.providerTimeout` in a story that needs requests to give up
+ * quickly — a hanging-endpoint story would otherwise wait out the SDK's
+ * 10-second default on every attempt.
+ */
+function getProviderTimeout(value: unknown): number | undefined {
+  return typeof value === 'number' ? value : undefined;
+}
+
 import { initialize, mswLoader } from 'msw-storybook-addon';
 import { StorybookEnvCheck } from '../src/test/StorybookEnvCheck';
 import { YouVersionProvider } from '../src/components/YouVersionProvider';
@@ -63,6 +73,7 @@ const preview: Preview = {
         };
       }, [theme]);
 
+      const providerTimeout = getProviderTimeout(context.parameters.providerTimeout);
       const includeAuth = context.parameters.includeAuth !== false;
       const requiredEnvVars = includeAuth
         ? ['STORYBOOK_YOUVERSION_APP_KEY', 'STORYBOOK_AUTH_REDIRECT_URL']
@@ -77,6 +88,7 @@ const preview: Preview = {
               apiHost={import.meta.env.STORYBOOK_YOUVERSION_API_HOST}
               includeAuth={true}
               theme={getTheme(context.globals.theme)}
+              timeout={providerTimeout}
             >
               <Story />
             </YouVersionProvider>
@@ -90,6 +102,7 @@ const preview: Preview = {
             appKey={import.meta.env.STORYBOOK_YOUVERSION_APP_KEY || ''}
             apiHost={import.meta.env.STORYBOOK_YOUVERSION_API_HOST}
             theme={getTheme(context.globals.theme)}
+            timeout={providerTimeout}
           >
             <Story />
           </YouVersionProvider>

--- a/packages/ui/src/components/bible-card.stories.tsx
+++ b/packages/ui/src/components/bible-card.stories.tsx
@@ -206,12 +206,19 @@ export const Error: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await waitFor(async () => {
-      await expect(canvas.getByRole('heading', { level: 2, name: /error/i })).toBeInTheDocument();
-      const errorMessages = canvas.getAllByText(
-        'The Bible service is having trouble right now. Please try again in a moment.',
-      );
-      await expect(errorMessages.length).toBeGreaterThan(0);
-    });
+    // A 500 is retryable, so the card spins through the whole retry chain
+    // before it settles on the error. The default 1000ms `waitFor` window
+    // expires mid-backoff; 5000ms clears the chain, matching the retryable
+    // error stories in bible-reader.stories.tsx.
+    await waitFor(
+      async () => {
+        await expect(canvas.getByRole('heading', { level: 2, name: /error/i })).toBeInTheDocument();
+        const errorMessages = canvas.getAllByText(
+          'The Bible service is having trouble right now. Please try again in a moment.',
+        );
+        await expect(errorMessages.length).toBeGreaterThan(0);
+      },
+      { timeout: 5000 },
+    );
   },
 };

--- a/packages/ui/src/components/bible-card.tsx
+++ b/packages/ui/src/components/bible-card.tsx
@@ -130,6 +130,7 @@ export function BibleCard({
     passage,
     loading: passageLoading,
     error: passageError,
+    refetch: refetchPassage,
   } = usePassage({
     versionId: versionNum,
     usfm: reference,
@@ -186,6 +187,7 @@ export function BibleCard({
               passage,
               loading: passageLoading,
               error: passageError,
+              onRetry: refetchPassage,
             }}
             onFootnotePress={onFootnotePress}
           />

--- a/packages/ui/src/components/bible-reader.stories.tsx
+++ b/packages/ui/src/components/bible-reader.stories.tsx
@@ -998,6 +998,74 @@ export const PassageErrorRetry: Story = {
   },
 };
 
+/** Reset per story run by the story's own `beforeEach`. */
+let passageAttempts = 0;
+
+/**
+ * The passage endpoint fails once with a 503 and then succeeds. `useApiData`
+ * retries on its own, so the Bible text appears with no click and the user
+ * never sees the error at all.
+ *
+ * This is the cross-package check that the retry loop in the hooks package
+ * reaches the reader.
+ */
+export const PassageRetriesAutomatically: Story = {
+  tags: ['integration'],
+  args: {
+    defaultVersionId: 111,
+    defaultBook: 'JHN',
+    defaultChapter: '1',
+  },
+  beforeEach: () => {
+    passageAttempts = 0;
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('*/v1/bibles/111/passages/:usfm', ({ params }) => {
+          passageAttempts += 1;
+
+          if (passageAttempts === 1) {
+            return HttpResponse.json({ message: 'Service unavailable' }, { status: 503 });
+          }
+
+          const usfm = params.usfm as string;
+          return HttpResponse.json({
+            id: usfm,
+            content: `<div class="p"><span class="verse">Recovered passage for ${usfm}.</span></div>`,
+            reference: usfm,
+          });
+        }),
+        ...globalHandlers,
+      ],
+    },
+  },
+  render: (args) => (
+    <div className="yv:h-screen yv:bg-background">
+      <BibleReader.Root {...args}>
+        <BibleReader.Content />
+        <BibleReader.Toolbar />
+      </BibleReader.Root>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    await waitFor(
+      async () => {
+        const renderer = canvasElement.querySelector('[data-slot="yv-bible-renderer"]');
+        await expect(renderer?.textContent).toContain('Recovered passage for JHN.1');
+      },
+      { timeout: 10000 },
+    );
+
+    // The first attempt failed, so the text on screen came from a retry.
+    await expect(passageAttempts).toBeGreaterThanOrEqual(2);
+
+    // No error was ever surfaced, and there is nothing for the user to click.
+    await expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    await expect(screen.queryByRole('button', { name: /try again/i })).not.toBeInTheDocument();
+  },
+};
+
 export const ChapterChangeLoadingOverlay: Story = {
   tags: ['integration'],
   args: {

--- a/packages/ui/src/components/bible-reader.stories.tsx
+++ b/packages/ui/src/components/bible-reader.stories.tsx
@@ -1141,6 +1141,71 @@ export const PassageHangsThenRecovers: Story = {
   },
 };
 
+/** Every `/v1/` path the worker saw, in order. Reset by the story's `beforeEach`. */
+let mountRequestPaths: string[] = [];
+
+/**
+ * A cold `BibleReader` mount asks the API for three things: the version, its
+ * book list, and the passage. Nothing else.
+ *
+ * Before YPE-4735 the same mount issued nine requests. In-flight deduplication
+ * in `ApiClient` collapsed the duplicate `useBooks` and `useVersion` call sites,
+ * and the version picker now defers its language and version lists until the
+ * user opens the popover.
+ *
+ * This is the only place the count is observable, because it needs the real
+ * client, the real hooks, and MSW running together.
+ */
+export const MountRequestCount: Story = {
+  tags: ['integration'],
+  args: {
+    defaultVersionId: 111,
+    defaultBook: 'JHN',
+    defaultChapter: '1',
+  },
+  beforeEach: () => {
+    mountRequestPaths = [];
+
+    const worker = getWorker();
+    const listener = ({ request }: { request: Request; requestId: string }) => {
+      const { pathname } = new URL(request.url);
+      if (pathname.startsWith('/v1/')) mountRequestPaths.push(pathname);
+    };
+
+    worker.events.on('request:start', listener);
+    return () => {
+      worker.events.removeListener('request:start', listener);
+    };
+  },
+  render: (args) => (
+    <div className="yv:h-screen yv:bg-background">
+      <BibleReader.Root {...args}>
+        <BibleReader.Content />
+        <BibleReader.Toolbar />
+      </BibleReader.Root>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    await waitFor(
+      async () => {
+        const renderer = canvasElement.querySelector('[data-slot="yv-bible-renderer"]');
+        await expect(renderer).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    // A request the render did not wait on would still be in flight here, so
+    // give the mount a beat to finish before counting.
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    await expect([...mountRequestPaths].sort()).toEqual([
+      '/v1/bibles/111',
+      '/v1/bibles/111/books',
+      '/v1/bibles/111/passages/JHN.1',
+    ]);
+  },
+};
+
 export const ChapterChangeLoadingOverlay: Story = {
   tags: ['integration'],
   args: {

--- a/packages/ui/src/components/bible-reader.stories.tsx
+++ b/packages/ui/src/components/bible-reader.stories.tsx
@@ -1066,6 +1066,81 @@ export const PassageRetriesAutomatically: Story = {
   },
 };
 
+/**
+ * The reported failure, end to end: the passage request is dispatched and never
+ * answered. The abort timer fires, the retry chain spends its attempts, the
+ * user gets a "Try again" button, and clicking it recovers the reader.
+ *
+ * `providerTimeout` drops the request timeout to 1500ms (the preview decorator
+ * reads it), so the whole retry budget completes in seconds rather than the
+ * 30-plus seconds the 10-second default would take.
+ */
+export const PassageHangsThenRecovers: Story = {
+  tags: ['integration'],
+  args: {
+    defaultVersionId: 111,
+    defaultBook: 'JHN',
+    defaultChapter: '1',
+  },
+  parameters: {
+    providerTimeout: 1500,
+    msw: {
+      handlers: [
+        http.get('*/v1/bibles/111/passages/:usfm', async () => {
+          await delay('infinite');
+          return HttpResponse.json({});
+        }),
+        ...globalHandlers,
+      ],
+    },
+  },
+  render: (args) => (
+    <div className="yv:h-screen yv:bg-background">
+      <BibleReader.Root {...args}>
+        <BibleReader.Content />
+        <BibleReader.Toolbar />
+      </BibleReader.Root>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    // Three attempts at 1500ms each, plus jittered backoff of up to 500ms and
+    // 1500ms between them. Worst case is a little over 6.5 seconds.
+    const retryButton = await screen.findByRole(
+      'button',
+      { name: /try again/i },
+      { timeout: 15000 },
+    );
+
+    const alert = await screen.findByRole('alert');
+    await expect(alert).toHaveTextContent(
+      "The Bible server couldn't be reached. Check your connection and try again.",
+    );
+
+    getWorker().use(
+      http.get('*/v1/bibles/111/passages/:usfm', ({ params }) => {
+        const usfm = params.usfm as string;
+        return HttpResponse.json({
+          id: usfm,
+          content: `<div class="p"><span class="verse">Recovered passage for ${usfm}.</span></div>`,
+          reference: usfm,
+        });
+      }),
+    );
+
+    await userEvent.click(retryButton);
+
+    await waitFor(
+      async () => {
+        const renderer = canvasElement.querySelector('[data-slot="yv-bible-renderer"]');
+        await expect(renderer?.textContent).toContain('Recovered passage for JHN.1');
+      },
+      { timeout: 5000 },
+    );
+
+    await expect(screen.queryByRole('button', { name: /try again/i })).not.toBeInTheDocument();
+  },
+};
+
 export const ChapterChangeLoadingOverlay: Story = {
   tags: ['integration'],
   args: {

--- a/packages/ui/src/components/bible-reader.stories.tsx
+++ b/packages/ui/src/components/bible-reader.stories.tsx
@@ -3,6 +3,7 @@ import { INTER_FONT, SOURCE_SERIF_FONT, UNTITLED_SERIF_FONT } from '@/lib/verse-
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { Highlight } from '@youversion/platform-core';
 import { delay, http, HttpResponse } from 'msw';
+import { getWorker } from 'msw-storybook-addon';
 import { useState } from 'react';
 import { expect, fn, screen, spyOn, userEvent, waitFor } from 'storybook/test';
 import mockBibles from '../test/mock-data/bibles.json';
@@ -928,6 +929,72 @@ export const ControlledFakeHost: Story = {
         </BibleReader.Root>
       </div>
     );
+  },
+};
+
+/**
+ * A 503 on the passage endpoint is retryable, so the error message carries a
+ * "Try again" button. The play function swaps the handler for a good response
+ * and asserts the click recovers the reader — the user-visible path out of the
+ * dead end reported in YPE-4735.
+ */
+export const PassageErrorRetry: Story = {
+  tags: ['integration'],
+  args: {
+    defaultVersionId: 111,
+    defaultBook: 'JHN',
+    defaultChapter: '1',
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('*/v1/bibles/111/passages/:usfm', () =>
+          HttpResponse.json({ message: 'Service unavailable' }, { status: 503 }),
+        ),
+        ...globalHandlers,
+      ],
+    },
+  },
+  render: (args) => (
+    <div className="yv:h-screen yv:bg-background">
+      <BibleReader.Root {...args}>
+        <BibleReader.Content />
+        <BibleReader.Toolbar />
+      </BibleReader.Root>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const alert = await screen.findByRole('alert', {}, { timeout: 5000 });
+    await expect(alert).toHaveTextContent(
+      'The Bible service is having trouble right now. Please try again in a moment.',
+    );
+
+    const retryButton = await screen.findByRole('button', { name: /try again/i });
+
+    // Swap the failing handler for a good one. `use` prepends a runtime handler,
+    // so it wins over the story's own parameters.msw handlers.
+    getWorker().use(
+      http.get('*/v1/bibles/111/passages/:usfm', ({ params }) => {
+        const usfm = params.usfm as string;
+        return HttpResponse.json({
+          id: usfm,
+          content: `<div class="p"><span class="verse">Recovered passage for ${usfm}.</span></div>`,
+          reference: usfm,
+        });
+      }),
+    );
+
+    await userEvent.click(retryButton);
+
+    await waitFor(
+      async () => {
+        const renderer = canvasElement.querySelector('[data-slot="yv-bible-renderer"]');
+        await expect(renderer?.textContent).toContain('Recovered passage for JHN.1');
+      },
+      { timeout: 5000 },
+    );
+
+    await expect(screen.queryByRole('button', { name: /try again/i })).not.toBeInTheDocument();
   },
 };
 

--- a/packages/ui/src/components/bible-reader.tsx
+++ b/packages/ui/src/components/bible-reader.tsx
@@ -695,6 +695,7 @@ function Content() {
     passage,
     loading: passageLoading,
     error: passageError,
+    refetch: refetchPassage,
   } = usePassage({
     versionId,
     usfm: usfmReference,
@@ -1060,6 +1061,7 @@ function Content() {
                 passage,
                 loading: isRefetching ? false : passageLoading,
                 error: passageError,
+                onRetry: refetchPassage,
               }}
             />
           </div>

--- a/packages/ui/src/components/bible-version-picker.stories.tsx
+++ b/packages/ui/src/components/bible-version-picker.stories.tsx
@@ -3,6 +3,9 @@ import { BibleVersionPicker, type RootProps } from './bible-version-picker';
 import { useState } from 'react';
 import { screen, userEvent, within, expect, waitFor } from 'storybook/test';
 import { http, HttpResponse, delay } from 'msw';
+import { getWorker } from 'msw-storybook-addon';
+import mockBibles from '../test/mock-data/bibles.json';
+import { globalHandlers } from '../test/mocks/handlers';
 import { BookOpenIcon } from './icons/book-open';
 import { Button } from './ui/button';
 import { RECENT_VERSIONS_KEY } from './bible-version-picker';
@@ -96,6 +99,89 @@ export const Loading: Story = {
         }),
       ],
     },
+  },
+};
+
+/**
+ * Paths of the picker's *list* requests, in order. `/v1/bibles/111` and
+ * `/v1/languages/en` look up one record each and are deliberately excluded.
+ */
+let listRequestPaths: string[] = [];
+
+/**
+ * The language and version lists live inside the popover, so the picker leaves
+ * them unfetched until the user opens it once (YPE-4735). A closed picker on a
+ * cold `BibleReader` mount used to cost four requests.
+ *
+ * The latch is sticky: closing the popover does not un-enable the hooks, because
+ * `useApiData` clears `data` when `enabled` goes true -> false and the list would
+ * blank out on every close.
+ */
+export const ListsDeferUntilOpened: Story = {
+  args: {
+    versionId: 111,
+    side: 'top',
+  },
+  tags: ['integration'],
+  parameters: {
+    msw: {
+      handlers: [
+        // Hold the list back long enough to see the panel's own loading state.
+        http.get('*/v1/bibles', async () => {
+          await delay(1000);
+          return HttpResponse.json(mockBibles.collections.default);
+        }),
+        ...globalHandlers,
+      ],
+    },
+  },
+  beforeEach: () => {
+    listRequestPaths = [];
+
+    const worker = getWorker();
+    const listener = ({ request }: { request: Request; requestId: string }) => {
+      const { pathname } = new URL(request.url);
+      if (pathname === '/v1/bibles' || pathname === '/v1/languages') {
+        listRequestPaths.push(pathname);
+      }
+    };
+
+    worker.events.on('request:start', listener);
+    return () => {
+      worker.events.removeListener('request:start', listener);
+    };
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // The trigger renders its abbreviation from its own single-version lookup,
+    // so it is readable without any list data.
+    const trigger = await canvas.findByRole('button', { name: /NIV/i }, { timeout: 10_000 });
+    await expect(listRequestPaths).toEqual([]);
+
+    await userEvent.click(trigger);
+    const dialog = await screen.findByRole('dialog');
+    await expect(dialog).toBeInTheDocument();
+
+    // The delayed handler is still pending here. The panel has to show its
+    // spinner, not the empty state, while the first fetch is in flight.
+    await expect(screen.queryByTestId('version-list')).not.toBeInTheDocument();
+    await expect(screen.queryByText('No versions found')).not.toBeInTheDocument();
+
+    await screen.findByTestId('version-list', undefined, { timeout: 10_000 });
+    const requestsAfterOpen = listRequestPaths.length;
+    await expect(requestsAfterOpen).toBeGreaterThan(0);
+
+    // Close and reopen. The lists stay enabled, so the data survives and no
+    // second round of requests goes out.
+    await userEvent.keyboard('{Escape}');
+    await waitFor(async () => {
+      await expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    await userEvent.click(trigger);
+    await expect(await screen.findByTestId('version-list')).toBeInTheDocument();
+    await expect(listRequestPaths.length).toBe(requestsAfterOpen);
   },
 };
 

--- a/packages/ui/src/components/bible-version-picker.tsx
+++ b/packages/ui/src/components/bible-version-picker.tsx
@@ -277,6 +277,19 @@ function Root({
   const [isPopoverOpenRaw, setIsPopoverOpenRaw] = useState(false);
   const isPopoverOpen = onVersionPickerPress ? false : isPopoverOpenRaw;
 
+  // The language and version lists are only ever read inside the popover, so
+  // they stay unfetched until the user opens it once. That takes four requests
+  // off the Bible Reader's cold mount (YPE-4735).
+  //
+  // The latch is sticky on purpose. `useApiData` clears `data` to `null` when
+  // `enabled` flips true -> false, so a latch that reset on close would blank
+  // the picker every time it closed.
+  const [hasOpenedPopover, setHasOpenedPopover] = useState(false);
+  // Host-driven mode never opens a popover, because `Root` returns below without
+  // one. The context it publishes still feeds the host's own composition, so the
+  // lists stay eager on that branch.
+  const listsEnabled = hasOpenedPopover || !!onVersionPickerPress;
+
   const resetLanguageSearch = useCallback(() => {
     setLanguageSearchQuery('');
   }, []);
@@ -290,6 +303,7 @@ function Root({
     (open: boolean) => {
       if (onVersionPickerPress) return;
       setIsPopoverOpenRaw(open);
+      if (open) setHasOpenedPopover(true);
       if (!open) {
         setSearchQuery('');
         setLanguageSearchQuery('');
@@ -308,21 +322,44 @@ function Root({
     });
   }, []);
 
-  const { languages, loading: languagesLoading } = useLanguages({
-    fields: ['id', 'display_names', 'speaking_population'],
+  const {
+    languages,
+    loading: languagesFetching,
+    error: languagesError,
+  } = useLanguages(
+    {
+      fields: ['id', 'display_names', 'speaking_population'],
+      page_size: '*',
+    },
+    { enabled: listsEnabled },
+  );
+
+  const {
+    versions,
+    loading: versionsFetching,
+    error: versionsError,
+  } = useVersions(selectedLanguageId, undefined, { enabled: listsEnabled });
+  const {
+    versions: versionsLanguageInfo,
+    loading: versionsLanguageInfoFetching,
+    error: versionsLanguageInfoError,
+  } = useVersions('*', undefined, {
+    enabled: listsEnabled,
+    fields: ['id', 'language_tag'],
     page_size: '*',
   });
 
-  const { versions, loading: versionsLoading } = useVersions(selectedLanguageId);
-  const { versions: versionsLanguageInfo, loading: versionsLanguageInfoLoading } = useVersions(
-    '*',
-    undefined,
-    {
-      fields: ['id', 'language_tag'],
-      page_size: '*',
-    },
-  );
-  const isLoadingLanguages = languagesLoading || versionsLanguageInfoLoading;
+  // `enabled` flips true on open, but the request does not start until the
+  // effect runs, so the raw `loading` flag is false for a frame. Treat "enabled
+  // with nothing fetched yet" as loading, or the list flashes its empty state
+  // before its spinner.
+  const isPending = (data: unknown, fetching: boolean, error: Error | null) =>
+    fetching || (listsEnabled && data === null && error === null);
+
+  const versionsLoading = isPending(versions, versionsFetching, versionsError);
+  const isLoadingLanguages =
+    isPending(languages, languagesFetching, languagesError) ||
+    isPending(versionsLanguageInfo, versionsLanguageInfoFetching, versionsLanguageInfoError);
   const filteredVersions = useFilteredVersions(
     versions?.data || [],
     searchQuery,
@@ -371,11 +408,14 @@ function Root({
   }, [languages, versionsLanguageInfo?.data, getLanguageDisplayName]);
 
   // pass zz to get the country languages based on IP Address
-  const { languages: countryLanguages } = useLanguages({
-    country: 'zz',
-    fields: ['id', 'display_names'],
-    page_size: '*',
-  });
+  const { languages: countryLanguages } = useLanguages(
+    {
+      country: 'zz',
+      fields: ['id', 'display_names'],
+      page_size: '*',
+    },
+    { enabled: listsEnabled },
+  );
 
   // Suggested languages = browser preference languages first, then API country
   // languages (via country:'zz' which detects country by IP). Both lists are

--- a/packages/ui/src/components/verse-of-the-day.tsx
+++ b/packages/ui/src/components/verse-of-the-day.tsx
@@ -131,11 +131,17 @@ export function VerseOfTheDay({
   const { t } = useTranslation(undefined, { i18n });
   const day = React.useMemo(() => dayOfYear || getDayOfYear(new Date()), [dayOfYear]);
   const verseRef = React.useRef<HTMLDivElement>(null);
-  const { data, loading: loadingVerseOfTheDay, error: errorVerseOfTheDay } = useVerseOfTheDay(day);
+  const {
+    data,
+    loading: loadingVerseOfTheDay,
+    error: errorVerseOfTheDay,
+    refetch: refetchVerseOfTheDay,
+  } = useVerseOfTheDay(day);
   const {
     passage,
     loading: loadingPassage,
     error: errorPassage,
+    refetch: refetchPassage,
   } = usePassage({
     versionId,
     usfm: data?.passage_id || '',
@@ -148,6 +154,11 @@ export function VerseOfTheDay({
   const theme = background || providerTheme;
 
   const isLoading = loadingPassage || loadingVerseOfTheDay || loadingVersion;
+
+  // The passage fetch is gated behind the verse-of-the-day response, so a VOTD
+  // failure is the one that has to be retried first; retrying the passage while
+  // `data.passage_id` is missing would do nothing.
+  const onRetry = errorVerseOfTheDay ? refetchVerseOfTheDay : refetchPassage;
 
   let referenceText = '';
   if (passage?.reference && version?.localized_abbreviation) {
@@ -249,6 +260,7 @@ export function VerseOfTheDay({
                 passage,
                 loading: isLoading,
                 error: errorPassage || errorVerseOfTheDay || null,
+                onRetry,
               }}
             />
           )}

--- a/packages/ui/src/components/verse.test.tsx
+++ b/packages/ui/src/components/verse.test.tsx
@@ -1065,6 +1065,113 @@ describe('BibleTextView - Error messaging', () => {
   });
 });
 
+describe('BibleTextView - Retry affordance', () => {
+  function createError(message: string, status?: number): Error {
+    return Object.assign(new Error(message), status === undefined ? {} : { status });
+  }
+
+  it('should render a retry button for a retryable error', async () => {
+    const { getByRole } = render(
+      <BibleTextView
+        reference="JHN.3.16"
+        versionId={3034}
+        passageState={{
+          passage: null,
+          loading: false,
+          error: createError('Request timeout after 10000ms'),
+          onRetry: vi.fn(),
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getByRole('button', { name: 'Try again' })).toBeInTheDocument();
+    });
+  });
+
+  it('should call onRetry when the retry button is clicked', async () => {
+    const onRetry = vi.fn();
+    const user = userEvent.setup();
+
+    const { getByRole } = render(
+      <BibleTextView
+        reference="JHN.3.16"
+        versionId={3034}
+        passageState={{
+          passage: null,
+          loading: false,
+          error: createError('Request failed with status 503', 503),
+          onRetry,
+        }}
+      />,
+    );
+
+    const retryButton = await waitFor(() => getByRole('button', { name: 'Try again' }));
+    await user.click(retryButton);
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not render a retry button for a 401', async () => {
+    const { getByRole, queryByRole } = render(
+      <BibleTextView
+        reference="JHN.3.16"
+        versionId={3034}
+        passageState={{
+          passage: null,
+          loading: false,
+          error: createError('Request failed with status 401', 401),
+          onRetry: vi.fn(),
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getByRole('alert')).toBeInTheDocument();
+    });
+    expect(queryByRole('button', { name: 'Try again' })).not.toBeInTheDocument();
+  });
+
+  it('should not render a retry button for a 404', async () => {
+    const { getByRole, queryByRole } = render(
+      <BibleTextView
+        reference="PRO.30.1"
+        versionId={2530}
+        passageState={{
+          passage: null,
+          loading: false,
+          error: createError('Bible passage PRO.30.1 for version 2530 not found', 404),
+          onRetry: vi.fn(),
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getByRole('alert')).toBeInTheDocument();
+    });
+    expect(queryByRole('button', { name: 'Try again' })).not.toBeInTheDocument();
+  });
+
+  it('should not render a retry button when the caller supplies no onRetry', async () => {
+    const { getByRole, queryByRole } = render(
+      <BibleTextView
+        reference="JHN.3.16"
+        versionId={3034}
+        passageState={{
+          passage: null,
+          loading: false,
+          error: createError('Request failed with status 503', 503),
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getByRole('alert')).toBeInTheDocument();
+    });
+    expect(queryByRole('button', { name: 'Try again' })).not.toBeInTheDocument();
+  });
+});
+
 describe('Verse.Html - onFootnotePress callback', () => {
   const htmlWithFootnote = `
     <div class="p">

--- a/packages/ui/src/components/verse.tsx
+++ b/packages/ui/src/components/verse.tsx
@@ -16,8 +16,9 @@ import { createPortal } from 'react-dom';
 import { ExclamationCircle } from '@/components/icons/exclamation-circle';
 import { Footnote } from '@/components/icons/footnote';
 import { LoaderIcon } from '@/components/icons/loader';
+import { Button } from '@/components/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import { getBibleTextErrorMessage } from '@/lib/bible-text-error';
+import { getBibleTextErrorMessage, isRetryableBibleTextError } from '@/lib/bible-text-error';
 import { cn } from '@/lib/utils';
 import { type FontFamily } from '@/lib/verse-html-utils';
 
@@ -111,6 +112,11 @@ export type BibleTextViewPassageState = {
   passage: PassageResult['passage'];
   loading: PassageResult['loading'];
   error: PassageResult['error'];
+  /**
+   * Retries the fetch that produced `error`. Supplied by the caller that owns
+   * the fetch; `BibleTextView` falls back to its own `usePassage` refetch.
+   */
+  onRetry: PassageResult['refetch'];
 };
 
 /**
@@ -253,8 +259,20 @@ const VerseFootnoteButton = memo(function VerseFootnoteButton({
 /**
  * Displays a verse-unavailable error message with a circular exclamation
  * icon and descriptive text.
+ *
+ * `onRetry` is only supplied for failures a retry can fix (see
+ * `isRetryableBibleTextError`). When it is absent the message is final and no
+ * button renders.
  */
-function VerseUnavailableMessage({ message }: { message: string }): React.ReactElement {
+function VerseUnavailableMessage({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry?: () => void;
+}): React.ReactElement {
+  const { t } = useTranslation(undefined, { i18n });
+
   return (
     <div
       role="alert"
@@ -263,6 +281,18 @@ function VerseUnavailableMessage({ message }: { message: string }): React.ReactE
     >
       <ExclamationCircle className="yv:size-5 yv:shrink-0 yv:text-foreground" />
       <p className="yv:m-0 yv:text-[13px] yv:font-medium yv:leading-tight">{message}</p>
+      {onRetry ? (
+        // Sized down from the `sm` default so the label sits on the message's
+        // 13px line rather than adding a second row to the alert.
+        <Button
+          variant="link"
+          size="sm"
+          onClick={onRetry}
+          className="yv:h-auto yv:shrink-0 yv:px-0 yv:text-[13px] yv:leading-tight"
+        >
+          {t('retryButton')}
+        </Button>
+      ) : null}
     </div>
   );
 }
@@ -566,6 +596,7 @@ export const BibleTextView = forwardRef<HTMLDivElement, BibleTextViewProps>(
       passage: fetchedPassage,
       loading: fetchedLoading,
       error: fetchedError,
+      refetch: fetchedRefetch,
     } = usePassage({
       versionId,
       usfm: reference,
@@ -581,6 +612,10 @@ export const BibleTextView = forwardRef<HTMLDivElement, BibleTextViewProps>(
       ? (passageState?.loading ?? false)
       : fetchedLoading;
     const currentError = hasProvidedPassageState ? (passageState?.error ?? null) : fetchedError;
+    // Same resolution rule as passage/loading/error: the caller that owns the
+    // fetch owns the retry. A caller that supplies passageState but no onRetry
+    // gets no button, which is the pre-existing behavior.
+    const currentRetry = hasProvidedPassageState ? passageState?.onRetry : fetchedRefetch;
 
     if (currentLoading && !currentPassage) {
       return (
@@ -603,7 +638,10 @@ export const BibleTextView = forwardRef<HTMLDivElement, BibleTextViewProps>(
     if (currentError) {
       return (
         <div ref={ref} data-yv-sdk data-yv-theme={currentTheme}>
-          <VerseUnavailableMessage message={getBibleTextErrorMessage(currentError, t)} />
+          <VerseUnavailableMessage
+            message={getBibleTextErrorMessage(currentError, t)}
+            onRetry={isRetryableBibleTextError(currentError) ? currentRetry : undefined}
+          />
         </div>
       );
     }

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -58,6 +58,7 @@
   "rateLimitedError": "The Bible service is receiving too many requests right now. Please wait a moment and try again.",
   "serverError": "The Bible service is having trouble right now. Please try again in a moment.",
   "genericPassageError": "We couldn't load this Bible passage. Please try again.",
+  "retryButton": "Try again",
   "copy": "Copy",
   "share": "Share",
   "verseActionsAriaLabel": "Verse actions",

--- a/packages/ui/src/lib/bible-text-error.test.ts
+++ b/packages/ui/src/lib/bible-text-error.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { isRetryableBibleTextError, type BibleTextError } from './bible-text-error';
+
+function createError(message: string, status?: number): BibleTextError {
+  return Object.assign(new Error(message), status === undefined ? {} : { status });
+}
+
+describe('isRetryableBibleTextError', () => {
+  const originalNavigator = globalThis.navigator;
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: originalNavigator,
+    });
+  });
+
+  function setOffline() {
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: { ...originalNavigator, onLine: false },
+    });
+  }
+
+  it('should not retry a 401', () => {
+    expect(isRetryableBibleTextError(createError('Request failed with status 401', 401))).toBe(
+      false,
+    );
+  });
+
+  it('should not retry a 403', () => {
+    expect(isRetryableBibleTextError(createError('Request failed with status 403', 403))).toBe(
+      false,
+    );
+  });
+
+  it('should not retry a 404', () => {
+    expect(
+      isRetryableBibleTextError(
+        createError('Bible passage PRO.30.1 for version 2530 not found', 404),
+      ),
+    ).toBe(false);
+  });
+
+  it('should retry a 429', () => {
+    expect(isRetryableBibleTextError(createError('Request failed with status 429', 429))).toBe(true);
+  });
+
+  it('should retry a 500', () => {
+    expect(isRetryableBibleTextError(createError('Request failed with status 500', 500))).toBe(true);
+  });
+
+  it('should retry a 503', () => {
+    expect(isRetryableBibleTextError(createError('Request failed with status 503', 503))).toBe(true);
+  });
+
+  it('should prioritize a 5xx status over "not found" in the message', () => {
+    expect(
+      isRetryableBibleTextError(
+        createError('Upstream dependency not found while handling request', 503),
+      ),
+    ).toBe(true);
+  });
+
+  it('should not retry a statusless "not found" message', () => {
+    expect(isRetryableBibleTextError(createError('Passage not found'))).toBe(false);
+  });
+
+  it('should retry when navigator reports offline', () => {
+    setOffline();
+    expect(isRetryableBibleTextError(createError('Unexpected connection state'))).toBe(true);
+  });
+
+  it('should not retry a 401 even when navigator reports offline', () => {
+    setOffline();
+    expect(isRetryableBibleTextError(createError('Request failed with status 401', 401))).toBe(
+      false,
+    );
+  });
+
+  it('should retry the SDK request timeout message', () => {
+    expect(isRetryableBibleTextError(createError('Request timeout after 10000ms'))).toBe(true);
+  });
+
+  it('should retry the Chrome transport failure message', () => {
+    expect(isRetryableBibleTextError(createError('Failed to fetch'))).toBe(true);
+  });
+
+  it('should retry the Firefox transport failure message', () => {
+    expect(
+      isRetryableBibleTextError(
+        createError('NetworkError when attempting to fetch resource'),
+      ),
+    ).toBe(true);
+  });
+
+  it('should retry the Safari transport failure message', () => {
+    expect(isRetryableBibleTextError(createError('Load failed'))).toBe(true);
+  });
+
+  it('should retry the React Native transport failure message', () => {
+    expect(isRetryableBibleTextError(createError('Network request failed'))).toBe(true);
+  });
+
+  it('should not retry an unrecognized error', () => {
+    expect(isRetryableBibleTextError(createError('Something unexpected happened'))).toBe(false);
+  });
+});

--- a/packages/ui/src/lib/bible-text-error.ts
+++ b/packages/ui/src/lib/bible-text-error.ts
@@ -1,6 +1,6 @@
 import type { TFunction } from 'i18next';
 
-type BibleTextError = Error & {
+export type BibleTextError = Error & {
   status?: number;
 };
 
@@ -47,4 +47,43 @@ export function getBibleTextErrorMessage(error: BibleTextError, t: TFunction): s
   }
 
   return t('genericPassageError');
+}
+
+/**
+ * Decides whether a failed Bible text fetch is worth retrying.
+ *
+ * Mirrors the guard order of `getBibleTextErrorMessage`: HTTP status first, then
+ * the message, then `navigator.onLine`. A 401, 403, or 404 is final — retrying
+ * cannot fix a bad app key, a forbidden app, or a passage that does not exist in
+ * the selected version. A 429, a 5xx, an offline device, and the transport and
+ * timeout message shapes are all transient, so the caller may offer a retry.
+ *
+ * Anything unrecognized returns `false`: an unknown failure gets a plain final
+ * message rather than a button that probably does nothing.
+ */
+export function isRetryableBibleTextError(error: BibleTextError): boolean {
+  const status = error.status;
+  const message = error.message.toLowerCase();
+
+  if (status === 401 || status === 403 || status === 404) {
+    return false;
+  }
+
+  if (status === 429) {
+    return true;
+  }
+
+  if (status !== undefined && status >= 500) {
+    return true;
+  }
+
+  if (message.includes('not found')) {
+    return false;
+  }
+
+  if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+    return true;
+  }
+
+  return isUnreachableServerError(message);
 }


### PR DESCRIPTION
[YPE-4735](https://lifechurch.atlassian.net/browse/YPE-4735) | [Artifacts](https://cloud.humanlayer.com/tasks/019fdce3-8c6a-7b17-9d17-29dea468a4e8/artifacts) | [PR Walkthrough (alpha)](https://cloud.humanlayer.com/artifacts/019fecb7-cf00-7c8b-83ad-23b2deaac769)

## What problems was I solving

A failed first load was terminal. The Bible Reader, Verse of the Day, and Bible
Card showed "The Bible server couldn't be reached" and stayed there. Nothing
retried. There was no button to press.

A cold `BibleReader` mount also sent 18 API requests. Only 3 of them were needed
to paint the first chapter. The other 15 made the failure more likely.

Success looks like this:

- A transient network failure recovers on its own.
- When it does not, the user gets a "Try again" button.
- A cold mount sends 3 requests, not 18.

## What user-facing changes did I ship

- **Automatic retry.** [`useApiData.ts`](https://github.com/youversion/platform-sdk-react/pull/323/files#diff-c35cc9f9757d61c37b477e8b3c54e5d4a61556e38b379c84b30d63f1bf57f27e) retries a failed request on its own. It retries a timeout, a transport failure, a 429, and a 5xx. It does not retry a 401, a 403, a 404, or a Zod error. The budget is 2 extra attempts and a 20-second wall clock, whichever runs out first. `loading` stays `true` for the whole chain, so the spinner does not flicker. Pass `retry: false` to opt out.
- **A "Try again" button.** [`verse.tsx`](https://github.com/youversion/platform-sdk-react/pull/323/files#diff-8e04cc5cbe013338272cbb26b436c9a1e0e4f5b9ff8ddbb05e355b50eae9e2bf) renders a button when automatic retry does not recover. The button appears only for failures a retry can fix. A 401, 403, or 404 stays a plain final message. `packages/ui` now exports `isRetryableBibleTextError`.
- **Fewer requests on mount.** [`client.ts`](https://github.com/youversion/platform-sdk-react/pull/323/files#diff-858339789c798051d9c13620bffce8ce860e7ad8ba18dba1c8711eb1f7d51a55) shares one in-flight GET between concurrent callers asking for the same URL and headers. [`bible-version-picker.tsx`](https://github.com/youversion/platform-sdk-react/pull/323/files#diff-0c0833df720c4698491de0ed46fc355f179eca40cd2cbe9484a527b3175919ef) waits for its popover to open before it loads the language and version lists. A cold mount now sends 3 requests, down from 18.
- **A configurable timeout.** [`YouVersionProvider.tsx`](https://github.com/youversion/platform-sdk-react/pull/323/files#diff-1beebead67e1e063537545e1b70f2736822bbdf074663a3d7f0cf0315304958b) accepts a `timeout` prop in milliseconds. The default is still 10000, so no integrator sees a change.

## How I implemented it

Five commits, one per phase. Read them in order.

### 1. Retry button ([`b1a8c7f`](https://github.com/youversion/platform-sdk-react/pull/323/commits/b1a8c7f))

Only `packages/ui` changes. Every Bible hook already returned `refetch`.

- [`bible-text-error.ts`](https://github.com/youversion/platform-sdk-react/pull/323/files#diff-f0743de82015313abdbfe2b79a08a2cd2b4bb622c500a679cc3a21f7d286467d) adds `isRetryableBibleTextError`. It mirrors the guard order of the message function. Anything unrecognized returns `false`.
- [`verse.tsx`](https://github.com/youversion/platform-sdk-react/pull/323/files#diff-8e04cc5cbe013338272cbb26b436c9a1e0e4f5b9ff8ddbb05e355b50eae9e2bf) resolves `onRetry` the same way it already resolved `passage`, `loading`, and `error`. The caller that owns the fetch owns the retry.
- The reader, the card, and Verse of the Day pass their `refetch` through. Verse of the Day is the exception: a VOTD failure retries the VOTD fetch, because the passage fetch is gated behind `data.passage_id`.

### 2. Automatic retry ([`9ef9d0d`](https://github.com/youversion/platform-sdk-react/pull/323/commits/9ef9d0d))

- [`retry-policy.ts`](https://github.com/youversion/platform-sdk-react/pull/323/files#diff-602a283a29301fb0e52574534bd30158633bc64bef05e50fe1042d134aab643a) is new. It owns the classification table, the budget constants, and jittered backoff over bases `[500, 1500]`.
- [`useApiData.ts`](https://github.com/youversion/platform-sdk-react/pull/323/files#diff-c35cc9f9757d61c37b477e8b3c54e5d4a61556e38b379c84b30d63f1bf57f27e) turns the `then`/`catch`/`finally` chain into a recursive `attempt(n)`. The wall clock starts once per `fetchData` call, not per attempt. `requestSeq` is re-checked twice: after the fetch, and again inside the backoff timer.
- The 20-second budget is fixed, not derived from the timeout. An integrator who sets a timeout above 20 seconds gets single-shot behavior, which is what the SDK did before.

### 3. Dedup, one shared client, configurable timeout ([`3357122`](https://github.com/youversion/platform-sdk-react/pull/323/commits/3357122))

- [`client.ts`](https://github.com/youversion/platform-sdk-react/pull/323/files#diff-858339789c798051d9c13620bffce8ce860e7ad8ba18dba1c8711eb1f7d51a55) adds an `inFlight` map. The entry is dropped when the promise settles, so this is in-flight sharing, not a response cache. Headers are part of the key, because Highlights GETs carry a Bearer token. `post` and `delete` are unchanged.
- **The correction.** The dedup map is private and per-instance. `useApiClient` built its client in a `useMemo`, which runs once per hook instance. Every sibling held its own map, so the dedup would have shipped and done nothing. [`YouVersionProvider.tsx`](https://github.com/youversion/platform-sdk-react/pull/323/files#diff-1beebead67e1e063537545e1b70f2736822bbdf074663a3d7f0cf0315304958b) now builds the one client the tree shares.
- [`useApiClient.ts`](https://github.com/youversion/platform-sdk-react/pull/323/files#diff-a6652ec4b1c880882f08fb23abef676c33790fdd067e978b67adf04c08d96c53) reads `context.apiClient` first. It falls back to a per-hook client, because a consumer can render `YouVersionContext.Provider` by hand.

### 4. Defer picker lists ([`5a7f73c`](https://github.com/youversion/platform-sdk-react/pull/323/commits/5a7f73c))

- [`bible-version-picker.tsx`](https://github.com/youversion/platform-sdk-react/pull/323/files#diff-0c0833df720c4698491de0ed46fc355f179eca40cd2cbe9484a527b3175919ef) gates four list hooks behind a sticky `hasOpenedPopover` latch. The latch is sticky because `useApiData` clears `data` when `enabled` flips true to false.
- Host-driven mode never opens a popover, so its lists stay eager.

### 5. Changeset and docs ([`55f2126`](https://github.com/youversion/platform-sdk-react/pull/323/commits/55f2126))

One minor changeset across all three packages. `packages/core/AGENTS.md` and
`packages/hooks/AGENTS.md` record the dedup, the timeout, the retry policy, and
the one-client-per-tree rule.

## Deviations from the plan

The plan is [`04-structure-outline-initial-load-resilience.md`](https://cloud.humanlayer.com/tasks/019fdce3-8c6a-7b17-9d17-29dea468a4e8/artifacts). It documents most of its own deviations inline.

### Implemented as planned

All five phases landed with the API shapes the plan named. The retry constants,
the classification table, the dedup key, the sticky latch, and the five
integration stories all match.

### Deviations and surprises

- **The one-client correction.** The plan put the dedup in `packages/core` alone. Implementation found it does nothing without a shared client instance, so `YouVersionProvider` now builds it. This is the most important thing to review.
- **`onRetry` is required, not optional.** The plan called for an optional field on `BibleTextViewPassageState`. It shipped required. All three internal callers supply it. An external consumer building `passageState` by hand must now supply it too.
- **Phase 3 collapsed into one commit.** The plan listed four commits inside that phase.
- **An `isPending` helper in the picker.** It treats "enabled but nothing fetched yet" as loading. Without it the list flashes its empty state for one frame before its spinner.

### Additions not in the plan

- [`__tests__/mocks/errors.ts`](https://github.com/youversion/platform-sdk-react/pull/323/files#diff-f7254737d5bebb50b45ff2887484b577466e1c4745bb40dce4ca13c83f5e2977) adds `createFinalError`. Retry-by-default broke 21 tests across 14 files that rejected with a bare `Error` and asserted the error surfaced. `createFinalError` pins a terminal status so each test keeps testing what it meant to test.
- `MockApiClient` is now constructible, because the provider calls `new ApiClient()`.
- `.storybook/preview.tsx` threads `parameters.providerTimeout`, so a hanging-endpoint story does not wait out 10 seconds per attempt.

### Planned but not implemented

Four handoffs are still open. None of them are code in this repo.

- Submit `retryButton` for translation in `platform-localization`.
- File the `AbortSignal` follow-up ticket.
- File the unbounded-body-read follow-up ticket.
- Tell QE to remove the `ensure_bible_reader_ready` SharedStep (YPE-4713).

## How to verify it

```bash
git fetch origin
git worktree add ../ype-4735 ype-4735-react-web-sdk-bible-reader-initial-load-can-enter-a-terminal-bible-server-couldnt-be-reached-state
cd ../ype-4735 && pnpm install
```

### Automated tests

```bash
pnpm test --force
```

1132 tests pass across 79 files: core 378, hooks 332, ui 422. Use `--force` to
bypass the Turbo cache, because a change in one package can break another.

### Manual testing

- [ ] Run `pnpm storybook` in `packages/ui`. Open `PassageHangsThenRecovers`.
- [ ] Set the network to offline in devtools. Load the reader. Confirm the button appears.
- [ ] Click "Try again" with the network back on. Confirm the chapter loads.
- [ ] Confirm the button sits on the message line, not a second row.
- [ ] Open the network tab. Mount the reader cold. Count 3 requests.
- [ ] Open the version picker. Confirm the list requests fire on the first open.
- [ ] Change chapter during a retry. Confirm the pending retry is abandoned.

## Description for the changelog

A failed Bible text load now retries automatically and offers a "Try again"
button, and a cold Bible Reader mount sends 3 API requests instead of 18.

[YPE-4735]: https://lifechurch.atlassian.net/browse/YPE-4735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds recoverable Bible-text loading and reduces cold-load request fanout.
- Adds automatic retry classification, retry limits, backoff, and manual retry UI.
- Shares concurrent GET requests through one provider-owned API client.
- Defers version-picker list requests until the picker opens.
- Adds provider-level request-timeout configuration and related coverage.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because the remaining direct locale-bundle edit causes the locale-ownership CI check to fail.

The retryButton entry remains in the upstream-owned English locale bundle, and the repository’s ownership check rejects locale changes from any author other than the localization synchronization bot.

**Files Needing Attention:** packages/ui/src/i18n/locales/en.json

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/hooks/src/useApiData.ts | Implements automatic retry with attempt limits, jittered backoff, stale-request checks, and a documented attempt-start budget. |
| packages/core/src/client.ts | Adds per-client in-flight GET deduplication keyed by URL and normalized per-call headers. |
| packages/hooks/src/context/YouVersionProvider.tsx | Creates the provider-wide API client and passes through configurable request timeout settings. |
| packages/ui/src/components/verse.tsx | Adds manual retry handling to recoverable Bible-text error states. |
| packages/ui/src/components/bible-version-picker.tsx | Defers picker list loading until the first popover open while preserving eager host-driven behavior. |
| packages/ui/src/i18n/locales/en.json | Still directly modifies an upstream-owned locale bundle, leaving the previously reported CI-blocking ownership failure unresolved. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant UI as Bible UI
  participant Hook as useApiData
  participant Client as Shared ApiClient
  participant API as Platform API
  UI->>Hook: Request Bible text
  Hook->>Client: GET
  Client->>API: Shared in-flight request
  alt Request succeeds
    API-->>Client: Bible data
    Client-->>Hook: Result
    Hook-->>UI: Render passage
  else Retryable failure
    API-->>Client: Timeout, transport, 429, or 5xx
    Hook->>Hook: Apply retry budget and backoff
    Hook->>Client: Retry GET
    alt Retries exhausted
      Hook-->>UI: Final error with Try again
      UI->>Hook: Manual refetch
    end
  end
```

<sub>Reviews (2): Last reviewed commit: ["docs(hooks): state the retry budget as a..."](https://github.com/youversion/platform-sdk-react/commit/2f068874e087be5c82e095ba5c0dd5a17e7c902a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51888562)</sub>

<!-- /greptile_comment -->