### PR TITLE
feat(ui): prototype automatic Shadow DOM style isolation

### DIFF
--- a/.changeset/prototype-shadow-dom-isolation.md
+++ b/.changeset/prototype-shadow-dom-isolation.md
@@ -1,0 +1,7 @@
+---
+'@youversion/platform-core': major
+'@youversion/platform-react-hooks': major
+'@youversion/platform-react-ui': major
+---
+
+Prototype automatic Shadow DOM style isolation on `YouVersionAuthButton` so host-page selectors cannot override its internal styles.

--- a/docs/adr/0005-prototype-shadow-dom-style-isolation.md
+++ b/docs/adr/0005-prototype-shadow-dom-style-isolation.md
@@ -8,6 +8,12 @@ Host applications can apply unlayered global rules such as `button { ... }` or
 Tailwind v3 preflight to SDK markup. Unlayered author CSS outranks the SDK's
 layered CSS, so selector specificity alone cannot guarantee isolation.
 
+Resets, stronger selectors, `!important`, cascade layers, and `@scope` all
+continue participating in the host document's cascade. They can reduce
+accidental conflicts but cannot prevent an outside selector from matching SDK
+internals. Shadow DOM was selected because it creates a browser-enforced
+selector boundary.
+
 ## Prototype
 
 `YouVersionAuthButton` automatically creates an open shadow root and renders its
@@ -47,19 +53,20 @@ document-wide `@font-face` limitation.
 - Constructed stylesheets are created per owner document, so mounting the shadow
   host in a same-origin iframe does not cause a cross-document adoption error.
 
-The focused Chromium tests verify a global hostile `button` selector, hostile
-generated content on the light-DOM host, iframe mounting, and existing
-interactions. The unit tests verify Strict Mode and the
-light-DOM host reset. The remaining hostile vectors are available for manual
-inspection on the demo page.
+Focused Chromium stories verify hostile button rules, host-generated
+pseudo-content, existing interactions, and mounting in a same-origin iframe.
+Unit tests verify Strict Mode behavior and the inline-important host reset. The
+remaining hostile vectors are available for manual inspection on the demo page.
 
 ## Compatibility impact
 
 Although the React props API is unchanged, the rendered DOM structure is not.
 Consumers that query or style internal light-DOM markup must instead account for
-the shadow root. The client-effect mount also changes first-paint and server
-rendering behavior. This is therefore represented as a breaking change rather
-than an implementation detail.
+the shadow root. Because the prototype attaches the shadow root in `useEffect`,
+server output contains an empty host. The button appears after hydration, and
+its forwarded ref becomes available later than it did previously. This is
+therefore represented as a breaking change rather than an implementation
+detail.
 
 ## Deliberately deferred
 
@@ -70,6 +77,9 @@ than an implementation detail.
 - A package-wide custom-property audit. `all: initial` does not reset custom
   properties; the larger investigation branch tested redeclaring Tailwind v4's
   generated theme tokens on the protected internal wrapper.
+- A deliberate inheritance policy for writing direction and future custom
+  properties. Some host values may be intentional localization inputs, while
+  SDK-owned visual tokens need shadow-local defaults.
 - Host `@font-face` rules, which are not scoped by Shadow DOM.
 - Ancestor layout constraints, which Shadow DOM cannot isolate.
 - Event retargeting, nested-root behavior, and a supported consumer customization

--- a/docs/adr/0005-prototype-shadow-dom-style-isolation.md
+++ b/docs/adr/0005-prototype-shadow-dom-style-isolation.md
@@ -26,6 +26,9 @@ created in the top-level document cannot be adopted by a shadow root rendered in
 a same-origin iframe. Browsers without constructable stylesheets receive a
 `<style>` element in the root. The light-DOM host gets an inline-important box
 reset; an inner, unreachable wrapper resets inherited standard properties.
+The shadow stylesheet also suppresses `::before` and `::after` on the
+light-DOM host with shadow-context important declarations, preventing host-page
+CSS from injecting generated content around the isolated component.
 Because that reset removes the light-DOM font inheritance the button previously
 relied on, the implementation now applies its intended `font-sans` utility
 explicitly.
@@ -44,8 +47,9 @@ document-wide `@font-face` limitation.
 - Constructed stylesheets are created per owner document, so mounting the shadow
   host in a same-origin iframe does not cause a cross-document adoption error.
 
-The focused Chromium tests verify a global hostile `button` selector, iframe
-mounting, and existing interactions. The unit tests verify Strict Mode and the
+The focused Chromium tests verify a global hostile `button` selector, hostile
+generated content on the light-DOM host, iframe mounting, and existing
+interactions. The unit tests verify Strict Mode and the
 light-DOM host reset. The remaining hostile vectors are available for manual
 inspection on the demo page.
 

--- a/docs/adr/0005-prototype-shadow-dom-style-isolation.md
+++ b/docs/adr/0005-prototype-shadow-dom-style-isolation.md
@@ -1,0 +1,45 @@
+# ADR 0005: Prototype automatic Shadow DOM style isolation
+
+Status: Proposed proof of concept
+
+## Problem
+
+Host applications can apply unlayered global rules such as `button { ... }` or
+Tailwind v3 preflight to SDK markup. Unlayered author CSS outranks the SDK's
+layered CSS, so selector specificity alone cannot guarantee isolation.
+
+## Prototype
+
+`YouVersionAuthButton` automatically creates an open shadow root and renders its
+existing implementation inside it. The SDK's compiled CSS is installed inside
+that root. Consumers continue to write `<YouVersionAuthButton />`; isolation is
+not an option they must discover or enable.
+
+This PR intentionally applies the architecture to one representative component.
+It asks whether automatic Shadow DOM boundaries are the right foundation before
+the same pattern is rolled out across the UI package.
+
+The constructable stylesheet is cached per owner `Document`, because a sheet
+created in the top-level document cannot be adopted by a shadow root rendered in
+a same-origin iframe. Browsers without constructable stylesheets receive a
+`<style>` element in the root. The light-DOM host gets an inline-important box
+reset; an inner, unreachable wrapper resets inherited standard properties.
+
+## What this proves
+
+- Ordinary and `!important` host selectors cannot select the button internals.
+- The consumer API is unchanged and isolation is automatic.
+- Existing click handlers and forwarded refs can cross the React portal.
+- Strict Mode does not attach the root twice.
+
+## Deliberately deferred
+
+- Rollout to all exported components.
+- Radix popover/dialog portal placement and focus management.
+- Form association when controls live outside their form's tree scope.
+- SSR/hydration and the first client paint.
+- Host `@font-face` rules, which are not scoped by Shadow DOM.
+- A full browser/accessibility matrix and consumer test-query migration guidance.
+
+This prototype should be reviewed as an architectural checkpoint, not as a
+complete solution ready for release.

--- a/docs/adr/0005-prototype-shadow-dom-style-isolation.md
+++ b/docs/adr/0005-prototype-shadow-dom-style-isolation.md
@@ -11,9 +11,11 @@ layered CSS, so selector specificity alone cannot guarantee isolation.
 ## Prototype
 
 `YouVersionAuthButton` automatically creates an open shadow root and renders its
-existing implementation inside it. The SDK's compiled CSS is installed inside
-that root. Consumers continue to write `<YouVersionAuthButton />`; isolation is
-not an option they must discover or enable.
+existing implementation inside it through a React portal. The SDK's compiled
+Tailwind CSS—generated from `src/styles/global.css` and embedded as
+`__YV_STYLES__`—is installed inside that root. Consumers continue to write
+`<YouVersionAuthButton />`; isolation is not an option they must discover or
+enable.
 
 This PR intentionally applies the architecture to one representative component.
 It asks whether automatic Shadow DOM boundaries are the right foundation before
@@ -24,13 +26,36 @@ created in the top-level document cannot be adopted by a shadow root rendered in
 a same-origin iframe. Browsers without constructable stylesheets receive a
 `<style>` element in the root. The light-DOM host gets an inline-important box
 reset; an inner, unreachable wrapper resets inherited standard properties.
+Because that reset removes the light-DOM font inheritance the button previously
+relied on, the implementation now applies its intended `font-sans` utility
+explicitly.
+
+The Vite example includes a Hostile CSS page with a light-DOM positive control
+beside the isolated SDK button. It demonstrates type selectors, inherited
+properties, universal `!important` rules, direct shadow-host attacks, and a known
+document-wide `@font-face` limitation.
 
 ## What this proves
 
 - Ordinary and `!important` host selectors cannot select the button internals.
-- The consumer API is unchanged and isolation is automatic.
-- Existing click handlers and forwarded refs can cross the React portal.
+- Isolation is automatic without changing the component's React props API.
+- Existing click behavior continues to work through the React portal.
 - Strict Mode does not attach the root twice.
+- Constructed stylesheets are created per owner document, so mounting the shadow
+  host in a same-origin iframe does not cause a cross-document adoption error.
+
+The focused Chromium tests verify a global hostile `button` selector, iframe
+mounting, and existing interactions. The unit tests verify Strict Mode and the
+light-DOM host reset. The remaining hostile vectors are available for manual
+inspection on the demo page.
+
+## Compatibility impact
+
+Although the React props API is unchanged, the rendered DOM structure is not.
+Consumers that query or style internal light-DOM markup must instead account for
+the shadow root. The client-effect mount also changes first-paint and server
+rendering behavior. This is therefore represented as a breaking change rather
+than an implementation detail.
 
 ## Deliberately deferred
 
@@ -38,8 +63,17 @@ reset; an inner, unreachable wrapper resets inherited standard properties.
 - Radix popover/dialog portal placement and focus management.
 - Form association when controls live outside their form's tree scope.
 - SSR/hydration and the first client paint.
+- A package-wide custom-property audit. `all: initial` does not reset custom
+  properties; the larger investigation branch tested redeclaring Tailwind v4's
+  generated theme tokens on the protected internal wrapper.
 - Host `@font-face` rules, which are not scoped by Shadow DOM.
-- A full browser/accessibility matrix and consumer test-query migration guidance.
+- Ancestor layout constraints, which Shadow DOM cannot isolate.
+- Event retargeting, nested-root behavior, and a supported consumer customization
+  model.
+- Stylesheet construction/adoption failure recovery beyond feature fallback.
+- A full browser and assistive-technology matrix; current browser verification is
+  Chromium-focused.
+- Consumer test-query migration guidance and a component-by-component rollout.
 
 This prototype should be reviewed as an architectural checkpoint, not as a
 complete solution ready for release.

--- a/examples/vite-react/src/App.tsx
+++ b/examples/vite-react/src/App.tsx
@@ -3,8 +3,9 @@ import { Navbar } from '@/components/navbar';
 import { BibleReaderPage } from '@/pages/BibleReaderPage';
 import { VotdPage } from '@/pages/VotdPage';
 import { BibleCardPage } from '@/pages/BibleCardPage';
+import { HostileCssPage } from '@/pages/HostileCssPage';
 
-export type Page = 'bible-reader' | 'votd' | 'bible-card';
+export type Page = 'bible-reader' | 'votd' | 'bible-card' | 'hostile-css';
 
 function App() {
   const [currentPage, setCurrentPage] = useState<Page>('bible-reader');
@@ -16,6 +17,7 @@ function App() {
         {currentPage === 'bible-reader' && <BibleReaderPage />}
         {currentPage === 'votd' && <VotdPage />}
         {currentPage === 'bible-card' && <BibleCardPage />}
+        {currentPage === 'hostile-css' && <HostileCssPage />}
       </main>
     </div>
   );

--- a/examples/vite-react/src/components/navbar.tsx
+++ b/examples/vite-react/src/components/navbar.tsx
@@ -10,6 +10,7 @@ const navItems: { label: string; page: Page }[] = [
   { label: 'Bible Reader', page: 'bible-reader' },
   { label: 'Verse of the Day', page: 'votd' },
   { label: 'Bible Card', page: 'bible-card' },
+  { label: 'Hostile CSS', page: 'hostile-css' },
 ];
 
 interface NavbarProps {

--- a/examples/vite-react/src/pages/HostileCssPage.tsx
+++ b/examples/vite-react/src/pages/HostileCssPage.tsx
@@ -1,0 +1,161 @@
+import { useState } from 'react';
+import { YouVersionAuthButton } from '@youversion/platform-react-ui';
+
+interface HostileVector {
+  key: string;
+  label: string;
+  expectation: string;
+  css: string;
+}
+
+const HOSTILE_VECTORS: HostileVector[] = [
+  {
+    key: 'type-selectors',
+    label: 'Type selectors',
+    expectation: 'The plain button changes; the SDK button should not.',
+    css: `
+.hostile-zone button,
+.hostile-zone [role='button'] {
+  appearance: none !important;
+  background: #b91c1c !important;
+  border: 8px dashed #84cc16 !important;
+  border-radius: 0 !important;
+  color: #fff !important;
+  font: 28px/1 fantasy !important;
+  padding: 28px !important;
+  text-transform: uppercase !important;
+}`,
+  },
+  {
+    key: 'inherited',
+    label: 'Inherited properties',
+    expectation: 'Host text changes; the SDK button should retain its typography.',
+    css: `
+.hostile-zone {
+  color: #d600d6 !important;
+  cursor: crosshair !important;
+  font-family: 'Comic Sans MS', fantasy !important;
+  font-size: 24px !important;
+  font-style: italic !important;
+  letter-spacing: 0.25em !important;
+  line-height: 2.4 !important;
+  text-transform: uppercase !important;
+}`,
+  },
+  {
+    key: 'universal-important',
+    label: 'Universal selector with !important',
+    expectation: 'Every reachable host element changes; shadow internals should not.',
+    css: `
+.hostile-zone * {
+  color: #d600d6 !important;
+  font-family: 'Comic Sans MS', fantasy !important;
+  letter-spacing: 0.2em !important;
+  text-transform: uppercase !important;
+}`,
+  },
+  {
+    key: 'shadow-host',
+    label: 'Shadow-host box attack',
+    expectation: 'The witness disappears; the SDK host should remain usable.',
+    css: `
+.hostile-zone [data-yv-shadow-host],
+.hostile-zone [data-host-box-witness] {
+  display: none !important;
+  opacity: 0 !important;
+  pointer-events: none !important;
+  transform: scale(0.5) !important;
+}`,
+  },
+  {
+    key: 'font-face',
+    label: '@font-face family collision (known limitation)',
+    expectation:
+      'Registers a document-level Inter collision that can reach the shadow tree; the visible result depends on locally installed fonts.',
+    css: `
+@font-face {
+  font-family: 'Inter';
+  src: local('Comic Sans MS'), local('Chalkboard SE');
+}
+@font-face {
+  font-family: 'Untitled Serif';
+  src: local('Comic Sans MS'), local('Chalkboard SE');
+}`,
+  },
+];
+
+export function HostileCssPage() {
+  const [enabled, setEnabled] = useState<Record<string, boolean>>({
+    'type-selectors': true,
+    inherited: false,
+    'universal-important': false,
+    'shadow-host': false,
+    'font-face': false,
+  });
+
+  const toggle = (key: string) => {
+    setEnabled((current) => ({ ...current, [key]: !current[key] }));
+  };
+
+  return (
+    <div className="flex flex-col gap-8 p-6 md:p-12">
+      {HOSTILE_VECTORS.filter((vector) => enabled[vector.key]).map((vector) => (
+        <style key={vector.key}>{vector.css}</style>
+      ))}
+
+      <section className="rounded-lg border p-5">
+        <h1 className="text-xl font-semibold">Automatic Shadow DOM isolation POC</h1>
+        <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+          This branch automatically isolates only <code>YouVersionAuthButton</code>. The plain host
+          controls are positive witnesses: they should look broken when an attack is active, while
+          the SDK button should remain stable. The font-face option demonstrates a known Shadow DOM
+          limitation.
+        </p>
+
+        <fieldset className="mt-5 flex flex-col gap-3">
+          <legend className="mb-2 font-medium">Hostile stylesheet vectors</legend>
+          {HOSTILE_VECTORS.map((vector) => (
+            <label key={vector.key} className="flex items-start gap-3 text-sm">
+              <input
+                className="mt-1"
+                type="checkbox"
+                checked={enabled[vector.key] ?? false}
+                onChange={() => toggle(vector.key)}
+              />
+              <span>
+                <span className="font-medium">{vector.label}</span>
+                <span className="block text-muted-foreground">{vector.expectation}</span>
+              </span>
+            </label>
+          ))}
+        </fieldset>
+      </section>
+
+      <div className="hostile-zone grid gap-8 md:grid-cols-2">
+        <section className="flex flex-col gap-5 rounded-lg border border-dashed p-5">
+          <h2 className="text-sm font-semibold">LIGHT DOM — SHOULD BE AFFECTED</h2>
+          <button type="button">Plain host-app button</button>
+          <p>Plain host text for inherited-property attacks.</p>
+          <div data-host-box-witness className="rounded border p-3">
+            Host-box witness — this should disappear during the host attack.
+          </div>
+          <p style={{ fontFamily: 'Inter, sans-serif' }}>
+            Host text requesting Inter for the font-face collision.
+          </p>
+        </section>
+
+        <section className="flex flex-col gap-5 rounded-lg border p-5">
+          <h2 className="text-sm font-semibold">SDK POC — SHOULD RESIST</h2>
+          <YouVersionAuthButton
+            size="short"
+            onAuthError={(error) => console.error('Auth error:', error)}
+          />
+          <p className="text-sm text-muted-foreground">
+            Other SDK components are intentionally absent: automatic isolation has not been rolled
+            out to them on this POC branch.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/examples/vite-react/src/pages/HostileCssPage.tsx
+++ b/examples/vite-react/src/pages/HostileCssPage.tsx
@@ -73,6 +73,22 @@ const HOSTILE_VECTORS: HostileVector[] = [
 }`,
   },
   {
+    key: 'host-pseudo-elements',
+    label: 'Shadow-host pseudo-elements',
+    expectation: 'The witness gains generated content; the SDK host should not.',
+    example: '[data-yv-shadow-host]::before { content: … !important }',
+    css: `
+.hostile-zone [data-yv-shadow-host]::before,
+.hostile-zone [data-yv-shadow-host]::after,
+.hostile-zone [data-host-pseudo-witness]::before {
+  content: 'HOSTILE' !important;
+  display: block !important;
+  background: #b91c1c !important;
+  color: #fff !important;
+  padding: 8px !important;
+}`,
+  },
+  {
     key: 'font-face',
     label: '@font-face family collision (known limitation)',
     expectation:
@@ -96,6 +112,7 @@ export function HostileCssPage() {
     inherited: false,
     'universal-important': false,
     'shadow-host': false,
+    'host-pseudo-elements': false,
     'font-face': false,
   });
 
@@ -152,6 +169,9 @@ export function HostileCssPage() {
           <p>Plain host text for inherited-property attacks.</p>
           <div data-host-box-witness className="rounded border p-3">
             Host-box witness — this should disappear during the host attack.
+          </div>
+          <div data-host-pseudo-witness className="rounded border p-3">
+            Pseudo-element witness — generated content should appear above this text.
           </div>
           <p style={{ fontFamily: 'Inter, sans-serif' }}>
             Host text requesting Inter for the font-face collision.

--- a/examples/vite-react/src/pages/HostileCssPage.tsx
+++ b/examples/vite-react/src/pages/HostileCssPage.tsx
@@ -5,6 +5,7 @@ interface HostileVector {
   key: string;
   label: string;
   expectation: string;
+  example: string;
   css: string;
 }
 
@@ -13,6 +14,7 @@ const HOSTILE_VECTORS: HostileVector[] = [
     key: 'type-selectors',
     label: 'Type selectors',
     expectation: 'The plain button changes; the SDK button should not.',
+    example: 'button { … }',
     css: `
 .hostile-zone button,
 .hostile-zone [role='button'] {
@@ -30,6 +32,7 @@ const HOSTILE_VECTORS: HostileVector[] = [
     key: 'inherited',
     label: 'Inherited properties',
     expectation: 'Host text changes; the SDK button should retain its typography.',
+    example: '.hostile-zone { font-family: … }',
     css: `
 .hostile-zone {
   color: #d600d6 !important;
@@ -46,6 +49,7 @@ const HOSTILE_VECTORS: HostileVector[] = [
     key: 'universal-important',
     label: 'Universal selector with !important',
     expectation: 'Every reachable host element changes; shadow internals should not.',
+    example: '* { … !important }',
     css: `
 .hostile-zone * {
   color: #d600d6 !important;
@@ -58,6 +62,7 @@ const HOSTILE_VECTORS: HostileVector[] = [
     key: 'shadow-host',
     label: 'Shadow-host box attack',
     expectation: 'The witness disappears; the SDK host should remain usable.',
+    example: '[data-yv-shadow-host] { display: none !important }',
     css: `
 .hostile-zone [data-yv-shadow-host],
 .hostile-zone [data-host-box-witness] {
@@ -72,6 +77,7 @@ const HOSTILE_VECTORS: HostileVector[] = [
     label: '@font-face family collision (known limitation)',
     expectation:
       'Registers a document-level Inter collision that can reach the shadow tree; the visible result depends on locally installed fonts.',
+    example: "@font-face { font-family: 'Inter'; … }",
     css: `
 @font-face {
   font-family: 'Inter';
@@ -115,18 +121,26 @@ export function HostileCssPage() {
         <fieldset className="mt-5 flex flex-col gap-3">
           <legend className="mb-2 font-medium">Hostile stylesheet vectors</legend>
           {HOSTILE_VECTORS.map((vector) => (
-            <label key={vector.key} className="flex items-start gap-3 text-sm">
-              <input
-                className="mt-1"
-                type="checkbox"
-                checked={enabled[vector.key] ?? false}
-                onChange={() => toggle(vector.key)}
-              />
-              <span>
-                <span className="font-medium">{vector.label}</span>
-                <span className="block text-muted-foreground">{vector.expectation}</span>
-              </span>
-            </label>
+            <div
+              key={vector.key}
+              className="flex flex-col gap-2 rounded-md border p-3 sm:flex-row sm:items-center sm:justify-between"
+            >
+              <label className="flex items-start gap-3 text-sm">
+                <input
+                  className="mt-1"
+                  type="checkbox"
+                  checked={enabled[vector.key] ?? false}
+                  onChange={() => toggle(vector.key)}
+                />
+                <span>
+                  <span className="font-medium">{vector.label}</span>
+                  <span className="block text-muted-foreground">{vector.expectation}</span>
+                </span>
+              </label>
+              <code className="w-fit max-w-full overflow-x-auto whitespace-nowrap rounded bg-muted px-2 py-1 text-xs">
+                {vector.example}
+              </code>
+            </div>
           ))}
         </fieldset>
       </section>

--- a/examples/vite-react/src/pages/HostileCssPage.tsx
+++ b/examples/vite-react/src/pages/HostileCssPage.tsx
@@ -162,28 +162,32 @@ export function HostileCssPage() {
         </fieldset>
       </section>
 
-      <div className="hostile-zone grid gap-8 md:grid-cols-2">
+      <div className="grid gap-8 md:grid-cols-2">
         <section className="flex flex-col gap-5 rounded-lg border border-dashed p-5">
           <h2 className="text-sm font-semibold">LIGHT DOM — SHOULD BE AFFECTED</h2>
-          <button type="button">Plain host-app button</button>
-          <p>Plain host text for inherited-property attacks.</p>
-          <div data-host-box-witness className="rounded border p-3">
-            Host-box witness — this should disappear during the host attack.
+          <div className="hostile-zone flex flex-col gap-5">
+            <button type="button">Plain host-app button</button>
+            <p>Plain host text for inherited-property attacks.</p>
+            <div data-host-box-witness className="rounded border p-3">
+              Host-box witness — this should disappear during the host attack.
+            </div>
+            <div data-host-pseudo-witness className="rounded border p-3">
+              Pseudo-element witness — generated content should appear above this text.
+            </div>
+            <p style={{ fontFamily: 'Inter, sans-serif' }}>
+              Host text requesting Inter for the font-face collision.
+            </p>
           </div>
-          <div data-host-pseudo-witness className="rounded border p-3">
-            Pseudo-element witness — generated content should appear above this text.
-          </div>
-          <p style={{ fontFamily: 'Inter, sans-serif' }}>
-            Host text requesting Inter for the font-face collision.
-          </p>
         </section>
 
         <section className="flex flex-col gap-5 rounded-lg border p-5">
           <h2 className="text-sm font-semibold">SDK POC — SHOULD RESIST</h2>
-          <YouVersionAuthButton
-            size="short"
-            onAuthError={(error) => console.error('Auth error:', error)}
-          />
+          <div className="hostile-zone">
+            <YouVersionAuthButton
+              size="short"
+              onAuthError={(error) => console.error('Auth error:', error)}
+            />
+          </div>
           <p className="text-sm text-muted-foreground">
             Other SDK components are intentionally absent: automatic isolation has not been rolled
             out to them on this POC branch.

--- a/packages/ui/src/components/YouVersionAuthButton.shadow-isolation.stories.tsx
+++ b/packages/ui/src/components/YouVersionAuthButton.shadow-isolation.stories.tsx
@@ -5,6 +5,13 @@ import { expect, waitFor } from 'storybook/test';
 import { ShadowRootHost } from '../lib/shadow-root-host';
 import { YouVersionAuthButton } from './YouVersionAuthButton';
 
+/**
+ * Focused architectural POC coverage. These stories answer two questions:
+ * whether a literal global `button {}` rule can change an automatically
+ * isolated SDK button, and whether the document-bound constructed stylesheet
+ * works when a shadow host mounts in a same-origin iframe. Package-wide hostile
+ * vectors and component-specific behavior are deliberately deferred.
+ */
 const HOSTILE_CSS = `
   button {
     appearance: none !important;
@@ -34,6 +41,24 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+function buttonStyleSnapshot(button: HTMLButtonElement) {
+  const styles = getComputedStyle(button);
+  return {
+    appearance: styles.appearance,
+    backgroundColor: styles.backgroundColor,
+    borderTopColor: styles.borderTopColor,
+    borderTopStyle: styles.borderTopStyle,
+    borderTopWidth: styles.borderTopWidth,
+    color: styles.color,
+    display: styles.display,
+    fontFamily: styles.fontFamily,
+    fontSize: styles.fontSize,
+    lineHeight: styles.lineHeight,
+    padding: styles.padding,
+    textTransform: styles.textTransform,
+  };
+}
+
 export const HostileGlobalButtonRule: Story = {
   tags: ['integration'],
   render: () => (
@@ -45,32 +70,45 @@ export const HostileGlobalButtonRule: Story = {
     </div>
   ),
   play: async ({ canvasElement }) => {
+    const control = await waitFor(() => {
+      const element = canvasElement.querySelector<HTMLButtonElement>(
+        '[data-testid="host-control"]',
+      );
+      if (!element) throw new Error('host control not rendered');
+      return element;
+    });
+    const host = await waitFor(() => {
+      const element = canvasElement.querySelector<HTMLElement>('[data-yv-shadow-host]');
+      if (!element?.shadowRoot) throw new Error('shadow root not attached');
+      return element;
+    });
+    const sdkButton = await waitFor(() => {
+      const element = host.shadowRoot?.querySelector<HTMLButtonElement>(
+        '[data-testid="sdk-button"]',
+      );
+      if (!element) throw new Error('SDK button not rendered');
+      return element;
+    });
+
+    const sdkBaseline = buttonStyleSnapshot(sdkButton);
+    // Guard against a false positive where an unstyled browser-default button
+    // also happens not to equal the hostile values below.
+    void expect(sdkBaseline.display).toBe('flex');
+    void expect(sdkBaseline.fontFamily).toContain('Inter');
+
     const style = document.createElement('style');
     style.textContent = HOSTILE_CSS;
-    document.head.append(style);
 
     try {
-      const control = await waitFor(() => {
-        const element = canvasElement.querySelector<HTMLElement>('[data-testid="host-control"]');
-        if (!element) throw new Error('host control not rendered');
-        return element;
-      });
-      const host = await waitFor(() => {
-        const element = canvasElement.querySelector<HTMLElement>('[data-yv-shadow-host]');
-        if (!element?.shadowRoot) throw new Error('shadow root not attached');
-        return element;
-      });
-      const sdkButton = await waitFor(() => {
-        const element = host.shadowRoot?.querySelector<HTMLElement>('[data-testid="sdk-button"]');
-        if (!element) throw new Error('SDK button not rendered');
-        return element;
-      });
+      document.head.append(style);
+
       await waitFor(() => {
         void expect(getComputedStyle(control).backgroundColor).toBe('rgb(185, 28, 28)');
       });
-      void expect(getComputedStyle(sdkButton).backgroundColor).not.toBe('rgb(185, 28, 28)');
-      void expect(getComputedStyle(sdkButton).borderTopWidth).not.toBe('10px');
-      void expect(getComputedStyle(sdkButton).fontSize).not.toBe('32px');
+
+      // The complete relevant style snapshot—not merely a few negative values—
+      // must remain identical to the pre-attack SDK baseline.
+      void expect(buttonStyleSnapshot(sdkButton)).toEqual(sdkBaseline);
     } finally {
       style.remove();
     }
@@ -97,10 +135,12 @@ export const SameOriginIframeDocument: Story = {
       );
 
       await waitFor(() => {
-        const host = iframe.contentDocument?.querySelector<HTMLElement>('[data-yv-shadow-host]');
-        const content = host?.shadowRoot?.querySelector('[data-testid="iframe-content"]');
+        const host = iframe.contentDocument?.querySelector<HTMLDivElement>('[data-yv-shadow-host]');
+        const shadowRoot = host?.shadowRoot;
+        const content = shadowRoot?.querySelector('[data-testid="iframe-content"]');
         if (!content) throw new Error('iframe shadow content not mounted');
         void expect(host?.ownerDocument).toBe(iframe.contentDocument);
+        void expect(shadowRoot?.adoptedStyleSheets).toHaveLength(1);
       });
     } finally {
       root.unmount();

--- a/packages/ui/src/components/YouVersionAuthButton.shadow-isolation.stories.tsx
+++ b/packages/ui/src/components/YouVersionAuthButton.shadow-isolation.stories.tsx
@@ -1,0 +1,110 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { http, HttpResponse } from 'msw';
+import { createRoot } from 'react-dom/client';
+import { expect, waitFor } from 'storybook/test';
+import { ShadowRootHost } from '../lib/shadow-root-host';
+import { YouVersionAuthButton } from './YouVersionAuthButton';
+
+const HOSTILE_CSS = `
+  button {
+    appearance: none !important;
+    background: rgb(185, 28, 28) !important;
+    border: 10px dashed lime !important;
+    color: yellow !important;
+    font: 32px/1 fantasy !important;
+    padding: 40px !important;
+    text-transform: uppercase !important;
+  }
+`;
+
+const meta = {
+  title: 'Spikes/Automatic Shadow DOM isolation',
+  component: YouVersionAuthButton,
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('*/v1/fonts/1/stylesheet', () =>
+          HttpResponse.text('', { headers: { 'Content-Type': 'text/css' } }),
+        ),
+      ],
+    },
+  },
+} satisfies Meta<typeof YouVersionAuthButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const HostileGlobalButtonRule: Story = {
+  tags: ['integration'],
+  render: () => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 24 }}>
+      <button type="button" data-testid="host-control">
+        Host control
+      </button>
+      <YouVersionAuthButton data-testid="sdk-button" />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const style = document.createElement('style');
+    style.textContent = HOSTILE_CSS;
+    document.head.append(style);
+
+    try {
+      const control = await waitFor(() => {
+        const element = canvasElement.querySelector<HTMLElement>('[data-testid="host-control"]');
+        if (!element) throw new Error('host control not rendered');
+        return element;
+      });
+      const host = await waitFor(() => {
+        const element = canvasElement.querySelector<HTMLElement>('[data-yv-shadow-host]');
+        if (!element?.shadowRoot) throw new Error('shadow root not attached');
+        return element;
+      });
+      const sdkButton = await waitFor(() => {
+        const element = host.shadowRoot?.querySelector<HTMLElement>('[data-testid="sdk-button"]');
+        if (!element) throw new Error('SDK button not rendered');
+        return element;
+      });
+      await waitFor(() => {
+        void expect(getComputedStyle(control).backgroundColor).toBe('rgb(185, 28, 28)');
+      });
+      void expect(getComputedStyle(sdkButton).backgroundColor).not.toBe('rgb(185, 28, 28)');
+      void expect(getComputedStyle(sdkButton).borderTopWidth).not.toBe('10px');
+      void expect(getComputedStyle(sdkButton).fontSize).not.toBe('32px');
+    } finally {
+      style.remove();
+    }
+  },
+};
+
+export const SameOriginIframeDocument: Story = {
+  tags: ['integration'],
+  parameters: { includeAuth: false },
+  render: () => <iframe data-testid="iframe" title="same-origin isolation target" />,
+  play: async ({ canvasElement }) => {
+    const iframe = canvasElement.querySelector<HTMLIFrameElement>('[data-testid="iframe"]');
+    if (!iframe?.contentDocument) throw new Error('same-origin iframe document not available');
+
+    const container = iframe.contentDocument.createElement('div');
+    iframe.contentDocument.body.append(container);
+    const root = createRoot(container);
+
+    try {
+      root.render(
+        <ShadowRootHost>
+          <span data-testid="iframe-content">Isolated</span>
+        </ShadowRootHost>,
+      );
+
+      await waitFor(() => {
+        const host = iframe.contentDocument?.querySelector<HTMLElement>('[data-yv-shadow-host]');
+        const content = host?.shadowRoot?.querySelector('[data-testid="iframe-content"]');
+        if (!content) throw new Error('iframe shadow content not mounted');
+        void expect(host?.ownerDocument).toBe(iframe.contentDocument);
+      });
+    } finally {
+      root.unmount();
+      container.remove();
+    }
+  },
+};

--- a/packages/ui/src/components/YouVersionAuthButton.shadow-isolation.stories.tsx
+++ b/packages/ui/src/components/YouVersionAuthButton.shadow-isolation.stories.tsx
@@ -50,7 +50,9 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 function buttonStyleSnapshot(button: HTMLButtonElement) {
-  const styles = getComputedStyle(button);
+  const ownerWindow = button.ownerDocument.defaultView;
+  if (!ownerWindow) throw new Error('button owner window not available');
+  const styles = ownerWindow.getComputedStyle(button);
   return {
     appearance: styles.appearance,
     backgroundColor: styles.backgroundColor,
@@ -78,6 +80,10 @@ export const HostileGlobalButtonRule: Story = {
     </div>
   ),
   play: async ({ canvasElement }) => {
+    const ownerDocument = canvasElement.ownerDocument;
+    const ownerWindow = ownerDocument.defaultView;
+    if (!ownerWindow) throw new Error('story owner window not available');
+
     const control = await waitFor(() => {
       const element = canvasElement.querySelector<HTMLButtonElement>(
         '[data-testid="host-control"]',
@@ -104,21 +110,21 @@ export const HostileGlobalButtonRule: Story = {
     void expect(sdkBaseline.display).toBe('flex');
     void expect(sdkBaseline.fontFamily).toContain('Inter');
 
-    const style = document.createElement('style');
+    const style = ownerDocument.createElement('style');
     style.textContent = HOSTILE_CSS;
 
     try {
-      document.head.append(style);
+      ownerDocument.head.append(style);
 
       await waitFor(() => {
-        void expect(getComputedStyle(control).backgroundColor).toBe('rgb(185, 28, 28)');
-        void expect(getComputedStyle(control, '::before').content).toBe('"HOSTILE"');
+        void expect(ownerWindow.getComputedStyle(control).backgroundColor).toBe('rgb(185, 28, 28)');
+        void expect(ownerWindow.getComputedStyle(control, '::before').content).toBe('"HOSTILE"');
       });
 
-      void expect(getComputedStyle(host, '::before').content).toBe('none');
-      void expect(getComputedStyle(host, '::before').display).toBe('none');
-      void expect(getComputedStyle(host, '::after').content).toBe('none');
-      void expect(getComputedStyle(host, '::after').display).toBe('none');
+      void expect(ownerWindow.getComputedStyle(host, '::before').content).toBe('none');
+      void expect(ownerWindow.getComputedStyle(host, '::before').display).toBe('none');
+      void expect(ownerWindow.getComputedStyle(host, '::after').content).toBe('none');
+      void expect(ownerWindow.getComputedStyle(host, '::after').display).toBe('none');
 
       // The complete relevant style snapshot—not merely a few negative values—
       // must remain identical to the pre-attack SDK baseline.

--- a/packages/ui/src/components/YouVersionAuthButton.shadow-isolation.stories.tsx
+++ b/packages/ui/src/components/YouVersionAuthButton.shadow-isolation.stories.tsx
@@ -22,6 +22,14 @@ const HOSTILE_CSS = `
     padding: 40px !important;
     text-transform: uppercase !important;
   }
+
+  [data-yv-shadow-host]::before,
+  [data-yv-shadow-host]::after,
+  [data-host-pseudo-control]::before {
+    content: "HOSTILE" !important;
+    display: block !important;
+    background: red !important;
+  }
 `;
 
 const meta = {
@@ -63,7 +71,7 @@ export const HostileGlobalButtonRule: Story = {
   tags: ['integration'],
   render: () => (
     <div style={{ display: 'flex', alignItems: 'center', gap: 24 }}>
-      <button type="button" data-testid="host-control">
+      <button type="button" data-testid="host-control" data-host-pseudo-control>
         Host control
       </button>
       <YouVersionAuthButton data-testid="sdk-button" />
@@ -104,7 +112,13 @@ export const HostileGlobalButtonRule: Story = {
 
       await waitFor(() => {
         void expect(getComputedStyle(control).backgroundColor).toBe('rgb(185, 28, 28)');
+        void expect(getComputedStyle(control, '::before').content).toBe('"HOSTILE"');
       });
+
+      void expect(getComputedStyle(host, '::before').content).toBe('none');
+      void expect(getComputedStyle(host, '::before').display).toBe('none');
+      void expect(getComputedStyle(host, '::after').content).toBe('none');
+      void expect(getComputedStyle(host, '::after').display).toBe('none');
 
       // The complete relevant style snapshot—not merely a few negative values—
       // must remain identical to the pre-attack SDK baseline.

--- a/packages/ui/src/components/YouVersionAuthButton.stories.tsx
+++ b/packages/ui/src/components/YouVersionAuthButton.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { expect, fn, userEvent, within, spyOn } from 'storybook/test';
+import { http, HttpResponse } from 'msw';
+import { expect, fn, userEvent, waitFor, spyOn } from 'storybook/test';
 import { YouVersionAuthButton } from './YouVersionAuthButton';
 
 // Store mock reference for interaction test
@@ -10,6 +11,13 @@ const meta = {
   component: YouVersionAuthButton,
   parameters: {
     layout: 'centered',
+    msw: {
+      handlers: [
+        http.get('*/v1/fonts/1/stylesheet', () =>
+          HttpResponse.text('', { headers: { 'Content-Type': 'text/css' } }),
+        ),
+      ],
+    },
   },
   tags: ['autodocs'],
   async beforeEach() {
@@ -73,6 +81,20 @@ const meta = {
 export default meta;
 
 type Story = StoryObj<typeof meta>;
+
+async function findAuthButton(
+  canvasElement: HTMLElement,
+  name: RegExp,
+): Promise<HTMLButtonElement> {
+  return waitFor(() => {
+    const host = canvasElement.querySelector<HTMLElement>('[data-yv-shadow-host]');
+    const button = Array.from(host?.shadowRoot?.querySelectorAll('button') ?? []).find(
+      (candidate) => name.test(candidate.textContent ?? ''),
+    );
+    if (!button) throw new Error(`auth button matching ${name} not found`);
+    return button;
+  });
+}
 
 export const Default: Story = {};
 
@@ -271,10 +293,8 @@ export const InteractionTestWithMockedAuth: Story = {
   },
   tags: ['integration'],
   play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
     // Wait for the auth provider to load and the button to appear
-    const loginButton = await canvas.findByRole('button', { name: /sign in with youversion/i });
+    const loginButton = await findAuthButton(canvasElement, /sign in with youversion/i);
     await userEvent.click(loginButton);
 
     void expect(signInMock).toHaveBeenCalled();
@@ -288,10 +308,8 @@ export const CustomText: Story = {
   },
   tags: ['integration'],
   play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
     // Wait for the auth provider to load and the button to appear
-    const loginButton = await canvas.findByRole('button', { name: /custom text/i });
+    const loginButton = await findAuthButton(canvasElement, /custom text/i);
     await userEvent.click(loginButton);
 
     void expect(signInMock).toHaveBeenCalled();

--- a/packages/ui/src/components/YouVersionAuthButton.tsx
+++ b/packages/ui/src/components/YouVersionAuthButton.tsx
@@ -198,7 +198,7 @@ const YouVersionAuthButtonImpl = React.forwardRef<HTMLButtonElement, YouVersionA
           data-yv-sdk
           data-yv-theme={theme}
           className={cn(
-            'yv:shadow-none yv:p-3 yv:h-auto yv:w-fit',
+            'yv:font-sans yv:shadow-none yv:p-3 yv:h-auto yv:w-fit',
             // The YV brand button is a neutral surface (white in light, dark in
             // dark) with its own text/logo color set below — pin the background
             // explicitly so it doesn't inherit the `default` variant's
@@ -236,7 +236,7 @@ const YouVersionAuthButtonImpl = React.forwardRef<HTMLButtonElement, YouVersionA
         data-yv-sdk
         data-yv-theme={theme}
         className={cn(
-          'yv:relative yv:shadow-none yv:w-fit',
+          'yv:font-sans yv:relative yv:shadow-none yv:w-fit',
           // Pin the neutral brand surface so the button doesn't inherit the
           // `default` variant's `bg-primary` (see the icon branch above).
           'yv:bg-background yv:hover:bg-background/90',

--- a/packages/ui/src/components/YouVersionAuthButton.tsx
+++ b/packages/ui/src/components/YouVersionAuthButton.tsx
@@ -10,6 +10,7 @@ import { useYVAuth, useTheme } from '@youversion/platform-react-hooks';
 import { Button } from '../components/ui/button';
 import { YouVersionLogo } from './icons/youversion-logo';
 import { cn } from '../lib/utils';
+import { withShadowIsolation } from '../lib/shadow-isolation';
 
 interface SignInAuthProps {
   /**
@@ -109,7 +110,7 @@ export interface YouVersionAuthButtonProps
  * <YouVersionAuthButton scopes={['profile']}/>
  *
  */
-export const YouVersionAuthButton = React.forwardRef<HTMLButtonElement, YouVersionAuthButtonProps>(
+const YouVersionAuthButtonImpl = React.forwardRef<HTMLButtonElement, YouVersionAuthButtonProps>(
   (
     {
       background,
@@ -266,4 +267,13 @@ export const YouVersionAuthButton = React.forwardRef<HTMLButtonElement, YouVersi
   },
 );
 
-YouVersionAuthButton.displayName = 'YouVersionAuthButton';
+YouVersionAuthButtonImpl.displayName = 'YouVersionAuthButtonImpl';
+
+/**
+ * Automatically rendered in a Shadow DOM so host-page selectors cannot style
+ * the button's internal DOM. No consumer wrapper or opt-in flag is required.
+ */
+export const YouVersionAuthButton = withShadowIsolation(
+  YouVersionAuthButtonImpl,
+  'YouVersionAuthButton',
+);

--- a/packages/ui/src/lib/shadow-isolation.tsx
+++ b/packages/ui/src/lib/shadow-isolation.tsx
@@ -12,14 +12,16 @@ export function withShadowIsolation<P extends object, T>(
   Implementation: ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>,
   displayName: string,
 ): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>> {
-  const Isolated = forwardRef<T, P>((props, ref) => (
-    <ShadowRootHost>
-      {createElement(Implementation, {
-        ...(props as P),
-        ref,
-      } as unknown as PropsWithoutRef<P> & RefAttributes<T>)}
-    </ShadowRootHost>
-  ));
+  const Isolated = forwardRef<T, P>((props, ref) => {
+    const implementationProps: PropsWithoutRef<P> & RefAttributes<T> = {
+      ...props,
+      ref,
+    };
+
+    return (
+      <ShadowRootHost>{createElement(Implementation, implementationProps)}</ShadowRootHost>
+    );
+  });
   Isolated.displayName = displayName;
   return Isolated;
 }

--- a/packages/ui/src/lib/shadow-isolation.tsx
+++ b/packages/ui/src/lib/shadow-isolation.tsx
@@ -1,0 +1,25 @@
+import {
+  createElement,
+  forwardRef,
+  type ForwardRefExoticComponent,
+  type PropsWithoutRef,
+  type RefAttributes,
+} from 'react';
+import { ShadowRootHost } from './shadow-root-host';
+
+/** @internal Applies automatic isolation while preserving the component ref. */
+export function withShadowIsolation<P extends object, T>(
+  Implementation: ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>,
+  displayName: string,
+): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>> {
+  const Isolated = forwardRef<T, P>((props, ref) => (
+    <ShadowRootHost>
+      {createElement(Implementation, {
+        ...(props as P),
+        ref,
+      } as unknown as PropsWithoutRef<P> & RefAttributes<T>)}
+    </ShadowRootHost>
+  ));
+  Isolated.displayName = displayName;
+  return Isolated;
+}

--- a/packages/ui/src/lib/shadow-root-host.test.tsx
+++ b/packages/ui/src/lib/shadow-root-host.test.tsx
@@ -1,0 +1,34 @@
+import { StrictMode } from 'react';
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ShadowRootHost } from './shadow-root-host';
+
+describe('ShadowRootHost', () => {
+  it('attaches one shadow root under StrictMode', () => {
+    expect(() =>
+      render(
+        <StrictMode>
+          <ShadowRootHost>
+            <span>content</span>
+          </ShadowRootHost>
+        </StrictMode>,
+      ),
+    ).not.toThrow();
+
+    const host = document.querySelector<HTMLElement>('[data-yv-shadow-host]');
+    expect(host?.shadowRoot?.textContent).toContain('content');
+  });
+
+  it('locks the host box against host-page important rules', () => {
+    render(
+      <ShadowRootHost>
+        <span>content</span>
+      </ShadowRootHost>,
+    );
+
+    const host = document.querySelector<HTMLElement>('[data-yv-shadow-host]');
+    expect(host?.style.getPropertyValue('all')).toBe('initial');
+    expect(host?.style.getPropertyValue('display')).toBe('contents');
+    expect(host?.style.getPropertyPriority('display')).toBe('important');
+  });
+});

--- a/packages/ui/src/lib/shadow-root-host.test.tsx
+++ b/packages/ui/src/lib/shadow-root-host.test.tsx
@@ -5,30 +5,41 @@ import { ShadowRootHost } from './shadow-root-host';
 
 describe('ShadowRootHost', () => {
   it('attaches one shadow root under StrictMode', () => {
-    expect(() =>
-      render(
+    let container!: HTMLElement;
+    expect(() => {
+      ({ container } = render(
         <StrictMode>
           <ShadowRootHost>
             <span>content</span>
           </ShadowRootHost>
         </StrictMode>,
-      ),
-    ).not.toThrow();
+      ));
+    }).not.toThrow();
 
-    const host = document.querySelector<HTMLElement>('[data-yv-shadow-host]');
+    const host = container.querySelector<HTMLElement>('[data-yv-shadow-host]');
+    expect(host).not.toBeNull();
+    expect(host?.shadowRoot).not.toBeNull();
     expect(host?.shadowRoot?.textContent).toContain('content');
   });
 
-  it('locks the host box against host-page important rules', () => {
-    render(
+  it('applies important inline declarations to stabilize the host box', () => {
+    const { container } = render(
       <ShadowRootHost>
         <span>content</span>
       </ShadowRootHost>,
     );
 
-    const host = document.querySelector<HTMLElement>('[data-yv-shadow-host]');
+    const host = container.querySelector<HTMLElement>('[data-yv-shadow-host]');
+    expect(host).not.toBeNull();
     expect(host?.style.getPropertyValue('all')).toBe('initial');
     expect(host?.style.getPropertyValue('display')).toBe('contents');
+    expect(host?.style.getPropertyValue('writing-mode')).toBe('inherit');
+    expect(host?.style.getPropertyValue('text-orientation')).toBe('inherit');
+
+    // jsdom's cssstyle backing does not track priority for `all`,
+    // `writing-mode`, or `text-orientation` (real browsers do), so only
+    // `display` can assert getPropertyPriority here. The value-only checks
+    // above still prove the other properties were set.
     expect(host?.style.getPropertyPriority('display')).toBe('important');
   });
 });

--- a/packages/ui/src/lib/shadow-root-host.test.tsx
+++ b/packages/ui/src/lib/shadow-root-host.test.tsx
@@ -42,4 +42,22 @@ describe('ShadowRootHost', () => {
     // above still prove the other properties were set.
     expect(host?.style.getPropertyPriority('display')).toBe('important');
   });
+
+  it('gives the fallback stylesheet a stable React resource identity', () => {
+    const { container } = render(
+      <ShadowRootHost>
+        <span>content</span>
+      </ShadowRootHost>,
+    );
+
+    const style = container
+      .querySelector<HTMLElement>('[data-yv-shadow-host]')
+      ?.shadowRoot?.querySelector('style');
+
+    // jsdom does not implement constructable stylesheets, so this exercises
+    // the fallback path. React uses href + precedence to hoist and de-duplicate
+    // stylesheet resources within the shadow root.
+    expect(style?.getAttribute('data-href')).toBe('yv-sdk-shadow-styles');
+    expect(style?.getAttribute('data-precedence')).toBe('yv-sdk');
+  });
 });

--- a/packages/ui/src/lib/shadow-root-host.tsx
+++ b/packages/ui/src/lib/shadow-root-host.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+
+declare const __YV_STYLES__: string;
+
+const sdkStyleSheets = new WeakMap<Document, CSSStyleSheet>();
+
+function getStyleSheetConstructor(root: ShadowRoot): typeof CSSStyleSheet | undefined {
+  return root.ownerDocument.defaultView?.CSSStyleSheet;
+}
+
+function supportsAdoptedStyleSheets(root: ShadowRoot): boolean {
+  const StyleSheet = getStyleSheetConstructor(root);
+  return (
+    StyleSheet !== undefined &&
+    typeof StyleSheet.prototype.replaceSync === 'function' &&
+    'adoptedStyleSheets' in root
+  );
+}
+
+function getOrCreateSdkStyleSheet(root: ShadowRoot): CSSStyleSheet {
+  const ownerDocument = root.ownerDocument;
+  const existing = sdkStyleSheets.get(ownerDocument);
+  if (existing) return existing;
+
+  const StyleSheet = getStyleSheetConstructor(root)!;
+  const sheet = new StyleSheet();
+  sheet.replaceSync(__YV_STYLES__);
+  sdkStyleSheets.set(ownerDocument, sheet);
+  return sheet;
+}
+
+function resetHost(host: HTMLDivElement): void {
+  // The host page can select this light-DOM element, including with !important.
+  // Inline author-important declarations establish the smallest stable box.
+  host.style.setProperty('all', 'initial', 'important');
+  host.style.setProperty('display', 'contents', 'important');
+  host.style.setProperty('writing-mode', 'inherit', 'important');
+  host.style.setProperty('text-orientation', 'inherit', 'important');
+}
+
+interface ShadowRootHostProps {
+  children: ReactNode;
+}
+
+/** @internal Proof-of-concept primitive; not part of the public API. */
+export function ShadowRootHost({ children }: ShadowRootHostProps): React.ReactNode {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const [shadowRoot, setShadowRoot] = useState<ShadowRoot | null>(null);
+  const [needsStyleFallback, setNeedsStyleFallback] = useState(false);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    // React StrictMode replays effects against the same DOM node. Inspect the
+    // live node instead of captured state so attachShadow is called only once.
+    if (!host || host.shadowRoot) return;
+
+    resetHost(host);
+    const root = host.attachShadow({ mode: 'open' });
+    if (supportsAdoptedStyleSheets(root)) {
+      root.adoptedStyleSheets = [getOrCreateSdkStyleSheet(root)];
+    } else {
+      setNeedsStyleFallback(true);
+    }
+    setShadowRoot(root);
+  }, []);
+
+  return (
+    <div ref={hostRef} data-yv-shadow-host>
+      {shadowRoot
+        ? createPortal(
+            <>
+              {needsStyleFallback ? <style>{__YV_STYLES__}</style> : null}
+              {/* Host selectors cannot reach this reset boundary. */}
+              <div style={{ all: 'initial', display: 'contents' }}>{children}</div>
+            </>,
+            shadowRoot,
+          )
+        : null}
+    </div>
+  );
+}

--- a/packages/ui/src/lib/shadow-root-host.tsx
+++ b/packages/ui/src/lib/shadow-root-host.tsx
@@ -44,7 +44,7 @@ interface ShadowRootHostProps {
 }
 
 /** @internal Proof-of-concept primitive; not part of the public API. */
-export function ShadowRootHost({ children }: ShadowRootHostProps): React.ReactNode {
+export function ShadowRootHost({ children }: ShadowRootHostProps): ReactNode {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const [shadowRoot, setShadowRoot] = useState<ShadowRoot | null>(null);
   const [needsStyleFallback, setNeedsStyleFallback] = useState(false);

--- a/packages/ui/src/lib/shadow-root-host.tsx
+++ b/packages/ui/src/lib/shadow-root-host.tsx
@@ -4,6 +4,8 @@ import { createPortal } from 'react-dom';
 declare const __YV_STYLES__: string;
 
 const sdkStyleSheets = new WeakMap<Document, CSSStyleSheet>();
+const SDK_SHADOW_STYLE_HREF = 'yv-sdk-shadow-styles';
+const SDK_SHADOW_STYLE_PRECEDENCE = 'yv-sdk';
 
 function getStyleSheetConstructor(root: ShadowRoot): typeof CSSStyleSheet | undefined {
   return root.ownerDocument.defaultView?.CSSStyleSheet;
@@ -70,7 +72,11 @@ export function ShadowRootHost({ children }: ShadowRootHostProps): ReactNode {
       {shadowRoot
         ? createPortal(
             <>
-              {needsStyleFallback ? <style>{__YV_STYLES__}</style> : null}
+              {needsStyleFallback ? (
+                <style href={SDK_SHADOW_STYLE_HREF} precedence={SDK_SHADOW_STYLE_PRECEDENCE}>
+                  {__YV_STYLES__}
+                </style>
+              ) : null}
               {/* Host selectors cannot reach this reset boundary. */}
               <div style={{ all: 'initial', display: 'contents' }}>{children}</div>
             </>,

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -45,6 +45,16 @@ layer(yv-sdk-fonts);
 @import '@youversion/platform-core/browser/styles/bible-reader.css' layer(yv-sdk-bible-reader);
 @import 'tw-animate-css';
 
+/* The light-DOM shadow host remains selectable by the consumer page. Prevent
+   hostile host-page rules from generating content around the isolated SDK UI.
+   For !important declarations on a shadow host, the shadow-tree declaration
+   outranks an outer author declaration by design. */
+:host::before,
+:host::after {
+  content: none !important;
+  display: none !important;
+}
+
 /* Untitled Serif has no @font-face here on purpose. Its stylesheet URL needs the
    consumer's app key, which this file cannot know — it is frozen into __YV_STYLES__ at
    build time. It is loaded instead by <YvFonts /> (src/lib/yv-fonts.tsx), rendered from


### PR DESCRIPTION
Same-repo copy of #322 so CI can read `YVP_API_HOST` / `YVP_APP_KEY`. The fork PR cannot see those secrets.

Code Implementor, sent on behalf of Cam. I am AI.

> [!NOTE]
> This is an architectural proof of concept on one representative component, not a package-wide rollout. YPE-4113 is intentionally partial.

## Summary

Host applications can apply global CSS to React SDK component internals. This PR prototypes automatic Shadow DOM isolation on `YouVersionAuthButton`. Consumers keep rendering the component normally, with no wrapper or opt-in.

See #322 for Austin's original write-up, ADR 0005, and the Hostile CSS demo.

HEAD: `f735fcb` (same as #322).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This proof of concept automatically renders `YouVersionAuthButton` within a Shadow DOM boundary while preserving its existing component API.
- Adds a reusable shadow host and higher-order isolation wrapper with per-document constructable stylesheet caching and a `<style>` fallback.
- Updates the auth button’s typography and stories for the new shadow-tree structure.
- Adds Strict Mode, hostile-CSS, pseudo-element, and same-origin iframe coverage.
- Adds an interactive hostile-CSS demonstration and an ADR documenting compatibility impacts and deferred work.

<h3>Confidence Score: 5/5</h3>

The proof of concept appears safe to merge with its intentionally limited scope and documented compatibility tradeoffs.

No concrete, unacknowledged blocking failure remains after accounting for the provider’s existing document-level font loading and the ADR’s explicit treatment of form association, SSR, hydration, and delayed refs.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/lib/shadow-root-host.tsx | Introduces effect-driven shadow-root creation, per-document stylesheet adoption, fallback style injection, and portal rendering. |
| packages/ui/src/lib/shadow-isolation.tsx | Adds a typed forward-ref wrapper that transparently places a component inside `ShadowRootHost`. |
| packages/ui/src/components/YouVersionAuthButton.tsx | Wraps the public auth button with automatic shadow isolation and explicitly applies its sans-serif utility. |
| packages/ui/src/styles/global.css | Adds shadow-context rules that suppress host pseudo-elements around isolated components. |
| packages/ui/src/lib/shadow-root-host.test.tsx | Covers Strict Mode attachment, the host reset, and fallback stylesheet resource identity. |
| packages/ui/src/components/YouVersionAuthButton.shadow-isolation.stories.tsx | Adds browser-level hostile-CSS and same-origin iframe coverage for the prototype. |
| docs/adr/0005-prototype-shadow-dom-style-isolation.md | Documents the architecture, breaking DOM and lifecycle effects, current evidence, and intentionally deferred limitations. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Consumer[Consumer renders YouVersionAuthButton] --> Wrapper[withShadowIsolation]
  Wrapper --> Host[Light-DOM shadow host]
  Host --> Root[Open ShadowRoot]
  Root --> Styles[Embedded SDK stylesheet]
  Root --> Portal[React portal]
  Portal --> Button[YouVersionAuthButton implementation]
  HostCSS[Host application CSS] -. selector boundary .-> Root
```

<sub>Reviews (1): Last reviewed commit: ["fix(ui): use style precedence for shadow..."](https://github.com/youversion/platform-sdk-react/commit/f735fcb10f93f444050854f6b32c3520a9fcdede) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54855535)</sub>

**Context used:**

- Knowledge Base — [packages/ui](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/ui-package.md)

<!-- /greptile_comment -->