### PR TITLE
docs: guide agents to Kent-style testing

### DIFF
--- a/.changeset/calm-tests-guide.md
+++ b/.changeset/calm-tests-guide.md
@@ -1,0 +1,4 @@
+---
+---
+
+Docs-only: Kent-style testing guidance in AGENTS.md (no package release).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,38 @@ dependency.
 - **Tailwind CSS injection**: built CSS is embedded as a JS constant via tsup `define` and rendered by `YouVersionProvider` through React 19 `<style precedence>`. Consumers need no build step.
 
 ### Testing
-- One change in a package could break something in another package, so run the full test suite across all packages before pushing
+Style adapted from [Kent C. Dodds / kody testing principles](https://github.com/kentcdodds/kody/blob/main/docs/contributing/testing-principles.md). Package AGENTS add the flavor matrix for that layer.
+
+**Pick the lightest flavor that can falsify the behavior** (do not use “integration” as a style term — choose by capability):
+
+| Flavor | Package | Use when |
+| --- | --- | --- |
+| Pure unit | core / hooks utils / ui lib | Pure functions, transformers, machines |
+| Mocked client (MSW) | core | Client + Zod + error mapping against fake HTTP |
+| Hook + provider + factories | hooks | Hook state/cache/auth against stubbed core clients |
+| Component Vitest + RTL | ui | Behavior/a11y without Storybook chrome |
+| Storybook `play` | ui | User-visible journeys that need real composition/slots |
+| Live API (`INTEGRATION_TESTS=true`) | core | Tiny smoke that mocks cannot falsify |
+
+**Musts for new and edited tests:**
+- Prefer fewer, longer workflow tests; multiple related assertions in one test are fine
+- Treat each test like a manual tester’s script; name it so intent is obvious
+- Flat tests: one optional top-level `describe` for the module; no nested `describe`
+- No `beforeEach`/`afterEach`; inline setup or call factories that return ready-to-run objects
+- No shared mutable state across cases — if the next assertion needs the same subject, it belongs in the same test
+- Don’t test what TypeScript already guarantees
+- Assert behavior / stable contracts / roles — not i18n prose or instructional copy
+- Prefer local fakes/fixtures; avoid the public internet by default
+- High bar for slower flavors (Storybook play, live API) and for unlikely one-off regression tests
+- Assert intermediate states inside the workflow that causes them
+
+**Package ownership:** core owns HTTP+Zod+MSW; hooks own React state against stubbed clients; UI owns user-visible behavior against stubbed hooks/providers. Do not re-test a lower package’s contract unless the bug is at the boundary. Rare vertical smokes (e.g. highlight auth) may climb one rung for critical journeys.
+
+**Scope:** bind on new/edited tests. When touching a file, bend the cases you edit toward this style — no mass rewrite of untouched suites.
+
+**Before pushing:** run the full test suite across all packages — a change in one package can break another.
+
+Legacy tooling labels (`INTEGRATION_TESTS`, Storybook `tags: ['integration']`, `*.integration.test.tsx`) stay as-is; they are CI/discovery tags, not a style vocabulary.
 
 ## MORE DETAIL PER PACKAGE
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ Legacy tooling labels (`INTEGRATION_TESTS`, Storybook `tags: ['integration']`, `
 
 ## Learned User Preferences
 
-- When posting PR review comments on Cam's behalf, be concise, use https://conventionalcomments.org/, and attribute as Cursor review sent on behalf of Cam; confirm before posting when the action is unclear.
+- When posting PR review comments on the author's behalf, be concise, use https://conventionalcomments.org/, and attribute as a Cursor review sent on their behalf; confirm before posting when the action is unclear.
 - Prefer aligning React SDK auth/UI flows, logos, and copy with the Swift and Kotlin sister SDKs when those already define the pattern.
 - When the user shares a recording or insists on observed product behavior, re-investigate deeply rather than asserting they are wrong.
 - For local auth, highlights, and Bible demos, use `examples/vite-react` and load env vars from the monorepo root (not worktree-local envs).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ Legacy tooling labels (`INTEGRATION_TESTS`, Storybook `tags: ['integration']`, `
 
 ## Learned User Preferences
 
-- When posting PR review comments on the author's behalf, be concise, use https://conventionalcomments.org/, and attribute as a Cursor review sent on their behalf; confirm before posting when the action is unclear.
+- When posting PR review comments on the author's behalf, be concise, use https://conventionalcomments.org/, and confirm before posting when the action is unclear.
 - Prefer aligning React SDK auth/UI flows, logos, and copy with the Swift and Kotlin sister SDKs when those already define the pattern.
 - When the user shares a recording or insists on observed product behavior, re-investigate deeply rather than asserting they are wrong.
 - For local auth, highlights, and Bible demos, use `examples/vite-react` and load env vars from the monorepo root (not worktree-local envs).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,6 @@ Legacy tooling labels (`INTEGRATION_TESTS`, Storybook `tags: ['integration']`, `
 
 ## Learned User Preferences
 
-- When posting PR review comments on the author's behalf, be concise, use https://conventionalcomments.org/, and confirm before posting when the action is unclear.
 - Prefer aligning React SDK auth/UI flows, logos, and copy with the Swift and Kotlin sister SDKs when those already define the pattern.
 - When the user shares a recording or insists on observed product behavior, re-investigate deeply rather than asserting they are wrong.
 - For local auth, highlights, and Bible demos, use `examples/vite-react` and load env vars from the monorepo root (not worktree-local envs).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,3 +92,18 @@ Legacy tooling labels (`INTEGRATION_TESTS`, Storybook `tags: ['integration']`, `
 - `packages/core/AGENTS.md` – API clients, schemas, auth
 - `packages/hooks/AGENTS.md` – React hooks, providers
 - `packages/ui/AGENTS.md` – UI components, styling, build order
+
+## Learned User Preferences
+
+- When posting PR review comments on Cam's behalf, be concise, use https://conventionalcomments.org/, and attribute as Cursor review sent on behalf of Cam; confirm before posting when the action is unclear.
+- Prefer aligning React SDK auth/UI flows, logos, and copy with the Swift and Kotlin sister SDKs when those already define the pattern.
+- When the user shares a recording or insists on observed product behavior, re-investigate deeply rather than asserting they are wrong.
+- For local auth, highlights, and Bible demos, use `examples/vite-react` and load env vars from the monorepo root (not worktree-local envs).
+- Prefer Kent C. Dodds / kody-style testing guidance for new and edited tests (lightest falsifying flavor, fewer longer workflows); do not mass-rewrite untouched suites.
+
+## Learned Workspace Facts
+
+- Root and package `CLAUDE.md` files are symlinks to the matching `AGENTS.md` — edit `AGENTS.md` only.
+- Bible chapter HTML from the API is YVDOM; consumers need transformed HTML before display — raw YVDOM (milestone verse markers, cross-paragraph verses, mixed footnotes) is not end-user-ready.
+- Sister repos `platform-sdk-swift` and `platform-sdk-kotlin` are cross-platform references for Sign-In UI, logos, and i18n strings.
+- Highlight auth UX: unsigned-in highlight opens Sign In with a highlights reason (permission included in that flow); a separate permission dialog is only for already-signed-in users missing scope — avoid sign-in then an immediate second dialog.

--- a/docs/adding-a-core-endpoint.md
+++ b/docs/adding-a-core-endpoint.md
@@ -24,8 +24,9 @@ for every input and output type.
    response.
 4. **Export from the public API** in `src/index.ts` so consumers can import the
    client and its types.
-5. **Add tests.** Unit tests with MSW for mocked responses. Integration tests are
-   optional and guarded by `INTEGRATION_TESTS=true`.
+5. **Add tests.** Prefer mocked-client (MSW) workflow tests; see
+   `packages/core/AGENTS.md` Testing. Live API smokes are optional and guarded by
+   `INTEGRATION_TESTS=true`.
 
 ## Constraints
 

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -116,6 +116,15 @@ See `docs/adding-a-core-endpoint.md`.
 
 ## TESTING
 
-- Mocking: MSW for API endpoints
-- Integration tests are guarded by `INTEGRATION_TESTS=true`. They run in CI or on
-  demand only — default to mocked tests.
+Follow root `AGENTS.md` Testing (Kent-style musts). This package’s flavors:
+
+| Flavor | Use when | Avoid when |
+| --- | --- | --- |
+| Pure unit | Transformers, storage, pure helpers | Needs HTTP |
+| Mocked client (MSW) | Client + Zod + error mapping against fake HTTP (default for client tests) | Hook/UI orchestration |
+| Live API (`INTEGRATION_TESTS=true`) | Tiny smoke mocks cannot falsify; CI or on-demand only | Capability-by-capability coverage |
+
+- Run: `pnpm --filter @youversion/platform-core test`
+- Framework: Vitest (Node)
+- MSW handlers/helpers: prefer shared factories under `__tests__/` (e.g. `handlers.ts`); import/call them inside each test — do not hide setup in `beforeEach`
+- Do not re-prove hook/UI orchestration here

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -116,7 +116,7 @@ See `docs/adding-a-core-endpoint.md`.
 
 ## TESTING
 
-Follow root `AGENTS.md` Testing (Kent-style musts). This package’s flavors:
+Follow root `AGENTS.md` Testing. This package’s flavors:
 
 | Flavor | Use when | Avoid when |
 | --- | --- | --- |

--- a/packages/hooks/AGENTS.md
+++ b/packages/hooks/AGENTS.md
@@ -54,6 +54,14 @@ signature.
 
 ## TESTING
 
-- Mock object factories live in `__tests__/mocks`. This package does **not** use
-  MSW — hooks delegate HTTP to core, so core owns the request mocking.
-- Wrap hooks in the real provider in tests so they see the same context as in the app.
+Follow root `AGENTS.md` Testing (Kent-style musts). This package’s flavors:
+
+| Flavor | Use when | Avoid when |
+| --- | --- | --- |
+| Pure unit | Utilities (`extractTextFromHTML`, etc.) | Needs React providers |
+| Hook + provider + factories | Hook state, cache, auth, refetch against stubbed core clients | Re-testing core HTTP/Zod parsing |
+
+- Run: `pnpm --filter @youversion/platform-react-hooks test`
+- Framework: Vitest (jsdom) + React Testing Library
+- Mock object factories live in `__tests__/mocks`. This package does **not** use MSW — core owns request mocking
+- Wrap hooks in the real provider so they see the same context as in the app; build ready-to-run wrappers via factories, not `beforeEach`

--- a/packages/hooks/AGENTS.md
+++ b/packages/hooks/AGENTS.md
@@ -54,7 +54,7 @@ signature.
 
 ## TESTING
 
-Follow root `AGENTS.md` Testing (Kent-style musts). This package’s flavors:
+Follow root `AGENTS.md` Testing. This package’s flavors:
 
 | Flavor | Use when | Avoid when |
 | --- | --- | --- |

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -48,9 +48,20 @@ Storybook stories are the live reference for every component's props and states.
 type-checked; prefer them over any prose description of a component's API.
 
 ## TESTING
-- **Prefer Storybook** for UI component tests using the `play` function
-- Every Storybook test with a play function needs `tags: ['integration']`
-- Vitest + jsdom for unit tests (`*.test.tsx`); setup is `src/test/setup.ts`
+
+Follow root `AGENTS.md` Testing (Kent-style musts). This package’s flavors:
+
+| Flavor | Use when | Avoid when |
+| --- | --- | --- |
+| Pure unit | Lib helpers (USFM, projection, pending highlight, etc.) | Needs a rendered component |
+| Component Vitest + RTL | Default for component behavior/a11y (`*.test.tsx`) | Journey needs real composition/slots |
+| Storybook `play` | User-visible composition journeys (reader, pickers, dialogs) | Fast leaf logic / edge cases Vitest can falsify |
+| Vertical smoke | Rare critical journeys that wire real hooks (e.g. highlight auth) | Re-testing core/hooks contracts |
+
+- Default: Vitest + jsdom + RTL; setup is `src/test/setup.ts`
+- Storybook `play` is the higher rung — use when composition/slots matter; every play story still needs tooling tag `tags: ['integration']` (CI discovery, not a style term)
+- Assert roles/behavior, not localized copy blobs
+- Do not talk to the network from UI tests; stub hooks/providers unless writing an intentional vertical smoke
 
 ## CRITICAL
 - **No module side effects**: styles are rendered via React 19 `<style precedence>` in the `YouVersionProvider` wrapper

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -49,7 +49,7 @@ type-checked; prefer them over any prose description of a component's API.
 
 ## TESTING
 
-Follow root `AGENTS.md` Testing (Kent-style musts). This package’s flavors:
+Follow root `AGENTS.md` Testing. This package’s flavors:
 
 | Flavor | Use when | Avoid when |
 | --- | --- | --- |

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -59,6 +59,8 @@ Follow root `AGENTS.md` Testing (Kent-style musts). This package’s flavors:
 | Vertical smoke | Rare critical journeys that wire real hooks (e.g. highlight auth) | Re-testing core/hooks contracts |
 
 - Default: Vitest + jsdom + RTL; setup is `src/test/setup.ts`
+- Run unit/RTL: `pnpm --filter @youversion/platform-react-ui test` (`vitest --project unit` only — does **not** run Storybook play)
+- Run Storybook `play` / tagged stories: `pnpm --filter @youversion/platform-react-ui test:integration` (or from `packages/ui`: `pnpm test:integration`)
 - Storybook `play` is the higher rung — use when composition/slots matter; every play story still needs tooling tag `tags: ['integration']` (CI discovery, not a style term)
 - Assert roles/behavior, not localized copy blobs
 - Do not talk to the network from UI tests; stub hooks/providers unless writing an intentional vertical smoke


### PR DESCRIPTION
## Summary

Agent guides now teach the lightest test flavor that can falsify a behavior, and prefer fewer longer workflow tests. Learned preferences and workspace facts that the Testing rewrite removed are restored.

## Changes

1. Root Testing section states shared musts and the flavor ladder for all packages.
2. Core, hooks, and UI package guides add local flavor matrices and run notes.
3. UI default is Vitest and RTL. Storybook play covers composition journeys only.
4. Core endpoint docs point at mocked-client tests. They no longer use "integration" as style language.
5. Empty changeset marks this as a no-release docs change.
6. Learned User Preferences and Learned Workspace Facts return to the root agent guide.

## Test plan

- Not tested

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates repository and package-level agent guides to prefer the lightest testing flavor capable of falsifying behavior.
- Adds testing-flavor matrices and package-specific commands for core, hooks, and UI.
- Documents the separate UI command that executes tagged Storybook play tests.
- Updates endpoint-testing guidance and includes an intentional empty changeset for this documentation-only change.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| AGENTS.md | Establishes shared testing principles, package ownership boundaries, and restored workspace guidance. |
| packages/core/AGENTS.md | Documents core testing flavors, mocked-client defaults, and the package test command. |
| packages/hooks/AGENTS.md | Documents hook/provider testing conventions and the hooks package test command. |
| packages/ui/AGENTS.md | Documents RTL versus Storybook testing responsibilities and resolves the prior omission by identifying the separate play-test command. |
| docs/adding-a-core-endpoint.md | Aligns endpoint documentation with mocked-client workflow terminology. |
| .changeset/calm-tests-guide.md | Records the documentation-only change without triggering a package release. |

<sub>Reviews (6): Last reviewed commit: ["docs: remove PR review preference bullet"](https://github.com/youversion/platform-sdk-react/commit/3313aeebf2485847d703b7051f4031fe43abe955) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52325825)</sub>

<!-- /greptile_comment -->