### PR TITLE
feat: filter which Bible versions the SDK offers (YPE-4657)

### DIFF
--- a/.changeset/ype-4657-version-filters.md
+++ b/.changeset/ype-4657-version-filters.md
@@ -1,0 +1,7 @@
+---
+"@youversion/platform-core": minor
+"@youversion/platform-react-hooks": minor
+"@youversion/platform-react-ui": minor
+---
+
+Add app-wide version filters (Swift SDK parity) — new `YouVersionProvider` props `permittedVersionIds`, `excludedVersionIds`, and `permittedLanguageTags` restrict which Bible versions the SDK offers. Exclusion is checked first and beats permission, the two allowlists are ANDed, an unset prop is unrestricted, and an **empty array permits nothing**. Enforcement is list-only: `BibleClient.getVersions`, `LanguagesClient.getLanguages`, `useVersions`, `useLanguages`, and the version picker (including its recently-used versions) return filtered results, while fetching or rendering a version by id is never blocked — components render a filtered-out `versionId` and log a development-only warning once per id, so deep links and saved reading positions survive a config change. Core also exports the `isVersionPermitted` predicate and the three matching `YouVersionPlatformConfiguration` statics for non-React consumers. The props are set-at-init: changing them affects future fetches only.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,6 +32,37 @@ the API boundary only.
 A highlight's fill, a 6-character lowercase hex string without `#`
 (`fff9b1`). Uppercase input is accepted and normalized at the API boundary.
 
+## Version filters
+
+The app-wide configuration triple (YPE-4657, Swift parity) that restricts
+which Bible versions the SDK offers: **permitted versions**, **excluded
+versions**, and **permitted language tags**. Filters shape what the SDK
+*offers* (version lists, language lists, the version picker); they never
+forbid fetching or rendering a version directly by id (decided in ADR-0005).
+
+## Permitted versions
+
+Allowlist of **Bible version** ids (`permittedVersionIds`). Unset means
+unrestricted. An **empty list permits nothing** — empty and unset are
+deliberately different (Swift parity). ANDed with **permitted language
+tags**: a version must pass both.
+
+## Excluded versions
+
+Denylist of **Bible version** ids (`excludedVersionIds`). Exclusion beats
+permission: a version named in both lists is excluded.
+
+## Permitted language tags
+
+Allowlist of BCP-47 language tags (`permittedLanguageTags`). Really a
+version filter: it drops versions whose language tag is not permitted.
+It is the only filter `getLanguages` applies: excluding every version in a
+language still leaves that language in the language list. The picker's
+language list is narrower, because it lists only languages that still have
+a version.
+_Avoid_: permitted language IDs (the YPE-4657 ticket text; both SDKs
+actually key on tags, not numeric ids)
+
 ## Verse selection
 
 The ephemeral set of verses the reader has tapped in `BibleReader`. Drives

--- a/docs/adr/0005-version-filters-enforce-in-core-list-only.md
+++ b/docs/adr/0005-version-filters-enforce-in-core-list-only.md
@@ -1,0 +1,90 @@
+# 5. Version filters enforce in core, and only on lists
+
+Date: 2026-08-18
+
+## Status
+
+Accepted
+
+## Context
+
+YPE-4657 ports the Swift SDK's version-filtering configuration to React:
+`permittedVersionIds`, `excludedVersionIds` (added in platform-sdk-swift
+db0666d7), and `permittedLanguageTags`. The session default is Swift parity,
+with deviations named explicitly (this ADR names them).
+
+Swift enforces all three filters in exactly one place: the version-picker
+view model (`BibleVersionsViewModel.isPermitted`). Nothing in Swift's core,
+repository, or reader layers consults them, so fetching or rendering an
+excluded version directly (deep link, hardcoded id) still works.
+
+React's public surface is layered in a way Swift's is not: integrators
+build their own pickers on public hooks (`useVersions`, `useLanguages`) and
+on core clients (`getVersions`, `getLanguages`). A picker-internal filter
+(Swift's mechanical locus) would leave those public layers unfiltered,
+which breaks the *intent* of an SDK-wide restriction even while matching
+Swift's implementation.
+
+## Decision
+
+**Locus — filter in core.** `BibleClient.getVersions` filters its results
+through the filter predicate; `LanguagesClient.getLanguages` drops
+languages excluded by `permittedLanguageTags`. Hooks and the UI picker
+inherit filtering for free; core-only integrators get it too. This is a
+named deviation from Swift's locus, forced by React's public layering; the
+observable picker behavior matches Swift.
+
+**Depth — lists only.** Fetching or rendering a version by id is never
+blocked: `getVersion`, `getChapter`, etc. and `<BibleReader versionId>`
+work regardless of the filters (Swift parity). The filters are "what we
+offer," not "what we forbid" — a hard guard would make an integrator's
+saved reading position start throwing when config changes.
+
+**Semantics — Swift parity.**
+
+- Exclusion is checked first and wins over permission.
+- Permitted version ids and permitted language tags are ANDed.
+- `undefined` permitted list = unrestricted; **empty array permits
+  nothing**. Kept deliberately so the same input never means different
+  things in the two SDKs; documented as a foot-gun.
+- `getLanguages` drops tags outside `permittedLanguageTags` and nothing
+  else — it is not recomputed from the surviving versions, so a version-id
+  filter can leave a language listed. The picker's language list *is*
+  additionally a projection of surviving versions, because it lists only
+  languages that still have a version.
+
+**Wiring.** Props on `YouVersionProvider` sync into the
+`YouVersionPlatformConfiguration` statics (as `signInPromptMessage` does),
+mirrored onto UI's bundled core copy. Documented as set-at-init: changing
+them mid-session affects future fetches only; already-fetched lists do not
+re-filter.
+
+**Guardrails beyond Swift** (cheap, named deviations):
+
+- Dev-only `console.warn` when a component renders a `versionId` the
+  filters would hide (Swift instead has fallback-version logic we are not
+  porting; React components render the requested version as-is).
+- The picker's localStorage recent-versions list is filtered through the
+  same predicate at read time; storage itself is not scrubbed, so lifting
+  an exclusion restores the recents. Stored recents carry no language tag,
+  so with `permittedLanguageTags` active the picker looks the tag up in the
+  versions list — recents stay hidden until that lookup lands, and stay
+  hidden if it fails. Hiding a recent we cannot yet judge is the right bias
+  for a filter.
+
+## Consequences
+
+- Client-side filtering can shrink a requested `page_size` page of
+  `getVersions`/`getLanguages` results. `total_size` still reports the
+  server's unfiltered total, so a consumer paginating on it over-counts.
+- The predicate keys off `id` and `language_tag`, so an active filter adds
+  those fields back into a caller's `fields` projection. `page_size: '*'`
+  accepts only 1-3 fields, so turning a filter on can push a maximal
+  projection past that limit and turn a working call into an API error. A
+  visible error beats a silently empty list.
+- `useVersions`/`getVersions` consumers see filtered data with no opt-out.
+- No fallback-version selection: excluding the default version (3034) and
+  rendering `<BibleReader>` bare still renders 3034, with a dev warn.
+- Swift's cache-purge behavior (`removeUnpermittedVersions`) has no React
+  equivalent and is intentionally not ported; the SDK persists no version
+  content client-side.

--- a/packages/core/src/YouVersionPlatformConfiguration.ts
+++ b/packages/core/src/YouVersionPlatformConfiguration.ts
@@ -18,6 +18,9 @@ export class YouVersionPlatformConfiguration {
   private static _expiryDateKey: string | null = null;
   private static _signInPromptMessage: string | undefined = undefined;
   private static _appName: string | undefined = undefined;
+  private static _permittedVersionIds: number[] | undefined = undefined;
+  private static _excludedVersionIds: number[] | undefined = undefined;
+  private static _permittedLanguageTags: string[] | undefined = undefined;
 
   private static getOrSetInstallationId(): string {
     const storage = getLocalStorage();
@@ -327,5 +330,49 @@ export class YouVersionPlatformConfiguration {
 
   static set appName(value: string | undefined) {
     this._appName = value;
+  }
+
+  /**
+   * Allowlist of Bible version ids the SDK offers. `undefined` is
+   * unrestricted; an **empty array permits nothing** (Swift parity — empty and
+   * unset mean different things). ANDed with {@link permittedLanguageTags}.
+   *
+   * Filters shape what the SDK offers in lists; they never block fetching or
+   * rendering a version by id (see ADR-0005). Optional; not persisted (it is
+   * supplied by configuration on each app load), and read at fetch time, so
+   * changing it affects future fetches only.
+   */
+  static get permittedVersionIds(): number[] | undefined {
+    return this._permittedVersionIds;
+  }
+
+  static set permittedVersionIds(value: number[] | undefined) {
+    this._permittedVersionIds = value;
+  }
+
+  /**
+   * Denylist of Bible version ids. Exclusion is checked first and beats
+   * permission: a version named in both lists is excluded. `undefined` or an
+   * empty array excludes nothing. Optional; not persisted.
+   */
+  static get excludedVersionIds(): number[] | undefined {
+    return this._excludedVersionIds;
+  }
+
+  static set excludedVersionIds(value: number[] | undefined) {
+    this._excludedVersionIds = value;
+  }
+
+  /**
+   * Allowlist of BCP-47 language tags. `undefined` is unrestricted; an **empty
+   * array permits nothing**. A version with no language tag fails this filter.
+   * ANDed with {@link permittedVersionIds}. Optional; not persisted.
+   */
+  static get permittedLanguageTags(): string[] | undefined {
+    return this._permittedLanguageTags;
+  }
+
+  static set permittedLanguageTags(value: string[] | undefined) {
+    this._permittedLanguageTags = value;
   }
 }

--- a/packages/core/src/__tests__/version-filters.test.ts
+++ b/packages/core/src/__tests__/version-filters.test.ts
@@ -24,15 +24,17 @@ function configureVersionFilters(
   YouVersionPlatformConfiguration.permittedLanguageTags = filters.permittedLanguageTags;
 }
 
+// One source for both the client and the per-test MSW overrides below, so a
+// handler can never be registered against a different host than the client calls.
+const apiHost = process.env.YVP_API_HOST || 'api.youversion.com';
+
 function createApiClient(): ApiClient {
   return new ApiClient({
-    apiHost: process.env.YVP_API_HOST || '',
+    apiHost,
     appKey: process.env.YVP_APP_KEY || '',
     installationId: 'test-installation',
   });
 }
-
-const apiHost = process.env.YVP_API_HOST || 'api.youversion.com';
 
 describe('version filters', () => {
   it('permits every version when no filters are configured', () => {
@@ -114,6 +116,59 @@ describe('version filters', () => {
     expect(requestedFields).toContain('language_tag');
     expect(requestedFields).toContain('abbreviation');
     expect(versions.data.map((version) => version.id)).toEqual([111]);
+  });
+
+  it('asks for `id` when a version id filter is active and the projection omits it', async () => {
+    configureVersionFilters({ excludedVersionIds: [999] });
+    let requestedFields: string[] = [];
+    server.use(
+      http.get(`https://${apiHost}/v1/bibles`, ({ request }) => {
+        requestedFields = new URL(request.url).searchParams.getAll('fields[]');
+        return HttpResponse.json({
+          data: [
+            { ...mockVersions[0]!, id: 111, language_tag: 'en' },
+            { ...mockVersions[0]!, id: 999, language_tag: 'en' },
+          ],
+          next_page_token: null,
+          total_size: 2,
+        });
+      }),
+    );
+    const bibleClient = new BibleClient(createApiClient());
+
+    const versions = await bibleClient.getVersions('en*', undefined, {
+      fields: ['abbreviation'],
+    });
+
+    expect(requestedFields).toContain('id');
+    // No language filter is active, so `language_tag` is not asked for.
+    expect(requestedFields).not.toContain('language_tag');
+    expect(versions.data.map((version) => version.id)).toEqual([111]);
+  });
+
+  it('asks getLanguages for `id` when the projection omits it', async () => {
+    configureVersionFilters({ permittedLanguageTags: ['en'] });
+    let requestedFields: string[] = [];
+    server.use(
+      http.get(`https://${apiHost}/v1/languages`, ({ request }) => {
+        requestedFields = new URL(request.url).searchParams.getAll('fields[]');
+        return HttpResponse.json({
+          data: [
+            { id: 'en', display_names: { en: 'English' } },
+            { id: 'es', display_names: { en: 'Spanish' } },
+          ],
+          next_page_token: null,
+          total_size: 2,
+        });
+      }),
+    );
+    const languagesClient = new LanguagesClient(createApiClient());
+
+    const languages = await languagesClient.getLanguages({ fields: ['display_names'] });
+
+    expect(requestedFields).toContain('id');
+    expect(requestedFields).toContain('display_names');
+    expect(languages.data.map((language) => language.id)).toEqual(['en']);
   });
 
   it('drops languages whose tag is not permitted from getLanguages', async () => {

--- a/packages/core/src/__tests__/version-filters.test.ts
+++ b/packages/core/src/__tests__/version-filters.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { ApiClient } from '../client';
+import { BibleClient } from '../bible';
+import { LanguagesClient } from '../languages';
+import { YouVersionPlatformConfiguration } from '../YouVersionPlatformConfiguration';
+import { isVersionPermitted } from '../version-filters';
+import { server } from './setup';
+import { mockVersions } from './MockVersions';
+
+/**
+ * Every test sets all three filters, so no case can inherit another's state.
+ * Omitted keys are written back as `undefined` (the unrestricted default).
+ */
+function configureVersionFilters(
+  filters: {
+    permittedVersionIds?: number[];
+    excludedVersionIds?: number[];
+    permittedLanguageTags?: string[];
+  } = {},
+): void {
+  YouVersionPlatformConfiguration.permittedVersionIds = filters.permittedVersionIds;
+  YouVersionPlatformConfiguration.excludedVersionIds = filters.excludedVersionIds;
+  YouVersionPlatformConfiguration.permittedLanguageTags = filters.permittedLanguageTags;
+}
+
+function createApiClient(): ApiClient {
+  return new ApiClient({
+    apiHost: process.env.YVP_API_HOST || '',
+    appKey: process.env.YVP_APP_KEY || '',
+    installationId: 'test-installation',
+  });
+}
+
+const apiHost = process.env.YVP_API_HOST || 'api.youversion.com';
+
+describe('version filters', () => {
+  it('permits every version when no filters are configured', () => {
+    configureVersionFilters();
+
+    expect(isVersionPermitted(111, 'en')).toBe(true);
+    expect(isVersionPermitted(3034)).toBe(true);
+  });
+
+  it('excludes a version id even when the same id is permitted', () => {
+    configureVersionFilters({ permittedVersionIds: [111, 3034], excludedVersionIds: [111] });
+
+    expect(isVersionPermitted(111, 'en')).toBe(false);
+    expect(isVersionPermitted(3034, 'en')).toBe(true);
+  });
+
+  it('permits nothing when a permitted list is empty, for ids and for language tags', () => {
+    configureVersionFilters({ permittedVersionIds: [] });
+    expect(isVersionPermitted(111, 'en')).toBe(false);
+
+    configureVersionFilters({ permittedLanguageTags: [] });
+    expect(isVersionPermitted(111, 'en')).toBe(false);
+    expect(isVersionPermitted(111)).toBe(false);
+  });
+
+  it('rejects a version whose language tag is unlisted or missing', () => {
+    configureVersionFilters({ permittedLanguageTags: ['en'] });
+
+    expect(isVersionPermitted(111, 'en')).toBe(true);
+    expect(isVersionPermitted(111, 'es')).toBe(false);
+    expect(isVersionPermitted(111)).toBe(false);
+  });
+
+  it('ANDs permitted version ids with permitted language tags', () => {
+    configureVersionFilters({ permittedVersionIds: [111, 222], permittedLanguageTags: ['en'] });
+
+    expect(isVersionPermitted(111, 'en')).toBe(true);
+    expect(isVersionPermitted(222, 'es')).toBe(false);
+    expect(isVersionPermitted(333, 'en')).toBe(false);
+  });
+
+  it('drops excluded versions from getVersions while still fetching one by id', async () => {
+    configureVersionFilters({ excludedVersionIds: [111] });
+    const bibleClient = new BibleClient(createApiClient());
+
+    const versions = await bibleClient.getVersions('en*', undefined, { page_size: 25 });
+
+    expect(versions.data.length).toBe(mockVersions.length - 1);
+    expect(versions.data.some((version) => version.id === 111)).toBe(false);
+
+    // Lists are "what we offer", not "what we forbid" (ADR-0005): fetching an
+    // excluded version directly still works.
+    const excluded = await bibleClient.getVersion(111);
+    expect(excluded.id).toBeDefined();
+  });
+
+  it('asks the API for the fields the filters key off when a projection omits them', async () => {
+    configureVersionFilters({ permittedLanguageTags: ['en'] });
+    let requestedFields: string[] = [];
+    server.use(
+      http.get(`https://${apiHost}/v1/bibles`, ({ request }) => {
+        requestedFields = new URL(request.url).searchParams.getAll('fields[]');
+        return HttpResponse.json({
+          data: [
+            { ...mockVersions[0]!, id: 111, language_tag: 'en' },
+            { ...mockVersions[0]!, id: 999, language_tag: 'es' },
+          ],
+          next_page_token: null,
+          total_size: 2,
+        });
+      }),
+    );
+    const bibleClient = new BibleClient(createApiClient());
+
+    const versions = await bibleClient.getVersions('en*', undefined, {
+      fields: ['abbreviation'],
+    });
+
+    expect(requestedFields).toContain('language_tag');
+    expect(requestedFields).toContain('abbreviation');
+    expect(versions.data.map((version) => version.id)).toEqual([111]);
+  });
+
+  it('drops languages whose tag is not permitted from getLanguages', async () => {
+    configureVersionFilters({ permittedLanguageTags: ['en', 'es'] });
+    const languagesClient = new LanguagesClient(createApiClient());
+
+    const languages = await languagesClient.getLanguages({ page_size: 99 });
+
+    expect(languages.data.map((language) => language.id).sort()).toEqual(['en', 'es']);
+  });
+
+  it('leaves getLanguages unfiltered when no language filter is configured', async () => {
+    configureVersionFilters();
+    const languagesClient = new LanguagesClient(createApiClient());
+
+    const languages = await languagesClient.getLanguages({ page_size: 99 });
+
+    expect(languages.data.length).toBeGreaterThan(2);
+  });
+});

--- a/packages/core/src/bible.ts
+++ b/packages/core/src/bible.ts
@@ -2,6 +2,8 @@ import { z } from 'zod';
 import type { ApiClient } from './client';
 import { transformBibleHtml, type TransformBibleHtmlOptions } from './bible-html-transformer';
 import { BibleVersionSchema } from './schemas';
+import { YouVersionPlatformConfiguration } from './YouVersionPlatformConfiguration';
+import { isVersionPermitted } from './version-filters';
 import type {
   BibleBook,
   BibleChapter,
@@ -42,6 +44,33 @@ async function getHtmlAdapters(): Promise<TransformBibleHtmlOptions> {
         .document as unknown as Document,
     serializeHtml: (doc) => doc.body.innerHTML,
   };
+}
+
+/**
+ * The version filters key off `id` and `language_tag`, so a caller's `fields`
+ * projection that omits them would leave the predicate nothing to match and
+ * silently reject every version. Request them back whenever the filter that
+ * needs them is active.
+ *
+ * Caveat: `page_size: '*'` accepts only 1-3 fields, so an active filter can
+ * push a maximal projection past that limit. A visible API error beats a
+ * silently empty list.
+ */
+function withFieldsRequiredByFilters(fields: (keyof BibleVersion)[]): (keyof BibleVersion)[] {
+  const required: (keyof BibleVersion)[] = [];
+
+  const { permittedVersionIds, excludedVersionIds, permittedLanguageTags } =
+    YouVersionPlatformConfiguration;
+
+  if (permittedVersionIds !== undefined || excludedVersionIds !== undefined) {
+    required.push('id');
+  }
+  if (permittedLanguageTags !== undefined) {
+    required.push('language_tag');
+  }
+
+  const missing = required.filter((field) => !fields.includes(field));
+  return missing.length > 0 ? [...fields, ...missing] : fields;
 }
 
 /**
@@ -105,6 +134,10 @@ export class BibleClient {
   /**
    * Fetches a collection of Bible versions filtered by language ranges.
    *
+   * Results also pass through the configured version filters
+   * ({@link isVersionPermitted}), so a page can come back smaller than the
+   * requested `page_size`.
+   *
    * @param language_ranges - One or more language codes or ranges to filter the versions (required).
    * @param license_id - Optional license ID to filter versions by license.
    * @returns A promise that resolves to a collection of BibleVersion objects.
@@ -135,7 +168,7 @@ export class BibleClient {
     }
 
     if (options?.fields) {
-      params['fields[]'] = options.fields;
+      params['fields[]'] = withFieldsRequiredByFilters(options.fields);
     }
 
     if (options?.page_token) {
@@ -145,7 +178,17 @@ export class BibleClient {
     if (options?.all_available) {
       params.all_available = 'true';
     }
-    return this.client.get<Collection<BibleVersion>>(`/v1/bibles`, params);
+    const collection = await this.client.get<Collection<BibleVersion>>(`/v1/bibles`, params);
+
+    // Filtering happens after the fetch, so an active filter can shrink a page
+    // below the requested `page_size`. `total_size` still reports the server's
+    // unfiltered total.
+    return {
+      ...collection,
+      data: collection.data.filter((version) =>
+        isVersionPermitted(version.id, version.language_tag),
+      ),
+    };
   }
 
   /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,7 @@ export * from './YouVersionUserInfo';
 export * from './SignInWithYouVersionResult';
 export * from './YouVersionAPI';
 export * from './YouVersionPlatformConfiguration';
+export { isVersionPermitted } from './version-filters';
 export * from './types';
 export * from './utils/constants';
 export { getAdjacentChapter } from './getAdjacentChapter';

--- a/packages/core/src/languages.ts
+++ b/packages/core/src/languages.ts
@@ -84,7 +84,10 @@ export class LanguagesClient {
       const fieldsSchema = z.array(LanguageSchema.keyof());
       fieldsSchema.parse(options.fields);
       // The language filter keys off `id`; a projection that omits it would
-      // leave nothing to match and silently drop every language.
+      // leave nothing to match and silently drop every language. Same caveat as
+      // `withFieldsRequiredByFilters` in `bible.ts`: the `page_size: '*'` guard
+      // below counts the caller's fields, so an active filter can send a fourth
+      // field and draw an API error. A visible error beats an empty list.
       const needsId =
         YouVersionPlatformConfiguration.permittedLanguageTags !== undefined &&
         !options.fields.includes('id');
@@ -111,10 +114,11 @@ export class LanguagesClient {
 
     const collection = await this.client.get<Collection<Language>>(`/v1/languages`, params);
 
-    // Language lists are a projection of the versions the SDK offers, so a
-    // language the tag allowlist rejects is dropped here. Filtering happens
-    // after the fetch, so a page can come back smaller than `page_size`;
-    // `total_size` still reports the server's unfiltered total.
+    // The tag allowlist is the only filter that applies here: the version id
+    // lists never touch languages, so a language whose every version is
+    // excluded is still listed (ADR-0005). Filtering happens after the fetch,
+    // so a page can come back smaller than `page_size`; `total_size` still
+    // reports the server's unfiltered total.
     return {
       ...collection,
       data: collection.data.filter((language) => isLanguageTagPermitted(language.id)),

--- a/packages/core/src/languages.ts
+++ b/packages/core/src/languages.ts
@@ -2,6 +2,8 @@ import { z } from 'zod';
 import type { ApiClient } from './client';
 import type { Collection, Language } from './types';
 import { LanguageSchema } from './schemas';
+import { YouVersionPlatformConfiguration } from './YouVersionPlatformConfiguration';
+import { isLanguageTagPermitted } from './version-filters';
 
 /**
  * Options for getting languages collection.
@@ -63,6 +65,10 @@ export class LanguagesClient {
 
   /**
    * Fetches a collection of languages supported in the Platform.
+   *
+   * When `permittedLanguageTags` is configured, languages outside that
+   * allowlist are dropped from the result.
+   *
    * @param options Query parameters for pagination and filtering.
    * @returns A collection of Language objects.
    */
@@ -77,7 +83,12 @@ export class LanguagesClient {
     if (options.fields !== undefined) {
       const fieldsSchema = z.array(LanguageSchema.keyof());
       fieldsSchema.parse(options.fields);
-      params['fields[]'] = options.fields;
+      // The language filter keys off `id`; a projection that omits it would
+      // leave nothing to match and silently drop every language.
+      const needsId =
+        YouVersionPlatformConfiguration.permittedLanguageTags !== undefined &&
+        !options.fields.includes('id');
+      params['fields[]'] = needsId ? [...options.fields, 'id'] : options.fields;
     }
 
     if (options.page_size !== undefined) {
@@ -98,7 +109,16 @@ export class LanguagesClient {
       params.page_token = options.page_token;
     }
 
-    return this.client.get<Collection<Language>>(`/v1/languages`, params);
+    const collection = await this.client.get<Collection<Language>>(`/v1/languages`, params);
+
+    // Language lists are a projection of the versions the SDK offers, so a
+    // language the tag allowlist rejects is dropped here. Filtering happens
+    // after the fetch, so a page can come back smaller than `page_size`;
+    // `total_size` still reports the server's unfiltered total.
+    return {
+      ...collection,
+      data: collection.data.filter((language) => isLanguageTagPermitted(language.id)),
+    };
   }
 
   /**

--- a/packages/core/src/version-filters.ts
+++ b/packages/core/src/version-filters.ts
@@ -1,0 +1,49 @@
+import { YouVersionPlatformConfiguration } from './YouVersionPlatformConfiguration';
+
+/**
+ * Whether a language tag survives {@link YouVersionPlatformConfiguration.permittedLanguageTags}.
+ *
+ * Internal to the version filters: language lists are a projection of the
+ * surviving versions, so this is the same rule applied to a language row.
+ * `undefined` permits everything; an empty array permits nothing; a missing
+ * tag can never match an active allowlist.
+ */
+export function isLanguageTagPermitted(languageTag?: string): boolean {
+  const permittedLanguageTags = YouVersionPlatformConfiguration.permittedLanguageTags;
+  if (permittedLanguageTags === undefined) {
+    return true;
+  }
+  return languageTag !== undefined && permittedLanguageTags.includes(languageTag);
+}
+
+/**
+ * Whether a Bible version survives the configured version filters.
+ *
+ * Semantics match the Swift SDK exactly:
+ * - `excludedVersionIds` is checked first and beats permission.
+ * - `permittedLanguageTags` and `permittedVersionIds` are ANDed.
+ * - `undefined` means unrestricted; an **empty array permits nothing**.
+ * - A version with no language tag fails an active language-tag filter.
+ *
+ * The filters describe what the SDK *offers*, so only list endpoints consult
+ * this (see ADR-0005). Fetching or rendering a version by id is never blocked.
+ *
+ * @param versionId The Bible version id.
+ * @param languageTag The version's BCP-47 language tag, when known.
+ */
+export function isVersionPermitted(versionId: number, languageTag?: string): boolean {
+  if (YouVersionPlatformConfiguration.excludedVersionIds?.includes(versionId)) {
+    return false;
+  }
+
+  if (!isLanguageTagPermitted(languageTag)) {
+    return false;
+  }
+
+  const permittedVersionIds = YouVersionPlatformConfiguration.permittedVersionIds;
+  if (permittedVersionIds !== undefined && !permittedVersionIds.includes(versionId)) {
+    return false;
+  }
+
+  return true;
+}

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -44,6 +44,40 @@ function App() {
 }
 ```
 
+## Version filters
+
+Restrict which Bible versions the SDK offers with three optional `YouVersionProvider` props:
+
+```tsx
+<YouVersionProvider
+  appKey="YOUR_APP_KEY"
+  permittedVersionIds={[111, 3034]}
+  excludedVersionIds={[206]}
+  permittedLanguageTags={['en', 'es']}
+>
+  <BibleVerse />
+</YouVersionProvider>
+```
+
+| Prop | Type | Behavior |
+|------|------|----------|
+| `permittedVersionIds` | `number[]` | Allowlist of Bible version ids |
+| `excludedVersionIds` | `number[]` | Denylist of Bible version ids |
+| `permittedLanguageTags` | `string[]` | Allowlist of BCP-47 language tags (`'en'`, `'es'`), matched against each version's language tag |
+
+Semantics match the Swift SDK:
+
+- Exclusion wins. A version in both `permittedVersionIds` and `excludedVersionIds` is excluded.
+- The two allowlists are ANDed. A version must pass both to be offered.
+- Leaving a prop unset means unrestricted.
+- **An empty array permits nothing.** `permittedVersionIds={[]}` offers no versions at all. Build the list before you pass it, or leave the prop off.
+
+Filtering covers lists only: `useVersions` and `useLanguages` return filtered results. Fetching a version by id is never blocked — `usePassage({ versionId: 206 })` works even when 206 is excluded, so deep links and saved reading positions keep working when your filters change. `permittedLanguageTags` is the only filter `useLanguages` applies. The version id lists do not touch it, so excluding every version in a language still leaves that language in the results.
+
+Filtering runs after the fetch, so a page can come back smaller than the requested `page_size`, and reported totals still count unfiltered server results.
+
+Set the filters when you mount the provider. Changing them later applies to future fetches only — data already fetched is not re-filtered.
+
 ## Documentation and API Reference
 * [developers.youversion.com/sdks/react](https://developers.youversion.com/sdks/react)
 

--- a/packages/hooks/src/context/YouVersionProvider.test.tsx
+++ b/packages/hooks/src/context/YouVersionProvider.test.tsx
@@ -27,6 +27,54 @@ describe('YouVersionProvider', () => {
     expect(id).not.toBe('none');
   });
 
+  it('syncs the version filter props onto the platform config, and only re-syncs when a list really changes', () => {
+    YouVersionPlatformConfiguration.permittedVersionIds = undefined;
+    YouVersionPlatformConfiguration.excludedVersionIds = undefined;
+    YouVersionPlatformConfiguration.permittedLanguageTags = undefined;
+
+    const { rerender } = render(
+      <YouVersionProvider
+        appKey="test"
+        permittedVersionIds={[111, 3034]}
+        excludedVersionIds={[206]}
+        permittedLanguageTags={['en']}
+      >
+        <ContextReader />
+      </YouVersionProvider>,
+    );
+
+    expect(YouVersionPlatformConfiguration.permittedVersionIds).toEqual([111, 3034]);
+    expect(YouVersionPlatformConfiguration.excludedVersionIds).toEqual([206]);
+    expect(YouVersionPlatformConfiguration.permittedLanguageTags).toEqual(['en']);
+
+    // A re-render with fresh-but-equal array literals must not re-run the sync
+    // effect. Overwrite the static first: if the effect re-runs, the sentinel
+    // is clobbered.
+    YouVersionPlatformConfiguration.permittedVersionIds = [999];
+    rerender(
+      <YouVersionProvider
+        appKey="test"
+        permittedVersionIds={[3034, 111]}
+        excludedVersionIds={[206]}
+        permittedLanguageTags={['en']}
+      >
+        <ContextReader />
+      </YouVersionProvider>,
+    );
+    expect(YouVersionPlatformConfiguration.permittedVersionIds).toEqual([999]);
+
+    // A changed list does sync, and dropping a prop returns that filter to
+    // unrestricted rather than leaving the previous value in place.
+    rerender(
+      <YouVersionProvider appKey="test" permittedVersionIds={[111]}>
+        <ContextReader />
+      </YouVersionProvider>,
+    );
+    expect(YouVersionPlatformConfiguration.permittedVersionIds).toEqual([111]);
+    expect(YouVersionPlatformConfiguration.excludedVersionIds).toBeUndefined();
+    expect(YouVersionPlatformConfiguration.permittedLanguageTags).toBeUndefined();
+  });
+
   it.each([
     ['undefined', undefined],
     ['empty string', ''],

--- a/packages/hooks/src/context/YouVersionProvider.test.tsx
+++ b/packages/hooks/src/context/YouVersionProvider.test.tsx
@@ -1,6 +1,6 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, onTestFinished } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { YouVersionPlatformConfiguration } from '@youversion/platform-core';
 import { YouVersionProvider } from './YouVersionProvider';
 import { YouVersionContext } from './YouVersionContext';
@@ -27,10 +27,28 @@ describe('YouVersionProvider', () => {
     expect(id).not.toBe('none');
   });
 
-  it('syncs the version filter props onto the platform config, and only re-syncs when a list really changes', () => {
+  it('syncs the version filter props onto the platform config before a child can fetch, and follows the props after', () => {
+    onTestFinished(() => {
+      YouVersionPlatformConfiguration.permittedVersionIds = undefined;
+      YouVersionPlatformConfiguration.excludedVersionIds = undefined;
+      YouVersionPlatformConfiguration.permittedLanguageTags = undefined;
+    });
     YouVersionPlatformConfiguration.permittedVersionIds = undefined;
     YouVersionPlatformConfiguration.excludedVersionIds = undefined;
     YouVersionPlatformConfiguration.permittedLanguageTags = undefined;
+
+    // Core's list clients read these while *building* a request, and a child
+    // fetches from its own effect — which React runs before the provider's.
+    // Record what a child sees at that moment: if the provider synced in an
+    // effect, this would be undefined and the first fetch of a fresh mount
+    // would build against an unset config.
+    let seenByChildEffect: number[] | undefined;
+    function FetchingChild(): React.ReactElement {
+      useEffect(() => {
+        seenByChildEffect = YouVersionPlatformConfiguration.permittedVersionIds;
+      }, []);
+      return <ContextReader />;
+    }
 
     const { rerender } = render(
       <YouVersionProvider
@@ -39,35 +57,20 @@ describe('YouVersionProvider', () => {
         excludedVersionIds={[206]}
         permittedLanguageTags={['en']}
       >
-        <ContextReader />
+        <FetchingChild />
       </YouVersionProvider>,
     );
 
+    expect(seenByChildEffect).toEqual([111, 3034]);
     expect(YouVersionPlatformConfiguration.permittedVersionIds).toEqual([111, 3034]);
     expect(YouVersionPlatformConfiguration.excludedVersionIds).toEqual([206]);
     expect(YouVersionPlatformConfiguration.permittedLanguageTags).toEqual(['en']);
 
-    // A re-render with fresh-but-equal array literals must not re-run the sync
-    // effect. Overwrite the static first: if the effect re-runs, the sentinel
-    // is clobbered.
-    YouVersionPlatformConfiguration.permittedVersionIds = [999];
-    rerender(
-      <YouVersionProvider
-        appKey="test"
-        permittedVersionIds={[3034, 111]}
-        excludedVersionIds={[206]}
-        permittedLanguageTags={['en']}
-      >
-        <ContextReader />
-      </YouVersionProvider>,
-    );
-    expect(YouVersionPlatformConfiguration.permittedVersionIds).toEqual([999]);
-
-    // A changed list does sync, and dropping a prop returns that filter to
+    // A changed list syncs, and dropping a prop returns that filter to
     // unrestricted rather than leaving the previous value in place.
     rerender(
       <YouVersionProvider appKey="test" permittedVersionIds={[111]}>
-        <ContextReader />
+        <FetchingChild />
       </YouVersionProvider>,
     );
     expect(YouVersionPlatformConfiguration.permittedVersionIds).toEqual([111]);

--- a/packages/hooks/src/context/YouVersionProvider.tsx
+++ b/packages/hooks/src/context/YouVersionProvider.tsx
@@ -110,20 +110,6 @@ function useResolvedTheme(theme: 'light' | 'dark' | 'system'): 'light' | 'dark' 
   return resolved;
 }
 
-/**
- * Keeps an array prop referentially stable across renders so it can sit in a
- * dependency array. Only membership matters to the version filters, so the
- * memo key sorts a copy — `[111, 3034]` and `[3034, 111]` are the same list.
- */
-function useStableList<T extends number | string>(list: T[] | undefined): T[] | undefined {
-  const key = list ? JSON.stringify([...list].sort()) : null;
-  return useMemo(
-    () => list,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [key],
-  );
-}
-
 export function YouVersionProvider(
   props: PropsWithChildren<YouVersionProviderPropsWithAuth | YouVersionProviderPropsWithoutAuth>,
 ): React.ReactElement {
@@ -178,13 +164,17 @@ function YouVersionProviderInner(
     [additionalHeadersKey],
   );
 
-  // Same stability problem as `additionalHeaders`: the version-filter props are
-  // arrays, so an inline literal is a new reference every render and would
-  // re-run the config sync effect each time. Membership is all the filters
-  // read, so the key sorts a copy — reordering the same ids is not a change.
-  const stablePermittedVersionIds = useStableList(permittedVersionIds);
-  const stableExcludedVersionIds = useStableList(excludedVersionIds);
-  const stablePermittedLanguageTags = useStableList(permittedLanguageTags);
+  // The version filters are the one part of the config that has to be in place
+  // *before* children render or fetch: core's list clients read it while
+  // building a request (`getVersions` adds the fields the predicate keys off
+  // back into a caller's projection), and children fetch from their own
+  // effects, which React runs before the parent's. Syncing these in an effect
+  // would leave the first fetch after a mount building against an unset
+  // config. Assign during render instead — plain idempotent writes to a
+  // singleton, no cleanup, and the parent renders before any child.
+  YouVersionPlatformConfiguration.permittedVersionIds = permittedVersionIds;
+  YouVersionPlatformConfiguration.excludedVersionIds = excludedVersionIds;
+  YouVersionPlatformConfiguration.permittedLanguageTags = permittedLanguageTags;
 
   // Sync props to YouVersionPlatformConfiguration so any code that reads the
   // static config (e.g. core's auth/PKCE flows, called from user actions) sees
@@ -195,18 +185,7 @@ function YouVersionProviderInner(
     YouVersionPlatformConfiguration.apiHost = apiHost;
     YouVersionPlatformConfiguration.appName = appName;
     YouVersionPlatformConfiguration.signInPromptMessage = signInPromptMessage;
-    YouVersionPlatformConfiguration.permittedVersionIds = stablePermittedVersionIds;
-    YouVersionPlatformConfiguration.excludedVersionIds = stableExcludedVersionIds;
-    YouVersionPlatformConfiguration.permittedLanguageTags = stablePermittedLanguageTags;
-  }, [
-    appKey,
-    apiHost,
-    appName,
-    signInPromptMessage,
-    stablePermittedVersionIds,
-    stableExcludedVersionIds,
-    stablePermittedLanguageTags,
-  ]);
+  }, [appKey, apiHost, appName, signInPromptMessage]);
 
   const contextValue = {
     appKey,

--- a/packages/hooks/src/context/YouVersionProvider.tsx
+++ b/packages/hooks/src/context/YouVersionProvider.tsx
@@ -34,6 +34,34 @@ interface YouVersionProviderPropsBase {
    * to replace `X-YVP-Sdk` with their own identifier.
    */
   additionalHeaders?: Record<string, string>;
+  /**
+   * Allowlist of Bible version ids the SDK offers in its lists. `undefined` is
+   * unrestricted; an **empty array permits nothing**. ANDed with
+   * {@link YouVersionProviderPropsBase.permittedLanguageTags}.
+   *
+   * Synced onto `YouVersionPlatformConfiguration.permittedVersionIds`, which
+   * `getVersions`/`getLanguages` read at fetch time. Set-at-init: changing this
+   * mid-session affects future fetches only — lists already fetched are not
+   * re-filtered. Filters never block fetching or rendering a version by id.
+   */
+  permittedVersionIds?: number[];
+  /**
+   * Denylist of Bible version ids. Exclusion is checked first and beats
+   * permission: a version named in both lists is excluded.
+   *
+   * Synced onto `YouVersionPlatformConfiguration.excludedVersionIds`; same
+   * set-at-init caveat as `permittedVersionIds`.
+   */
+  excludedVersionIds?: number[];
+  /**
+   * Allowlist of BCP-47 language tags. `undefined` is unrestricted; an **empty
+   * array permits nothing**. ANDed with
+   * {@link YouVersionProviderPropsBase.permittedVersionIds}.
+   *
+   * Synced onto `YouVersionPlatformConfiguration.permittedLanguageTags`; same
+   * set-at-init caveat as `permittedVersionIds`.
+   */
+  permittedLanguageTags?: string[];
 }
 
 interface YouVersionProviderPropsWithAuth extends YouVersionProviderPropsBase {
@@ -82,6 +110,20 @@ function useResolvedTheme(theme: 'light' | 'dark' | 'system'): 'light' | 'dark' 
   return resolved;
 }
 
+/**
+ * Keeps an array prop referentially stable across renders so it can sit in a
+ * dependency array. Only membership matters to the version filters, so the
+ * memo key sorts a copy — `[111, 3034]` and `[3034, 111]` are the same list.
+ */
+function useStableList<T extends number | string>(list: T[] | undefined): T[] | undefined {
+  const key = list ? JSON.stringify([...list].sort()) : null;
+  return useMemo(
+    () => list,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [key],
+  );
+}
+
 export function YouVersionProvider(
   props: PropsWithChildren<YouVersionProviderPropsWithAuth | YouVersionProviderPropsWithoutAuth>,
 ): React.ReactElement {
@@ -115,6 +157,9 @@ function YouVersionProviderInner(
     additionalHeaders,
     appName,
     signInPromptMessage,
+    permittedVersionIds,
+    excludedVersionIds,
+    permittedLanguageTags,
     children,
   } = props;
 
@@ -133,6 +178,14 @@ function YouVersionProviderInner(
     [additionalHeadersKey],
   );
 
+  // Same stability problem as `additionalHeaders`: the version-filter props are
+  // arrays, so an inline literal is a new reference every render and would
+  // re-run the config sync effect each time. Membership is all the filters
+  // read, so the key sorts a copy — reordering the same ids is not a change.
+  const stablePermittedVersionIds = useStableList(permittedVersionIds);
+  const stableExcludedVersionIds = useStableList(excludedVersionIds);
+  const stablePermittedLanguageTags = useStableList(permittedLanguageTags);
+
   // Sync props to YouVersionPlatformConfiguration so any code that reads the
   // static config (e.g. core's auth/PKCE flows, called from user actions) sees
   // the same values. Children that read via context get the prop directly
@@ -142,7 +195,18 @@ function YouVersionProviderInner(
     YouVersionPlatformConfiguration.apiHost = apiHost;
     YouVersionPlatformConfiguration.appName = appName;
     YouVersionPlatformConfiguration.signInPromptMessage = signInPromptMessage;
-  }, [appKey, apiHost, appName, signInPromptMessage]);
+    YouVersionPlatformConfiguration.permittedVersionIds = stablePermittedVersionIds;
+    YouVersionPlatformConfiguration.excludedVersionIds = stableExcludedVersionIds;
+    YouVersionPlatformConfiguration.permittedLanguageTags = stablePermittedLanguageTags;
+  }, [
+    appKey,
+    apiHost,
+    appName,
+    signInPromptMessage,
+    stablePermittedVersionIds,
+    stableExcludedVersionIds,
+    stablePermittedLanguageTags,
+  ]);
 
   const contextValue = {
     appKey,

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -145,6 +145,45 @@ Individual components accept a `background` prop to override the provider theme 
 }
 ```
 
+## Version filters
+
+Restrict which Bible versions the SDK offers with three optional `YouVersionProvider` props:
+
+```tsx
+<YouVersionProvider
+  appKey="YOUR_APP_KEY"
+  permittedVersionIds={[111, 3034]}
+  excludedVersionIds={[206]}
+  permittedLanguageTags={['en', 'es']}
+>
+  <BibleVersionPicker.Root versionId={3034}>
+    <BibleVersionPicker.Trigger />
+    <BibleVersionPicker.Content />
+  </BibleVersionPicker.Root>
+</YouVersionProvider>
+```
+
+| Prop | Type | Behavior |
+|------|------|----------|
+| `permittedVersionIds` | `number[]` | Allowlist of Bible version ids |
+| `excludedVersionIds` | `number[]` | Denylist of Bible version ids |
+| `permittedLanguageTags` | `string[]` | Allowlist of BCP-47 language tags (`'en'`, `'es'`), matched against each version's language tag |
+
+Semantics match the Swift SDK:
+
+- Exclusion wins. A version in both `permittedVersionIds` and `excludedVersionIds` is excluded.
+- The two allowlists are ANDed. A version must pass both to be offered.
+- Leaving a prop unset means unrestricted.
+- **An empty array permits nothing.** `permittedVersionIds={[]}` offers no versions at all. Build the list before you pass it, or leave the prop off.
+
+### What filtering covers
+
+Filters shape the lists the SDK offers: version lists, language lists, and the version picker (including its recently-used versions). They never block fetching or rendering a version by id. `<BibleReader.Root versionId={206} />` renders 206 even when 206 is excluded, and logs a warning once per version id in development builds only. Deep links and saved reading positions keep working when your filters change.
+
+In the picker, language lists follow the versions. Exclude every version in a language and that language leaves the picker's language list, because the picker only lists languages that still have a version. `useLanguages` on its own does not do this — it filters by `permittedLanguageTags` alone.
+
+Set the filters when you mount the provider. Changing them later applies to future fetches only — lists already fetched are not re-filtered.
+
 ## Documentation and API Reference
 * [developers.youversion.com/sdks/react](https://developers.youversion.com/sdks/react)
 

--- a/packages/ui/src/components/YouVersionProvider.test.tsx
+++ b/packages/ui/src/components/YouVersionProvider.test.tsx
@@ -67,6 +67,42 @@ describe('UI YouVersionProvider', () => {
     );
   });
 
+  it('mirrors the version filters onto the UI-bundled config and forwards them to the hooks provider', () => {
+    YouVersionPlatformConfiguration.permittedVersionIds = undefined;
+    YouVersionPlatformConfiguration.excludedVersionIds = undefined;
+    YouVersionPlatformConfiguration.permittedLanguageTags = undefined;
+
+    render(
+      <YouVersionProvider
+        appKey="test-key"
+        permittedVersionIds={[111, 3034]}
+        excludedVersionIds={[206]}
+        permittedLanguageTags={['en']}
+      >
+        <div data-testid="child">hello</div>
+      </YouVersionProvider>,
+    );
+
+    // The UI bundles its own copy of core; the picker and the dev warn read
+    // this one.
+    expect(YouVersionPlatformConfiguration.permittedVersionIds).toEqual([111, 3034]);
+    expect(YouVersionPlatformConfiguration.excludedVersionIds).toEqual([206]);
+    expect(YouVersionPlatformConfiguration.permittedLanguageTags).toEqual(['en']);
+
+    // …and the hooks provider still gets the props so it can sync its own copy.
+    expect(baseProviderMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        permittedVersionIds: [111, 3034],
+        excludedVersionIds: [206],
+        permittedLanguageTags: ['en'],
+      }),
+    );
+
+    YouVersionPlatformConfiguration.permittedVersionIds = undefined;
+    YouVersionPlatformConfiguration.excludedVersionIds = undefined;
+    YouVersionPlatformConfiguration.permittedLanguageTags = undefined;
+  });
+
   it.each([
     ['undefined', undefined],
     ['empty string', ''],

--- a/packages/ui/src/components/YouVersionProvider.tsx
+++ b/packages/ui/src/components/YouVersionProvider.tsx
@@ -27,6 +27,23 @@ export function YouVersionProvider(
     YouVersionPlatformConfiguration.signInPromptMessage = props.signInPromptMessage;
   }, [props.appName, props.signInPromptMessage]);
 
+  // Same dual-instance problem for the version filters: the picker's recents
+  // filter and the dev-only render warning call `isVersionPermitted` from
+  // *this* copy of core, so it needs the same lists the hooks provider syncs.
+  // Set-at-init, like the props themselves: changing them affects future
+  // fetches only.
+  const permittedVersionIdsKey = JSON.stringify(props.permittedVersionIds ?? null);
+  const excludedVersionIdsKey = JSON.stringify(props.excludedVersionIds ?? null);
+  const permittedLanguageTagsKey = JSON.stringify(props.permittedLanguageTags ?? null);
+  useEffect(() => {
+    YouVersionPlatformConfiguration.permittedVersionIds = props.permittedVersionIds;
+    YouVersionPlatformConfiguration.excludedVersionIds = props.excludedVersionIds;
+    YouVersionPlatformConfiguration.permittedLanguageTags = props.permittedLanguageTags;
+    // Depend on the serialized lists, not the array identities: an inline
+    // literal is a new reference every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [permittedVersionIdsKey, excludedVersionIdsKey, permittedLanguageTagsKey]);
+
   // Guard against a missing/empty app key here (rather than letting the base
   // provider throw) so consumers of the UI package see a styled message instead
   // of a blank page. The visible panel is intentionally generic; the actionable

--- a/packages/ui/src/components/YouVersionProvider.tsx
+++ b/packages/ui/src/components/YouVersionProvider.tsx
@@ -30,19 +30,15 @@ export function YouVersionProvider(
   // Same dual-instance problem for the version filters: the picker's recents
   // filter and the dev-only render warning call `isVersionPermitted` from
   // *this* copy of core, so it needs the same lists the hooks provider syncs.
-  // Set-at-init, like the props themselves: changing them affects future
-  // fetches only.
-  const permittedVersionIdsKey = JSON.stringify(props.permittedVersionIds ?? null);
-  const excludedVersionIdsKey = JSON.stringify(props.excludedVersionIds ?? null);
-  const permittedLanguageTagsKey = JSON.stringify(props.permittedLanguageTags ?? null);
-  useEffect(() => {
-    YouVersionPlatformConfiguration.permittedVersionIds = props.permittedVersionIds;
-    YouVersionPlatformConfiguration.excludedVersionIds = props.excludedVersionIds;
-    YouVersionPlatformConfiguration.permittedLanguageTags = props.permittedLanguageTags;
-    // Depend on the serialized lists, not the array identities: an inline
-    // literal is a new reference every render.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [permittedVersionIdsKey, excludedVersionIdsKey, permittedLanguageTagsKey]);
+  //
+  // Assigned during render, not in an effect, for the same reason the hooks
+  // provider does it: both readers run while children render or in child
+  // effects, and React runs those before the parent's effect. Plain idempotent
+  // writes to a singleton, no cleanup. Set-at-init, like the props themselves:
+  // changing them affects future fetches only.
+  YouVersionPlatformConfiguration.permittedVersionIds = props.permittedVersionIds;
+  YouVersionPlatformConfiguration.excludedVersionIds = props.excludedVersionIds;
+  YouVersionPlatformConfiguration.permittedLanguageTags = props.permittedLanguageTags;
 
   // Guard against a missing/empty app key here (rather than letting the base
   // provider throw) so consumers of the UI package see a styled message instead

--- a/packages/ui/src/components/bible-card.tsx
+++ b/packages/ui/src/components/bible-card.tsx
@@ -9,6 +9,7 @@ import { Button } from './ui/button';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { UNTITLED_SERIF_FONT } from '@/lib/verse-html-utils';
 import { useDelayedLoading } from '@/lib/use-delayed-loading';
+import { useVersionFilterWarning } from '@/lib/use-version-filter-warning';
 import { LoaderIcon } from './icons/loader';
 import { AnimatedHeight } from './animated-height';
 
@@ -133,6 +134,7 @@ export function BibleCard({
     onChange: onVersionChange,
   });
   const { version } = useVersion(versionNum);
+  useVersionFilterWarning(versionNum, version?.language_tag);
   const {
     passage,
     loading: passageLoading,

--- a/packages/ui/src/components/bible-reader.tsx
+++ b/packages/ui/src/components/bible-reader.tsx
@@ -3,6 +3,7 @@
 import i18n from '@/i18n';
 import { IS_PRODUCTION } from '@/lib/constants';
 import { useDelayedLoading } from '@/lib/use-delayed-loading';
+import { useVersionFilterWarning } from '@/lib/use-version-filter-warning';
 import { cn } from '@/lib/utils';
 import {
   INTER_FONT,
@@ -690,6 +691,7 @@ function Content() {
     clearSelectionSignal,
   } = useBibleReaderContext();
   const { version } = useVersion(versionId);
+  useVersionFilterWarning(versionId, version?.language_tag);
 
   const bookData = useMemo(() => {
     return booksData.find((b) => b.id === book);

--- a/packages/ui/src/components/bible-version-picker.test.tsx
+++ b/packages/ui/src/components/bible-version-picker.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 /* eslint-disable @typescript-eslint/no-empty-function */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, onTestFinished } from 'vitest';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -763,6 +763,11 @@ describe('BibleVersionPicker', () => {
       key === RECENT_VERSIONS_KEY ? JSON.stringify(stored) : null,
     );
     const setItem = vi.spyOn(window.localStorage, 'setItem');
+    // The config is a module-level singleton: reset on finish, not after the
+    // assertions, so a failure here can't hand its filter to the next test.
+    onTestFinished(() => {
+      YouVersionPlatformConfiguration.excludedVersionIds = undefined;
+    });
     YouVersionPlatformConfiguration.excludedVersionIds = [206];
 
     setupDefaultMocks();
@@ -805,6 +810,9 @@ describe('BibleVersionPicker', () => {
     vi.spyOn(window.localStorage, 'getItem').mockImplementation((key) =>
       key === RECENT_VERSIONS_KEY ? JSON.stringify(stored) : null,
     );
+    onTestFinished(() => {
+      YouVersionPlatformConfiguration.permittedLanguageTags = undefined;
+    });
     YouVersionPlatformConfiguration.permittedLanguageTags = ['en'];
 
     setupDefaultMocks();
@@ -817,7 +825,5 @@ describe('BibleVersionPicker', () => {
     const recentList = await screen.findByTestId('recent-version-list');
     expect(within(recentList).getByText('New International Version')).toBeInTheDocument();
     expect(within(recentList).queryByText('Reina Valera 1960')).toBeNull();
-
-    YouVersionPlatformConfiguration.permittedLanguageTags = undefined;
   });
 });

--- a/packages/ui/src/components/bible-version-picker.test.tsx
+++ b/packages/ui/src/components/bible-version-picker.test.tsx
@@ -29,7 +29,12 @@ import {
   useOrganizations,
   useTheme,
 } from '@youversion/platform-react-hooks';
-import type { BibleVersion, Language, Organization } from '@youversion/platform-core';
+import {
+  YouVersionPlatformConfiguration,
+  type BibleVersion,
+  type Language,
+  type Organization,
+} from '@youversion/platform-core';
 
 vi.mock('@youversion/platform-react-hooks');
 
@@ -737,5 +742,82 @@ describe('BibleVersionPicker', () => {
       expect(onLanguageChange).toHaveBeenCalledWith('ko');
       expect(screen.getByRole('heading', { name: /bible versions/i })).toBeInTheDocument();
     });
+  });
+
+  it('drops an excluded version from recents at read time and leaves localStorage alone', async () => {
+    const stored = [
+      {
+        id: 111,
+        title: 'New International Version',
+        localized_abbreviation: 'NIV',
+        abbreviation: 'NIV',
+      },
+      {
+        id: 206,
+        title: 'New Living Translation',
+        localized_abbreviation: 'NLT',
+        abbreviation: 'NLT',
+      },
+    ];
+    vi.spyOn(window.localStorage, 'getItem').mockImplementation((key) =>
+      key === RECENT_VERSIONS_KEY ? JSON.stringify(stored) : null,
+    );
+    const setItem = vi.spyOn(window.localStorage, 'setItem');
+    YouVersionPlatformConfiguration.excludedVersionIds = [206];
+
+    setupDefaultMocks();
+    const { unmount } = renderPicker();
+    await openPicker();
+
+    // Scoped to the recents list: the hooks are stubbed here, so the all-versions
+    // list below is not the core-filtered one a real app would get.
+    const recentList = await screen.findByTestId('recent-version-list');
+    expect(within(recentList).getByText('New International Version')).toBeInTheDocument();
+    expect(within(recentList).queryByText('New Living Translation')).toBeNull();
+    expect(setItem).not.toHaveBeenCalledWith(RECENT_VERSIONS_KEY, expect.anything());
+
+    // Storage was never scrubbed, so lifting the exclusion brings the recent back.
+    unmount();
+    YouVersionPlatformConfiguration.excludedVersionIds = undefined;
+    setupDefaultMocks();
+    renderPicker();
+    await openPicker();
+
+    const restoredList = await screen.findByTestId('recent-version-list');
+    expect(within(restoredList).getByText('New Living Translation')).toBeInTheDocument();
+  });
+
+  it('judges a recent by the language tag from the versions list, not by the absent stored tag', async () => {
+    const stored = [
+      {
+        id: 111,
+        title: 'New International Version',
+        localized_abbreviation: 'NIV',
+        abbreviation: 'NIV',
+      },
+      {
+        id: 222,
+        title: 'Reina Valera 1960',
+        localized_abbreviation: 'RVR1960',
+        abbreviation: 'RVR1960',
+      },
+    ];
+    vi.spyOn(window.localStorage, 'getItem').mockImplementation((key) =>
+      key === RECENT_VERSIONS_KEY ? JSON.stringify(stored) : null,
+    );
+    YouVersionPlatformConfiguration.permittedLanguageTags = ['en'];
+
+    setupDefaultMocks();
+    renderPicker();
+    await openPicker();
+
+    // Stored recents carry no `language_tag`. 111 is tagged `en` in the
+    // all-languages version list; without that lookup the predicate would reject
+    // it for a missing tag. 222 is tagged `es` and is genuinely filtered out.
+    const recentList = await screen.findByTestId('recent-version-list');
+    expect(within(recentList).getByText('New International Version')).toBeInTheDocument();
+    expect(within(recentList).queryByText('Reina Valera 1960')).toBeNull();
+
+    YouVersionPlatformConfiguration.permittedLanguageTags = undefined;
   });
 });

--- a/packages/ui/src/components/bible-version-picker.tsx
+++ b/packages/ui/src/components/bible-version-picker.tsx
@@ -3,6 +3,7 @@ import i18n from '@/i18n';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import {
   getLocalStorage,
+  isVersionPermitted,
   setStorageItem,
   type BibleVersion,
   type Language,
@@ -326,23 +327,42 @@ function Root({
     },
   );
   const isLoadingLanguages = languagesLoading || versionsLanguageInfoLoading;
+
+  // Recents are persisted, so a version the app later excludes is still in
+  // localStorage. Filter at read time rather than scrubbing storage: lifting an
+  // exclusion restores the recent (ADR-0005).
+  //
+  // The stored rows carry no `language_tag`, and `isVersionPermitted` rejects a
+  // missing tag whenever `permittedLanguageTags` is active — so look the tag up
+  // in the all-languages version list instead of guessing. That list comes from
+  // core already filtered, so a version missing from it is one the filters
+  // hide, which is the same answer the predicate gives.
+  const permittedRecentVersions = useMemo(() => {
+    const languageTagById = new Map(
+      (versionsLanguageInfo?.data ?? []).map((version) => [version.id, version.language_tag]),
+    );
+    return recentVersions.filter((version) =>
+      isVersionPermitted(version.id, languageTagById.get(version.id)),
+    );
+  }, [recentVersions, versionsLanguageInfo?.data]);
+
   const filteredVersions = useFilteredVersions(
     versions?.data || [],
     searchQuery,
     selectedLanguageId,
-    recentVersions,
+    permittedRecentVersions,
   );
 
   const filteredRecentVersions = useMemo(() => {
-    if (!searchQuery.trim()) return recentVersions;
+    if (!searchQuery.trim()) return permittedRecentVersions;
     const query = searchQuery.trim().toLowerCase();
-    return recentVersions.filter(
+    return permittedRecentVersions.filter(
       (v) =>
         v.title?.toLowerCase().includes(query) ||
         v.localized_abbreviation?.toLowerCase().includes(query) ||
         v.abbreviation?.toLowerCase().includes(query),
     );
-  }, [recentVersions, searchQuery]);
+  }, [permittedRecentVersions, searchQuery]);
 
   const getLanguageDisplayName = useCallback(
     (language: Pick<Language, 'id' | 'display_names'>) => {
@@ -429,7 +449,7 @@ function Root({
     filteredRecentVersions,
     isLanguagesOpen,
     setIsLanguagesOpen,
-    recentVersions,
+    recentVersions: permittedRecentVersions,
     addRecentVersion,
     isPopoverOpen,
     setIsPopoverOpen,

--- a/packages/ui/src/components/verse-of-the-day.tsx
+++ b/packages/ui/src/components/verse-of-the-day.tsx
@@ -17,6 +17,7 @@ import { Button } from '@/components/ui/button';
 import { BibleTextView } from '@/components/verse';
 import { DEFAULT_LICENSE_FREE_BIBLE_VERSION } from '@youversion/platform-core';
 import { cn } from '@/lib/utils';
+import { useVersionFilterWarning } from '@/lib/use-version-filter-warning';
 
 export type VerseOfTheDayShareData = {
   /** Full share body: verse text, blank line, then reference (same as Web Share `text`). */
@@ -144,6 +145,7 @@ export function VerseOfTheDay({
     },
   });
   const { version, loading: loadingVersion } = useVersion(versionId);
+  useVersionFilterWarning(versionId, version?.language_tag);
   const providerTheme = useTheme();
   const theme = background || providerTheme;
 

--- a/packages/ui/src/lib/use-version-filter-warning.test.ts
+++ b/packages/ui/src/lib/use-version-filter-warning.test.ts
@@ -1,12 +1,17 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, onTestFinished, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { YouVersionPlatformConfiguration } from '@youversion/platform-core';
 import { resetVersionFilterWarnings, useVersionFilterWarning } from './use-version-filter-warning';
 
-/** Ready-to-run subject: clean ledger, clean filters, a spied `console.warn`. */
+/**
+ * Ready-to-run subject: clean ledger, clean filters, a spied `console.warn`.
+ * The filters and the ledger are module-level globals, so teardown registers
+ * with `onTestFinished` — it has to run even when an assertion throws, or the
+ * rest of the file inherits this test's config.
+ */
 function setup(filters: {
   permittedVersionIds?: number[];
   excludedVersionIds?: number[];
@@ -18,19 +23,19 @@ function setup(filters: {
   YouVersionPlatformConfiguration.permittedLanguageTags = filters.permittedLanguageTags;
 
   const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-  const cleanup = () => {
+  onTestFinished(() => {
     warn.mockRestore();
     YouVersionPlatformConfiguration.permittedVersionIds = undefined;
     YouVersionPlatformConfiguration.excludedVersionIds = undefined;
     YouVersionPlatformConfiguration.permittedLanguageTags = undefined;
     resetVersionFilterWarnings();
-  };
-  return { warn, cleanup };
+  });
+  return { warn };
 }
 
 describe('useVersionFilterWarning', () => {
   it('warns once per hidden version id and stays silent for permitted ones', () => {
-    const { warn, cleanup } = setup({ excludedVersionIds: [206] });
+    const { warn } = setup({ excludedVersionIds: [206] });
 
     const hidden = renderHook(() => useVersionFilterWarning(206, 'en'));
     expect(warn).toHaveBeenCalledTimes(1);
@@ -45,12 +50,10 @@ describe('useVersionFilterWarning', () => {
     // A different, permitted version says nothing at all.
     renderHook(() => useVersionFilterWarning(111, 'en'));
     expect(warn).toHaveBeenCalledTimes(1);
-
-    cleanup();
   });
 
   it('holds the warning until the language tag loads, then warns on a real mismatch', () => {
-    const { warn, cleanup } = setup({ permittedLanguageTags: ['en'] });
+    const { warn } = setup({ permittedLanguageTags: ['en'] });
 
     // No tag yet: rejecting here would be an artifact of the unloaded version
     // data, not of the version's language.
@@ -64,25 +67,25 @@ describe('useVersionFilterWarning', () => {
     rerender({ languageTag: 'es' });
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn.mock.calls[0]?.[0]).toContain('555');
-
-    cleanup();
   });
 
   it('warns before the tag loads when no language filter is active', () => {
-    const { warn, cleanup } = setup({ excludedVersionIds: [777] });
+    const { warn } = setup({ excludedVersionIds: [777] });
 
     renderHook(() => useVersionFilterWarning(777, undefined));
 
     // Without `permittedLanguageTags` the predicate needs no tag, so there is
     // nothing to wait for.
     expect(warn).toHaveBeenCalledTimes(1);
-
-    cleanup();
   });
 
   it('stays silent in production builds', async () => {
     vi.stubEnv('NODE_ENV', 'production');
     vi.resetModules();
+    onTestFinished(() => {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+    });
 
     // Re-import both modules from the fresh graph: the production gate is a
     // module-level constant, and the hook must read the same core copy.
@@ -93,14 +96,13 @@ describe('useVersionFilterWarning', () => {
       ]);
     config.excludedVersionIds = [206];
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    onTestFinished(() => {
+      config.excludedVersionIds = undefined;
+      warn.mockRestore();
+    });
 
     renderHook(() => hookInProd(206, 'en'));
 
     expect(warn).not.toHaveBeenCalled();
-
-    config.excludedVersionIds = undefined;
-    warn.mockRestore();
-    vi.unstubAllEnvs();
-    vi.resetModules();
   });
 });

--- a/packages/ui/src/lib/use-version-filter-warning.test.tsx
+++ b/packages/ui/src/lib/use-version-filter-warning.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { YouVersionPlatformConfiguration } from '@youversion/platform-core';
+import { resetVersionFilterWarnings, useVersionFilterWarning } from './use-version-filter-warning';
+
+/** Ready-to-run subject: clean ledger, clean filters, a spied `console.warn`. */
+function setup(filters: {
+  permittedVersionIds?: number[];
+  excludedVersionIds?: number[];
+  permittedLanguageTags?: string[];
+}) {
+  resetVersionFilterWarnings();
+  YouVersionPlatformConfiguration.permittedVersionIds = filters.permittedVersionIds;
+  YouVersionPlatformConfiguration.excludedVersionIds = filters.excludedVersionIds;
+  YouVersionPlatformConfiguration.permittedLanguageTags = filters.permittedLanguageTags;
+
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  const cleanup = () => {
+    warn.mockRestore();
+    YouVersionPlatformConfiguration.permittedVersionIds = undefined;
+    YouVersionPlatformConfiguration.excludedVersionIds = undefined;
+    YouVersionPlatformConfiguration.permittedLanguageTags = undefined;
+    resetVersionFilterWarnings();
+  };
+  return { warn, cleanup };
+}
+
+describe('useVersionFilterWarning', () => {
+  it('warns once per hidden version id and stays silent for permitted ones', () => {
+    const { warn, cleanup } = setup({ excludedVersionIds: [206] });
+
+    const hidden = renderHook(() => useVersionFilterWarning(206, 'en'));
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain('206');
+
+    // Re-rendering, and a second component rendering the same version, must not
+    // repeat the message — the ledger is module-scoped, not per hook instance.
+    hidden.rerender();
+    renderHook(() => useVersionFilterWarning(206, 'en'));
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    // A different, permitted version says nothing at all.
+    renderHook(() => useVersionFilterWarning(111, 'en'));
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it('holds the warning until the language tag loads, then warns on a real mismatch', () => {
+    const { warn, cleanup } = setup({ permittedLanguageTags: ['en'] });
+
+    // No tag yet: rejecting here would be an artifact of the unloaded version
+    // data, not of the version's language.
+    const { rerender } = renderHook<void, { languageTag?: string }>(
+      ({ languageTag }) => useVersionFilterWarning(555, languageTag),
+      { initialProps: {} },
+    );
+    expect(warn).not.toHaveBeenCalled();
+
+    // Tag loads and really is outside the allowlist.
+    rerender({ languageTag: 'es' });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain('555');
+
+    cleanup();
+  });
+
+  it('warns before the tag loads when no language filter is active', () => {
+    const { warn, cleanup } = setup({ excludedVersionIds: [777] });
+
+    renderHook(() => useVersionFilterWarning(777, undefined));
+
+    // Without `permittedLanguageTags` the predicate needs no tag, so there is
+    // nothing to wait for.
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it('stays silent in production builds', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.resetModules();
+
+    // Re-import both modules from the fresh graph: the production gate is a
+    // module-level constant, and the hook must read the same core copy.
+    const [{ useVersionFilterWarning: hookInProd }, { YouVersionPlatformConfiguration: config }] =
+      await Promise.all([
+        import('./use-version-filter-warning'),
+        import('@youversion/platform-core'),
+      ]);
+    config.excludedVersionIds = [206];
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    renderHook(() => hookInProd(206, 'en'));
+
+    expect(warn).not.toHaveBeenCalled();
+
+    config.excludedVersionIds = undefined;
+    warn.mockRestore();
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+});

--- a/packages/ui/src/lib/use-version-filter-warning.ts
+++ b/packages/ui/src/lib/use-version-filter-warning.ts
@@ -1,0 +1,49 @@
+import { useEffect } from 'react';
+import { isVersionPermitted, YouVersionPlatformConfiguration } from '@youversion/platform-core';
+import { IS_PRODUCTION } from './constants';
+
+// Warn-once ledger, module-scoped so a remount or a sibling component rendering
+// the same version doesn't repeat the message.
+const warnedVersionIds = new Set<number>();
+
+/** Test seam: clears the warn-once ledger. */
+export function resetVersionFilterWarnings(): void {
+  warnedVersionIds.clear();
+}
+
+/**
+ * Dev-only nudge when a component renders a Bible version the configured
+ * filters would hide.
+ *
+ * The version still renders. Filters are list-only (ADR-0005) — they shape what
+ * the SDK offers in the picker and in `getVersions`/`getLanguages`, and never
+ * block rendering a version by id. This is the guardrail for the case where
+ * that divergence is a config mistake rather than a deep link.
+ *
+ * @param versionId The version being rendered.
+ * @param languageTag The version's language tag, once its data has loaded.
+ *   Pass `undefined` while loading; see the missing-tag note below.
+ */
+export function useVersionFilterWarning(versionId: number, languageTag?: string): void {
+  useEffect(() => {
+    if (IS_PRODUCTION) return;
+    if (warnedVersionIds.has(versionId)) return;
+
+    // A version's own data is the only source of its language tag, and
+    // `isVersionPermitted` rejects a missing tag whenever `permittedLanguageTags`
+    // is active. Before the tag loads, that rejection says nothing about the
+    // version — stay quiet rather than warn wrongly.
+    const languageFilterActive = YouVersionPlatformConfiguration.permittedLanguageTags !== undefined;
+    if (languageTag === undefined && languageFilterActive) return;
+
+    if (isVersionPermitted(versionId, languageTag)) return;
+
+    warnedVersionIds.add(versionId);
+    console.warn(
+      `[YouVersion Platform] Bible version ${versionId} is rendering, but the configured ` +
+        'version filters (permittedVersionIds / excludedVersionIds / permittedLanguageTags) ' +
+        'hide it from version and language lists. Rendering is never blocked, so this is only ' +
+        'a problem if the filters were meant to cover it.',
+    );
+  }, [versionId, languageTag]);
+}


### PR DESCRIPTION
## Summary

Apps can now limit which Bible versions the SDK offers, with the same three filters the Swift SDK has (YPE-4657). Filtering runs in core, so lists, hooks, and the version picker all inherit it, and rendering a version by id is never blocked.

## Changes

1. Apps can pass `permittedVersionIds`, `excludedVersionIds`, and `permittedLanguageTags` to `YouVersionProvider` to control which Bible versions the SDK offers.
2. Version and language lists respect the filters at every layer, because `getVersions` and `getLanguages` filter in core.
3. Exclusion beats permission, the two allowlists combine with AND, `undefined` means no restriction, and an empty array permits nothing (Swift parity).
4. The version picker hides filtered-out recent versions at read time and never edits localStorage, so a lifted filter restores them.
5. In development, components warn once when they render a version that the filters hide, and rendering still works.
6. An active filter adds `id` and `language_tag` back into a caller's `fields` projection, so a narrow projection cannot silently empty the list.
7. ADR 0005 and the CONTEXT.md glossary record the design, and the hooks and ui READMEs document the props (one minor changeset, three packages).

**Start here:** change 1: the providers set the config statics during render, because an effect runs after child mount fetches and left them an empty list.

## Flow

<details><summary>Under the hood</summary>

The UI package bundles its own copy of core, so the UI provider mirrors the three values onto that copy. Both providers write the values during render, not in an effect, because React runs child effects before parent effects. The effect-based first draft left child mount fetches with unset config, which silently emptied filtered lists.

</details>

## Test plan

- `pnpm lint`, `pnpm typecheck`, and `turbo build --force`: clean
- Unit suites all pass: core 423, hooks 291, ui 434
- Mutation checks: the new tests fail when the filter predicate, the field add-back, or the dev warning is removed
- Storybook play suite: 43 local failures in files this branch does not touch, assessed as environmental

**Needs manual check:** make sure that the Storybook play suite passes in CI. The local failures look environmental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds app-wide Bible-version allowlists, exclusions, and language-tag filtering across core, hooks, and UI, including filtered picker recents and development warnings.

- Adds public provider configuration and core filtering predicates.
- Filters version and language client results and augments field projections.
- Mirrors configuration into hooks and UI package realms.
- Updates picker recents, component warnings, tests, documentation, ADR, and package changesets.

<h3>Confidence Score: 2/5</h3>

The PR should not merge until provider configuration is commit-safe and the picker reliably retains permitted paginated and recent versions.

Render-phase singleton writes can leak configuration from abandoned renders, first-page filtering can omit permitted versions from the picker, and a failed language-info lookup permanently hides valid recents for the mounted picker.

**Files Needing Attention:** packages/hooks/src/context/YouVersionProvider.tsx, packages/core/src/bible.ts, packages/ui/src/components/bible-version-picker.tsx

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/bible.ts | Adds field projection augmentation and post-fetch version filtering, but single-page filtering can hide permitted rows on later pages. |
| packages/core/src/languages.ts | Adds permitted-language filtering and required id projection while retaining unfiltered pagination metadata. |
| packages/core/src/version-filters.ts | Implements the documented exclusion precedence and intersecting allowlist semantics. |
| packages/hooks/src/context/YouVersionProvider.tsx | Adds public filter props but writes shared configuration during render, allowing abandoned renders to alter committed behavior. |
| packages/ui/src/components/YouVersionProvider.tsx | Mirrors filters into UI's bundled core copy using the same render-phase singleton mutation. |
| packages/ui/src/components/bible-version-picker.tsx | Filters persisted recents, but treats unavailable language lookup data as denial and relies on a bounded selected-language page. |
| packages/ui/src/lib/use-version-filter-warning.ts | Adds a development-only, once-per-version warning without blocking direct rendering. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant App
  participant Provider
  participant Hook
  participant Core
  participant API
  participant Picker
  App->>Provider: Configure version filters
  Provider->>Core: Write ambient filter statics
  Hook->>Core: getVersions/getLanguages
  Core->>API: Fetch server page
  API-->>Core: Unfiltered collection
  Core->>Core: Apply configured filters
  Core-->>Hook: Filtered collection
  Hook-->>Picker: Render offered versions/languages
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20youversion%2Fplatform-sdk-react%20PR%20%23339%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=youversion%2Fplatform-sdk-react&pr=339&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fhooks%2Fsrc%2Fcontext%2FYouVersionProvider.tsx%3A175-177%0A**Render%20leaks%20uncommitted%20filters**%0A%0AWhen%20a%20provider%20render%20suspends%20or%20is%20abandoned%20after%20these%20assignments%2C%20it%20still%20overwrites%20the%20shared%20configuration%20read%20by%20active%20clients%2C%20causing%20committed%20providers%20to%20return%20version%20and%20language%20lists%20filtered%20with%20the%20wrong%20configuration.%0A%0A%23%23%23%20Issue%202%0Apackages%2Fcore%2Fsrc%2Fbible.ts%3A186-190%0A**Page%20filtering%20drops%20permitted%20versions**%0A%0AWhen%20the%20selected%20language's%20first%20server%20page%20contains%20filtered-out%20versions%20and%20permitted%20versions%20exist%20on%20later%20pages%2C%20this%20code%20returns%20an%20empty%20or%20incomplete%20page%20while%20the%20picker%20never%20follows%20%60next_page_token%60%2C%20causing%20those%20permitted%20versions%20to%20remain%20unavailable%20for%20selection.%0A%0A%23%23%23%20Issue%203%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fbible-version-picker.tsx%3A340-347%0A**Failed%20lookup%20hides%20valid%20recents**%0A%0AWhen%20%60permittedLanguageTags%60%20is%20active%20and%20the%20auxiliary%20version-language%20request%20is%20loading%20or%20fails%2C%20the%20empty%20lookup%20passes%20%60undefined%60%20for%20every%20recent%20version%20and%20rejects%20them%20all%3B%20after%20an%20error%2C%20valid%20recents%20remain%20hidden%20for%20the%20lifetime%20of%20the%20mounted%20picker%20because%20the%20request%20error%20and%20refetch%20function%20are%20discarded.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=youversion%2Fplatform-sdk-react&pr=339&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Fhooks%2Fsrc%2Fcontext%2FYouVersionProvider.tsx%3A175-177%0A**Render%20leaks%20uncommitted%20filters**%0A%0AWhen%20a%20provider%20render%20suspends%20or%20is%20abandoned%20after%20these%20assignments%2C%20it%20still%20overwrites%20the%20shared%20configuration%20read%20by%20active%20clients%2C%20causing%20committed%20providers%20to%20return%20version%20and%20language%20lists%20filtered%20with%20the%20wrong%20configuration.%0A%0A%23%23%23%20Issue%202%0Apackages%2Fcore%2Fsrc%2Fbible.ts%3A186-190%0A**Page%20filtering%20drops%20permitted%20versions**%0A%0AWhen%20the%20selected%20language's%20first%20server%20page%20contains%20filtered-out%20versions%20and%20permitted%20versions%20exist%20on%20later%20pages%2C%20this%20code%20returns%20an%20empty%20or%20incomplete%20page%20while%20the%20picker%20never%20follows%20%60next_page_token%60%2C%20causing%20those%20permitted%20versions%20to%20remain%20unavailable%20for%20selection.%0A%0A%23%23%23%20Issue%203%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fbible-version-picker.tsx%3A340-347%0A**Failed%20lookup%20hides%20valid%20recents**%0A%0AWhen%20%60permittedLanguageTags%60%20is%20active%20and%20the%20auxiliary%20version-language%20request%20is%20loading%20or%20fails%2C%20the%20empty%20lookup%20passes%20%60undefined%60%20for%20every%20recent%20version%20and%20rejects%20them%20all%3B%20after%20an%20error%2C%20valid%20recents%20remain%20hidden%20for%20the%20lifetime%20of%20the%20mounted%20picker%20because%20the%20request%20error%20and%20refetch%20function%20are%20discarded.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=339&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-react%22%20on%20the%20existing%20branch%20%22bb%2Fthr_v2nxgsjun2%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22bb%2Fthr_v2nxgsjun2%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Fhooks%2Fsrc%2Fcontext%2FYouVersionProvider.tsx%3A175-177%0A**Render%20leaks%20uncommitted%20filters**%0A%0AWhen%20a%20provider%20render%20suspends%20or%20is%20abandoned%20after%20these%20assignments%2C%20it%20still%20overwrites%20the%20shared%20configuration%20read%20by%20active%20clients%2C%20causing%20committed%20providers%20to%20return%20version%20and%20language%20lists%20filtered%20with%20the%20wrong%20configuration.%0A%0A%23%23%23%20Issue%202%0Apackages%2Fcore%2Fsrc%2Fbible.ts%3A186-190%0A**Page%20filtering%20drops%20permitted%20versions**%0A%0AWhen%20the%20selected%20language's%20first%20server%20page%20contains%20filtered-out%20versions%20and%20permitted%20versions%20exist%20on%20later%20pages%2C%20this%20code%20returns%20an%20empty%20or%20incomplete%20page%20while%20the%20picker%20never%20follows%20%60next_page_token%60%2C%20causing%20those%20permitted%20versions%20to%20remain%20unavailable%20for%20selection.%0A%0A%23%23%23%20Issue%203%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fbible-version-picker.tsx%3A340-347%0A**Failed%20lookup%20hides%20valid%20recents**%0A%0AWhen%20%60permittedLanguageTags%60%20is%20active%20and%20the%20auxiliary%20version-language%20request%20is%20loading%20or%20fails%2C%20the%20empty%20lookup%20passes%20%60undefined%60%20for%20every%20recent%20version%20and%20rejects%20them%20all%3B%20after%20an%20error%2C%20valid%20recents%20remain%20hidden%20for%20the%20lifetime%20of%20the%20mounted%20picker%20because%20the%20request%20error%20and%20refetch%20function%20are%20discarded.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=youversion%2Fplatform-sdk-react&pr=339&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/hooks/src/context/YouVersionProvider.tsx:175-177
**Render leaks uncommitted filters**

When a provider render suspends or is abandoned after these assignments, it still overwrites the shared configuration read by active clients, causing committed providers to return version and language lists filtered with the wrong configuration.

### Issue 2
packages/core/src/bible.ts:186-190
**Page filtering drops permitted versions**

When the selected language's first server page contains filtered-out versions and permitted versions exist on later pages, this code returns an empty or incomplete page while the picker never follows `next_page_token`, causing those permitted versions to remain unavailable for selection.

### Issue 3
packages/ui/src/components/bible-version-picker.tsx:340-347
**Failed lookup hides valid recents**

When `permittedLanguageTags` is active and the auxiliary version-language request is loading or fails, the empty lookup passes `undefined` for every recent version and rejects them all; after an error, valid recents remain hidden for the lifetime of the mounted picker because the request error and refetch function are discarded.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: changesets, docs and ADR for versi..."](https://github.com/youversion/platform-sdk-react/commit/dadfa901c73713cd82db618b8ba0a7ef62e0ecab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54497673)</sub>

> Greptile also left **3 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Core Package (`@youversion/platform-core`)](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/core-package.md)
- Knowledge Base — [packages/hooks — React hooks for the YouVersion Platform](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/hooks-package.md)
- Knowledge Base — [packages/ui](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/ui-package.md)
</details>

<!-- /greptile_comment -->