### PR TITLE
docs: add Cursor Cloud specific agent instructions

### DIFF
--- a/.changeset/cursor-cloud-agents.md
+++ b/.changeset/cursor-cloud-agents.md
@@ -1,0 +1,4 @@
+---
+---
+
+Empty changeset: Cursor Cloud agent notes in AGENTS.md only. No package release.

--- a/.changeset/cursor-cloud-agents.md
+++ b/.changeset/cursor-cloud-agents.md
@@ -1,4 +1,4 @@
 ---
 ---
 
-Empty changeset: Cursor Cloud agent notes in AGENTS.md only. No package release.
+Empty changeset: Cursor Cloud agent notes plus AGENTS.md rightsizing. No package release.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,30 +29,5 @@ Release, versioning, or publishing: read `PUBLISHING.md`; decisions live in `doc
 ## Domain
 Domain terms (highlight, passage, Bible version, auth flow): read `CONTEXT.md`.
 
-## Cursor Cloud specific instructions
-
-This repo is an SDK monorepo, not a backend. There is no Docker Compose, database, or local API to start. The only long-running process for a product walkthrough is the Vite demo (`examples/vite-react`), which talks to the hosted YouVersion Platform API.
-
-Standard install/lint/test/build/dev commands live in `CONTRIBUTING.md` and root `package.json`. Prefer those over reinventing them.
-
-### Env files (gitignored)
-
-Core unit tests use MSW but still fail if `YVP_API_HOST` is unset (`packages/core/src/__tests__/handlers.ts`). Copy the examples before `pnpm test`:
-
-- `packages/core/.env.example` → `packages/core/.env.local` (`YVP_API_HOST=api.youversion.com`; a placeholder `YVP_APP_KEY` is enough for mocked tests)
-- `packages/ui/.env.example` → `packages/ui/.env.local` (Storybook)
-- `examples/vite-react/.env.example` → `examples/vite-react/.env.local` (`VITE_YVP_APP_KEY` required for live Bible content)
-
-Get a real app key from https://platform.youversion.com. Without `VITE_YVP_APP_KEY`, the demo renders the SDK missing-app-key panel instead of the Bible reader.
-
-### Running the demo
-
-`pnpm dev:web` is stale (it still filters a removed `nextjs` package). Start the demo with:
-
-```bash
-pnpm --filter vite-react exec vite --host 127.0.0.1 --port 5173
-```
-
-`pnpm --filter vite-react dev -- --host 127.0.0.1` does **not** bind IPv4: pnpm already inserts `--`, so Vite sees `-- --host` and listens on `::1` only. `curl http://127.0.0.1:5173` then fails even though `http://localhost:5173` works.
-
-After `pnpm build`, a real `YVP_APP_KEY` lets you call `@youversion/platform-core` from `packages/core` (dotenv loads `.env.local`) to fetch versions and a passage such as `JHN.3.16`. Auth/highlights also need a YouVersion account and a registered redirect URL (`http://localhost:5173` for the demo). Storybook is optional (`pnpm --filter @youversion/platform-react-ui storybook`, port 6006).
+## Cursor Cloud
+Cloud VM, env files, Vite bind, or demo startup: read `docs/cursor-cloud.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,3 +28,31 @@ Release, versioning, or publishing: read `PUBLISHING.md`; decisions live in `doc
 
 ## Domain
 Domain terms (highlight, passage, Bible version, auth flow): read `CONTEXT.md`.
+
+## Cursor Cloud specific instructions
+
+This repo is an SDK monorepo, not a backend. There is no Docker Compose, database, or local API to start. The only long-running process for a product walkthrough is the Vite demo (`examples/vite-react`), which talks to the hosted YouVersion Platform API.
+
+Standard install/lint/test/build/dev commands live in `CONTRIBUTING.md` and root `package.json`. Prefer those over reinventing them.
+
+### Env files (gitignored)
+
+Core unit tests use MSW but still fail if `YVP_API_HOST` is unset (`packages/core/src/__tests__/handlers.ts`). Copy the examples before `pnpm test`:
+
+- `packages/core/.env.example` → `packages/core/.env.local` (`YVP_API_HOST=api.youversion.com`; a placeholder `YVP_APP_KEY` is enough for mocked tests)
+- `packages/ui/.env.example` → `packages/ui/.env.local` (Storybook)
+- `examples/vite-react/.env.example` → `examples/vite-react/.env.local` (`VITE_YVP_APP_KEY` required for live Bible content)
+
+Get a real app key from https://platform.youversion.com. Without `VITE_YVP_APP_KEY`, the demo renders the SDK missing-app-key panel instead of the Bible reader.
+
+### Running the demo
+
+`pnpm dev:web` is stale (it still filters a removed `nextjs` package). Start the demo with:
+
+```bash
+pnpm --filter vite-react exec vite --host 127.0.0.1 --port 5173
+```
+
+`pnpm --filter vite-react dev -- --host 127.0.0.1` does **not** bind IPv4: pnpm already inserts `--`, so Vite sees `-- --host` and listens on `::1` only. `curl http://127.0.0.1:5173` then fails even though `http://localhost:5173` works.
+
+After `pnpm build`, a real `YVP_APP_KEY` lets you call `@youversion/platform-core` from `packages/core` (dotenv loads `.env.local`) to fetch versions and a passage such as `JHN.3.16`. Auth/highlights also need a YouVersion account and a registered redirect URL (`http://localhost:5173` for the demo). Storybook is optional (`pnpm --filter @youversion/platform-react-ui storybook`, port 6006).

--- a/docs/cursor-cloud.md
+++ b/docs/cursor-cloud.md
@@ -28,10 +28,22 @@ Do not put an extra `--` before `--host`. `pnpm --filter vite-react dev -- --hos
 
 ## Live core client
 
-After `pnpm build`, source `packages/core/.env.local` into the shell before calling `@youversion/platform-core`. Test scripts load that file via `dotenv-cli`; the runtime client does not.
+After `pnpm build`, source `packages/core/.env.local` and pass those values into `ApiClient`. Test scripts load the file via `dotenv-cli`; the runtime client reads only the config object you give it.
 
 ```bash
 set -a && . packages/core/.env.local && set +a
+cd packages/core
+```
+
+```js
+import { ApiClient, BibleClient } from '@youversion/platform-core';
+
+const apiClient = new ApiClient({
+  appKey: process.env.YVP_APP_KEY,
+  apiHost: process.env.YVP_API_HOST,
+});
+const bibleClient = new BibleClient(apiClient);
+await bibleClient.getPassage(3034, 'JHN.3.16');
 ```
 
 Auth/highlights also need a YouVersion account and a registered redirect URL (`http://localhost:5173` for the demo). Storybook is optional (`pnpm --filter @youversion/platform-react-ui storybook`, port 6006).

--- a/docs/cursor-cloud.md
+++ b/docs/cursor-cloud.md
@@ -1,0 +1,27 @@
+# Cursor Cloud
+
+This repo is an SDK monorepo, not a backend. There is no Docker Compose, database, or local API to start. The only long-running process for a product walkthrough is the Vite demo (`examples/vite-react`), which talks to the hosted YouVersion Platform API.
+
+Standard install/lint/test/build/dev commands live in `CONTRIBUTING.md` and root `package.json`.
+
+## Env files (gitignored)
+
+Core unit tests use MSW but still throw if `YVP_API_HOST` is unset (`packages/core/src/__tests__/handlers.ts`). Copy the examples before `pnpm test`:
+
+- `packages/core/.env.example` → `packages/core/.env.local` (`YVP_API_HOST=api.youversion.com`; a placeholder `YVP_APP_KEY` is enough for mocked tests)
+- `packages/ui/.env.example` → `packages/ui/.env.local` (Storybook)
+- `examples/vite-react/.env.example` → `examples/vite-react/.env.local` (`VITE_YVP_APP_KEY` required for live Bible content)
+
+Get a real app key from https://platform.youversion.com. Without `VITE_YVP_APP_KEY`, the demo renders the SDK missing-app-key panel instead of the Bible reader.
+
+## Running the demo
+
+`pnpm dev:web` is stale (it still filters a removed `nextjs` package). Start the demo with:
+
+```bash
+pnpm --filter vite-react exec vite --host 127.0.0.1 --port 5173
+```
+
+`pnpm --filter vite-react dev -- --host 127.0.0.1` does not bind IPv4: pnpm already inserts `--`, so Vite sees `-- --host` and listens on `::1` only. `curl http://127.0.0.1:5173` then fails even though `http://localhost:5173` works.
+
+After `pnpm build`, a real `YVP_APP_KEY` lets you call `@youversion/platform-core` from `packages/core` (dotenv loads `.env.local`) to fetch versions and a passage such as `JHN.3.16`. Auth/highlights also need a YouVersion account and a registered redirect URL (`http://localhost:5173` for the demo). Storybook is optional (`pnpm --filter @youversion/platform-react-ui storybook`, port 6006).

--- a/docs/cursor-cloud.md
+++ b/docs/cursor-cloud.md
@@ -19,9 +19,19 @@ Get a real app key from https://platform.youversion.com. Without `VITE_YVP_APP_K
 `pnpm dev:web` is stale (it still filters a removed `nextjs` package). Start the demo with:
 
 ```bash
-pnpm --filter vite-react exec vite --host 127.0.0.1 --port 5173
+pnpm --filter vite-react dev --host 127.0.0.1 --port 5173
 ```
 
-`pnpm --filter vite-react dev -- --host 127.0.0.1` does not bind IPv4: pnpm already inserts `--`, so Vite sees `-- --host` and listens on `::1` only. `curl http://127.0.0.1:5173` then fails even though `http://localhost:5173` works.
+Do not put an extra `--` before `--host`. `pnpm --filter vite-react dev -- --host 127.0.0.1` becomes `vite -- --host 127.0.0.1`; Vite then ignores `--host` and listens on `localhost` (often `::1` only), so `curl http://127.0.0.1:5173` fails.
 
-After `pnpm build`, a real `YVP_APP_KEY` lets you call `@youversion/platform-core` from `packages/core` (dotenv loads `.env.local`) to fetch versions and a passage such as `JHN.3.16`. Auth/highlights also need a YouVersion account and a registered redirect URL (`http://localhost:5173` for the demo). Storybook is optional (`pnpm --filter @youversion/platform-react-ui storybook`, port 6006).
+`pnpm --filter vite-react exec vite --host 127.0.0.1 --port 5173` is equivalent.
+
+## Live core client
+
+After `pnpm build`, source `packages/core/.env.local` into the shell before calling `@youversion/platform-core`. Test scripts load that file via `dotenv-cli`; the runtime client does not.
+
+```bash
+set -a && . packages/core/.env.local && set +a
+```
+
+Auth/highlights also need a YouVersion account and a registered redirect URL (`http://localhost:5173` for the demo). Storybook is optional (`pnpm --filter @youversion/platform-react-ui storybook`, port 6006).

--- a/docs/cursor-cloud.md
+++ b/docs/cursor-cloud.md
@@ -43,7 +43,7 @@ const apiClient = new ApiClient({
   apiHost: process.env.YVP_API_HOST,
 });
 const bibleClient = new BibleClient(apiClient);
-await bibleClient.getPassage(3034, 'JHN.3.16');
+await bibleClient.getPassage(3034, 'JHN.3.16', 'text');
 ```
 
 Auth/highlights also need a YouVersion account and a registered redirect URL (`http://localhost:5173` for the demo). Storybook is optional (`pnpm --filter @youversion/platform-react-ui storybook`, port 6006).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -35,6 +35,10 @@ core owns HTTP+Zod+MSW; hooks own React state against stubbed clients; UI owns u
 
 Bind on new/edited tests. When touching a file, bend the cases you edit toward this style — no mass rewrite of untouched suites.
 
+## Env
+
+Missing `YVP_API_HOST` or other env files: read `docs/cursor-cloud.md`.
+
 ## Before pushing
 
 Run the full test suite across all packages — a change in one package can break another.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` so future cloud agents can run tests and the Vite demo without rediscovering env-file and IPv4-bind gotchas.

This is a no-release docs/tooling change, so it includes an empty changeset.

## What was verified in the cloud VM

- `pnpm install`, `pnpm lint`, `pnpm typecheck`, `pnpm build`, and `pnpm test` all pass
- Core SDK hello-world: fetched English Bible versions and John 3:16 from `api.youversion.com`
- Vite demo at `http://127.0.0.1:5173` loaded John 1, navigated to John 2, Verse of the Day, and the Bible Card

[vite_demo_bible_reader_walkthrough.mp4](https://cursor.com/agents/bc-665e859b-67a4-44ac-83e2-cc26ed9787f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvite_demo_bible_reader_walkthrough.mp4)

[Bible reader John 1](https://cursor.com/agents/bc-665e859b-67a4-44ac-83e2-cc26ed9787f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_bible_reader_john1.png)
[Bible reader John 2](https://cursor.com/agents/bc-665e859b-67a4-44ac-83e2-cc26ed9787f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_bible_reader_john2.png)
[Verse of the Day Romans 6:5](https://cursor.com/agents/bc-665e859b-67a4-44ac-83e2-cc26ed9787f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_verse_of_the_day_romans65.png)
[Bible Card John 3:16](https://cursor.com/agents/bc-665e859b-67a4-44ac-83e2-cc26ed9787f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_bible_card_john316.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-665e859b-67a4-44ac-83e2-cc26ed9787f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-665e859b-67a4-44ac-83e2-cc26ed9787f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds focused Cursor Cloud setup and troubleshooting documentation, with an intentional empty changeset.
- Links cloud-agent guidance from `AGENTS.md` and testing documentation.
- Documents environment setup, IPv4 Vite startup, and a built-core API walkthrough.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/cursor-cloud.md | Adds cloud-VM environment, Vite startup, and live core-client instructions; the previously reported runtime configuration, passage-format, and separator concerns are resolved or invalid. |
| AGENTS.md | Routes Cursor Cloud setup questions to the new dedicated guide. |
| docs/testing.md | Directs environment-related test failures to the Cursor Cloud documentation. |
| .changeset/cursor-cloud-agents.md | Records the documentation-only change as an intentional empty changeset. |

<sub>Reviews (4): Last reviewed commit: ["docs: use text format in the live core p..."](https://github.com/youversion/platform-sdk-react/commit/cca376047338d3f1fdbd9baca5c934ccacaad1f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54472424)</sub>

<!-- /greptile_comment -->