### PR TITLE
docs: name Life.Church Operations, LLC as LICENSE copyright owner

### DIFF
--- a/.changeset/ype-4654-license-copyright.md
+++ b/.changeset/ype-4654-license-copyright.md
@@ -1,0 +1,4 @@
+---
+---
+
+Empty changeset: LICENSE appendix copyright fill-in only. No package release.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Life.Church Operations, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

The Apache LICENSE appendix now names Life.Church Operations, LLC as the copyright owner (YPE-4654). The wording matches the React Native Expo packages so partner legal review does not stop on an empty template.

## Changes

1. Partners who read the LICENSE see Life.Church Operations, LLC on the copyright line.
2. An empty changeset marks this as a no-release change.

## Test plan

- Made sure that LICENSE line 189 equals `   Copyright 2026 Life.Church Operations, LLC`
- Made sure that `git diff` shows one LICENSE line change plus the empty changeset

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces the placeholder copyright notice in the Apache License appendix with Life.Church Operations, LLC and records the documentation-only update with an empty changeset.
- Names Life.Church Operations, LLC as the 2026 copyright owner.
- Adds an intentional no-release changeset.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable issues identified.

The license wording matches the stated intent, and the accompanying empty changeset satisfies the repository requirement for documentation-only changes without initiating a package release.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| LICENSE | Replaces the Apache License appendix placeholder with the intended copyright owner and year. |
| .changeset/ype-4654-license-copyright.md | Adds a valid empty changeset documenting that the license-only update requires no package release. |

<sub>Reviews (1): Last reviewed commit: ["docs: name Life.Church Operations, LLC a..."](https://github.com/youversion/platform-sdk-react/commit/ede8500440eec8b1e44c45f8bce15df5c75f7f14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54407160)</sub>

<!-- /greptile_comment -->