### PR TITLE
feat(ui): prototype shared shadow overlay for portals (YPE-5138)

### DIFF
--- a/.changeset/calm-shadows-float.md
+++ b/.changeset/calm-shadows-float.md
@@ -1,0 +1,5 @@
+---
+'@youversion/platform-react-ui': patch
+---
+
+Route isolated Radix popovers and dialogs through a shared styled shadow overlay, and constrain popovers to the available viewport height.

--- a/docs/adr/0005-prototype-shadow-dom-style-isolation.md
+++ b/docs/adr/0005-prototype-shadow-dom-style-isolation.md
@@ -58,6 +58,31 @@ pseudo-content, existing interactions, and mounting in a same-origin iframe.
 Unit tests verify Strict Mode behavior and the inline-important host reset. The
 remaining hostile vectors are available for manual inspection on the demo page.
 
+## Subsequent complex-component spike
+
+A follow-up spike rendered `BibleVersionPicker` inside the prototype boundary
+without changing the picker's public export. Radix popover content is routed to
+one shared SDK overlay shadow root under `document.body`. This preserves the CSS
+boundary while allowing floating content to escape clipping and transformed
+ancestors. The overlay root is reused by isolated components and receives the
+same SDK stylesheet as component roots.
+
+Focused Chromium stories verify portal placement, SDK styling, resistance to
+host selectors, ancestor and viewport collision handling, keyboard focus,
+Escape and outside-click dismissal, and overlay reuse. Manual Chromium
+inspection also confirmed internal scrolling at constrained viewport heights.
+The same container plumbing is available to the shared Radix dialog primitive,
+with a focused isolated `SignInDialog` browser proof.
+
+This architecture introduces a separate tree scope for triggers and their
+overlays. Although Radix emits matching `aria-controls` and content IDs for the
+popover, Chromium does not resolve `ariaControlsElements` across the two shadow
+roots. This remains an explicit assistive-technology validation gate rather
+than a proven accessible relationship. Radix's development-only dialog checks
+also search for title and description IDs through `document`, so they warn for
+elements that the browser proof confirms are present in the overlay shadow
+root; real assistive-technology behavior is still unresolved.
+
 ## Compatibility impact
 
 Although the React props API is unchanged, the rendered DOM structure is not.
@@ -71,7 +96,9 @@ detail.
 ## Deliberately deferred
 
 - Rollout to all exported components.
-- Radix popover/dialog portal placement and focus management.
+- Broader Radix popover/dialog rollout and assistive-technology validation. The
+  shared overlay-root mechanism and representative Chromium focus behavior are
+  proven, but package-wide and real-AT coverage are not.
 - Form association when controls live outside their form's tree scope.
 - SSR/hydration and the first client paint.
 - A package-wide custom-property audit. `all: initial` does not reset custom
@@ -81,7 +108,10 @@ detail.
   properties. Some host values may be intentional localization inputs, while
   SDK-owned visual tokens need shadow-local defaults.
 - Host `@font-face` rules, which are not scoped by Shadow DOM.
-- Ancestor layout constraints, which Shadow DOM cannot isolate.
+- Ancestor layout constraints on the component host, which Shadow DOM cannot
+  isolate. Portalled floating content can escape ancestor clipping through the
+  shared body-level overlay root, but the host itself can still be hidden,
+  clipped, or transformed by its ancestors.
 - Event retargeting, nested-root behavior, and a supported consumer customization
   model.
 - Stylesheet construction/adoption failure recovery beyond feature fallback.

--- a/packages/ui/src/components/BibleVersionPicker.shadow-isolation.stories.tsx
+++ b/packages/ui/src/components/BibleVersionPicker.shadow-isolation.stories.tsx
@@ -1,0 +1,486 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { http, HttpResponse } from 'msw';
+import { useState } from 'react';
+import { expect, userEvent, waitFor } from 'storybook/test';
+import { ShadowRootHost } from '../lib/shadow-root-host';
+import { globalHandlers } from '../test/mocks/handlers';
+import { BibleVersionPicker } from './bible-version-picker';
+
+function IsolatedBibleVersionPicker({
+  side = 'top',
+}: {
+  side?: 'top' | 'right' | 'bottom' | 'left';
+}): React.ReactNode {
+  const [versionId, setVersionId] = useState(111);
+
+  return (
+    <ShadowRootHost>
+      <BibleVersionPicker.Root versionId={versionId} onVersionChange={setVersionId} side={side}>
+        <BibleVersionPicker.Trigger />
+        <BibleVersionPicker.Content />
+      </BibleVersionPicker.Root>
+    </ShadowRootHost>
+  );
+}
+
+function SharedOverlayLifecycleHarness(): React.ReactNode {
+  const [showSecondPicker, setShowSecondPicker] = useState(true);
+
+  return (
+    <div>
+      <div data-testid="first-picker">
+        <IsolatedBibleVersionPicker />
+      </div>
+      {showSecondPicker ? (
+        <div data-testid="second-picker">
+          <IsolatedBibleVersionPicker />
+        </div>
+      ) : null}
+      <button type="button" onClick={() => setShowSecondPicker(false)}>
+        Unmount second picker
+      </button>
+    </div>
+  );
+}
+
+const meta = {
+  title: 'Spikes/BibleVersionPicker Shadow DOM isolation',
+  component: IsolatedBibleVersionPicker,
+  tags: ['integration'],
+  parameters: {
+    layout: 'centered',
+    msw: {
+      handlers: [
+        ...globalHandlers,
+        http.get('*/v1/fonts/1/stylesheet', () =>
+          HttpResponse.text('', { headers: { 'Content-Type': 'text/css' } }),
+        ),
+      ],
+    },
+  },
+} satisfies Meta<typeof IsolatedBibleVersionPicker>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function styleSnapshot(element: HTMLElement) {
+  const ownerWindow = element.ownerDocument.defaultView;
+  if (!ownerWindow) throw new Error('element window not available');
+  const styles = ownerWindow.getComputedStyle(element);
+  return {
+    appearance: styles.appearance,
+    backgroundColor: styles.backgroundColor,
+    borderRadius: styles.borderRadius,
+    borderTopColor: styles.borderTopColor,
+    borderTopStyle: styles.borderTopStyle,
+    borderTopWidth: styles.borderTopWidth,
+    color: styles.color,
+    display: styles.display,
+    fontFamily: styles.fontFamily,
+    fontSize: styles.fontSize,
+    lineHeight: styles.lineHeight,
+    padding: styles.padding,
+  };
+}
+
+async function getComponentRoot(container: ParentNode): Promise<ShadowRoot> {
+  const host = await waitFor(() => {
+    const element = container.querySelector<HTMLElement>('[data-yv-shadow-host]');
+    if (!element?.shadowRoot) throw new Error('component shadow root not attached');
+    return element;
+  });
+  return host.shadowRoot!;
+}
+
+async function getPickerTrigger(container: ParentNode): Promise<HTMLElement> {
+  const root = await getComponentRoot(container);
+  return waitFor(() => {
+    const element = root.querySelector<HTMLElement>('[data-slot="popover-trigger"]');
+    if (!element) throw new Error('version picker trigger not rendered');
+    return element;
+  });
+}
+
+async function getOverlayRoot(ownerDocument: Document): Promise<ShadowRoot> {
+  const host = await waitFor(() => {
+    const element = ownerDocument.body.querySelector<HTMLElement>('[data-yv-shadow-overlay-host]');
+    if (!element?.shadowRoot) throw new Error('shared overlay shadow root not attached');
+    return element;
+  });
+  return host.shadowRoot!;
+}
+
+async function getPopoverPanel(overlayRoot: ShadowRoot): Promise<HTMLElement> {
+  return waitFor(() => {
+    const element = overlayRoot.querySelector<HTMLElement>('[data-slot="popover-content"]');
+    if (!element) throw new Error('popover panel not rendered');
+    return element;
+  });
+}
+
+async function openPicker(container: ParentNode, ownerDocument: Document) {
+  const componentRoot = await getComponentRoot(container);
+  const trigger = await getPickerTrigger(container);
+  await userEvent.click(trigger);
+  const overlayRoot = await getOverlayRoot(ownerDocument);
+  const panel = await getPopoverPanel(overlayRoot);
+  return { componentRoot, trigger, overlayRoot, panel };
+}
+
+async function getNamedPickerTrigger(
+  canvasElement: HTMLElement,
+  pickerTestId: string,
+): Promise<HTMLElement> {
+  const picker = canvasElement.querySelector<HTMLElement>(`[data-testid="${pickerTestId}"]`);
+  if (!picker) throw new Error(`${pickerTestId} not rendered`);
+  return getPickerTrigger(picker);
+}
+
+export const PortalContentRendersInsideShadowRoot: Story = {
+  tags: ['integration'],
+  play: async ({ canvasElement }) => {
+    const { componentRoot, overlayRoot, panel } = await openPicker(
+      canvasElement,
+      canvasElement.ownerDocument,
+    );
+
+    void expect(panel.getRootNode()).toBe(overlayRoot);
+    void expect(componentRoot.querySelector('[data-slot="popover-content"]')).toBeNull();
+    void expect(
+      canvasElement.ownerDocument.body.querySelector('[data-slot="popover-content"]'),
+    ).toBeNull();
+    void expect(
+      canvasElement.ownerDocument.body.querySelectorAll('[data-yv-shadow-overlay-host]'),
+    ).toHaveLength(1);
+  },
+};
+
+export const AncestorClippingAndPositioning: Story = {
+  tags: ['integration'],
+  render: () => (
+    <div
+      data-testid="clipping-container"
+      style={{
+        width: 180,
+        height: 56,
+        overflow: 'hidden',
+        transform: 'translateZ(0)',
+      }}
+    >
+      <IsolatedBibleVersionPicker side="bottom" />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const clippingContainer = canvasElement.querySelector<HTMLElement>(
+      '[data-testid="clipping-container"]',
+    );
+    if (!clippingContainer) throw new Error('clipping container not rendered');
+
+    const { overlayRoot, panel } = await openPicker(clippingContainer, canvasElement.ownerDocument);
+
+    const containerRect = clippingContainer.getBoundingClientRect();
+    const panelRect = panel.getBoundingClientRect();
+    void expect(panelRect.bottom).toBeGreaterThan(containerRect.bottom + 1);
+
+    const viewport = canvasElement.ownerDocument.defaultView;
+    if (!viewport) throw new Error('story window not available');
+    void expect(panelRect.top).toBeGreaterThanOrEqual(0);
+    void expect(panelRect.left).toBeGreaterThanOrEqual(0);
+    void expect(panelRect.bottom).toBeLessThanOrEqual(viewport.innerHeight);
+    void expect(panelRect.right).toBeLessThanOrEqual(viewport.innerWidth);
+
+    const sampleX = panelRect.left + panelRect.width / 2;
+    const sampleY = Math.max(panelRect.top + 2, containerRect.bottom + 2);
+    if (sampleY >= panelRect.bottom) {
+      throw new Error('popover panel did not extend far enough beyond the clipping container');
+    }
+
+    const hit = overlayRoot.elementFromPoint(sampleX, sampleY);
+    void expect(hit === panel || (hit !== null && panel.contains(hit))).toBe(true);
+  },
+};
+
+export const SharedOverlayStylesResistHostCss: Story = {
+  tags: ['integration'],
+  render: () => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 24 }}>
+      <button type="button" data-testid="host-control">
+        Host control
+      </button>
+      <IsolatedBibleVersionPicker />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const ownerDocument = canvasElement.ownerDocument;
+    const ownerWindow = ownerDocument.defaultView;
+    if (!ownerWindow) throw new Error('story window not available');
+
+    const control = canvasElement.querySelector<HTMLButtonElement>('[data-testid="host-control"]');
+    if (!control) throw new Error('host control not rendered');
+
+    const { panel } = await openPicker(canvasElement, ownerDocument);
+    const input = await waitFor(() => {
+      const element = panel.querySelector<HTMLInputElement>('input');
+      if (!element) throw new Error('popover search input not rendered');
+      return element;
+    });
+
+    const panelBaseline = styleSnapshot(panel);
+    const inputBaseline = styleSnapshot(input);
+    void expect(panelBaseline.display).toBe('grid');
+    void expect(panelBaseline.backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+    void expect(panelBaseline.borderRadius).not.toBe('0px');
+    void expect(inputBaseline.fontFamily).toContain('Inter');
+
+    const hostileStyle = ownerDocument.createElement('style');
+    hostileStyle.textContent = `
+      button,
+      input,
+      [role='dialog'] {
+        appearance: none !important;
+        background: rgb(185, 28, 28) !important;
+        border: 10px dashed lime !important;
+        border-radius: 0 !important;
+        color: yellow !important;
+        font: 32px/1 fantasy !important;
+        padding: 40px !important;
+      }
+    `;
+
+    try {
+      ownerDocument.head.append(hostileStyle);
+      await waitFor(() => {
+        void expect(ownerWindow.getComputedStyle(control).backgroundColor).toBe('rgb(185, 28, 28)');
+      });
+
+      void expect(styleSnapshot(panel)).toEqual(panelBaseline);
+      void expect(styleSnapshot(input)).toEqual(inputBaseline);
+    } finally {
+      hostileStyle.remove();
+    }
+  },
+};
+
+export const HostSpacingCustomPropertyDoesNotAffectOverlay: Story = {
+  tags: ['integration'],
+  play: async ({ canvasElement }) => {
+    const ownerDocument = canvasElement.ownerDocument;
+    const { overlayRoot } = await openPicker(canvasElement, ownerDocument);
+    const languageTrigger = await waitFor(() => {
+      const element = overlayRoot.querySelector<HTMLButtonElement>(
+        'button[aria-label="Select language"]',
+      );
+      if (!element) throw new Error('language trigger not rendered');
+      return element;
+    });
+    await userEvent.click(languageTrigger);
+
+    const tabsList = await waitFor(() => {
+      const element = overlayRoot.querySelector<HTMLElement>('[data-slot="tabs-list"]');
+      if (!element) throw new Error('language tabs not rendered');
+      return element;
+    });
+    const baselineWidth = tabsList.getBoundingClientRect().width;
+    void expect(baselineWidth).toBeGreaterThan(0);
+
+    const documentRoot = ownerDocument.documentElement;
+    const previousValue = documentRoot.style.getPropertyValue('--spacing');
+    const previousPriority = documentRoot.style.getPropertyPriority('--spacing');
+
+    try {
+      documentRoot.style.setProperty('--spacing', '20px');
+      await waitFor(() => {
+        void expect(tabsList.getBoundingClientRect().width).toBe(baselineWidth);
+      });
+    } finally {
+      if (previousValue) {
+        documentRoot.style.setProperty('--spacing', previousValue, previousPriority);
+      } else {
+        documentRoot.style.removeProperty('--spacing');
+      }
+    }
+  },
+};
+
+export const KeyboardFocusAndEscapeCrossShadowRoots: Story = {
+  tags: ['integration'],
+  play: async ({ canvasElement }) => {
+    const ownerDocument = canvasElement.ownerDocument;
+    const componentRoot = await getComponentRoot(canvasElement);
+    const trigger = await getPickerTrigger(canvasElement);
+
+    trigger.focus();
+    void expect(componentRoot.activeElement).toBe(trigger);
+    await userEvent.keyboard('{Enter}');
+
+    const overlayRoot = await getOverlayRoot(ownerDocument);
+    const panel = await getPopoverPanel(overlayRoot);
+
+    await waitFor(() => {
+      const focusedElement = overlayRoot.activeElement;
+      void expect(focusedElement !== null && panel.contains(focusedElement)).toBe(true);
+    });
+
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => {
+      void expect(overlayRoot.querySelector('[data-slot="popover-content"]')).toBeNull();
+    });
+    await waitFor(() => {
+      void expect(componentRoot.activeElement).toBe(trigger);
+    });
+  },
+};
+
+export const InsideAndOutsideClicksCrossShadowRoots: Story = {
+  tags: ['integration'],
+  render: () => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 24 }}>
+      <button type="button" data-testid="outside-control">
+        Outside control
+      </button>
+      <IsolatedBibleVersionPicker />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const ownerDocument = canvasElement.ownerDocument;
+    const outsideControl = canvasElement.querySelector<HTMLButtonElement>(
+      '[data-testid="outside-control"]',
+    );
+    if (!outsideControl) throw new Error('outside control not rendered');
+
+    const { overlayRoot, panel } = await openPicker(canvasElement, ownerDocument);
+    const input = await waitFor(() => {
+      const element = panel.querySelector<HTMLInputElement>('input');
+      if (!element) throw new Error('popover search input not rendered');
+      return element;
+    });
+
+    await userEvent.click(input);
+    void expect(overlayRoot.querySelector('[data-slot="popover-content"]')).toBe(panel);
+
+    await userEvent.click(outsideControl);
+    await waitFor(() => {
+      void expect(overlayRoot.querySelector('[data-slot="popover-content"]')).toBeNull();
+    });
+  },
+};
+
+export const AriaControlsDoesNotResolveAcrossSharedShadowRoots: Story = {
+  tags: ['integration'],
+  play: async ({ canvasElement }) => {
+    const ownerDocument = canvasElement.ownerDocument;
+    const { trigger, panel } = await openPicker(canvasElement, ownerDocument);
+
+    void expect(trigger.getAttribute('aria-controls')).toBe(panel.id);
+
+    const reflectedControls = (
+      trigger as HTMLElement & { ariaControlsElements?: readonly Element[] }
+    ).ariaControlsElements;
+    if (!reflectedControls) {
+      throw new Error('Chromium did not expose ariaControlsElements');
+    }
+    // The ID strings match, but IDREF resolution is scoped to the trigger's
+    // shadow tree and therefore cannot reach the separate overlay shadow tree.
+    void expect(reflectedControls).toHaveLength(0);
+  },
+};
+
+export const PopoverDialogSemanticsAndFocusAcrossShadowRoots: Story = {
+  tags: ['integration'],
+  play: async ({ canvasElement }) => {
+    const ownerDocument = canvasElement.ownerDocument;
+    const componentRoot = await getComponentRoot(canvasElement);
+    const trigger = await getPickerTrigger(canvasElement);
+
+    trigger.focus();
+    await userEvent.keyboard('{Enter}');
+
+    const overlayRoot = await getOverlayRoot(ownerDocument);
+    const panel = await getPopoverPanel(overlayRoot);
+
+    void expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    void expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+    void expect(panel).toHaveAttribute('role', 'dialog');
+    await waitFor(() => {
+      const focusedElement = overlayRoot.activeElement;
+      void expect(focusedElement !== null && panel.contains(focusedElement)).toBe(true);
+    });
+
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => {
+      void expect(componentRoot.activeElement).toBe(trigger);
+    });
+  },
+};
+
+export const SharedOverlayReuseAndLifecycle: Story = {
+  tags: ['integration'],
+  render: () => <SharedOverlayLifecycleHarness />,
+  play: async ({ canvasElement }) => {
+    const ownerDocument = canvasElement.ownerDocument;
+    const firstTrigger = await getNamedPickerTrigger(canvasElement, 'first-picker');
+    const secondTrigger = await getNamedPickerTrigger(canvasElement, 'second-picker');
+    const overlayRoot = await getOverlayRoot(ownerDocument);
+
+    void expect(ownerDocument.body.querySelectorAll('[data-yv-shadow-overlay-host]')).toHaveLength(
+      1,
+    );
+
+    await userEvent.click(firstTrigger);
+    await waitFor(() => {
+      void expect(overlayRoot.querySelectorAll('[data-slot="popover-content"]')).toHaveLength(1);
+    });
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => {
+      void expect(overlayRoot.querySelectorAll('[data-slot="popover-content"]')).toHaveLength(0);
+    });
+
+    await userEvent.click(secondTrigger);
+    await waitFor(() => {
+      void expect(overlayRoot.querySelectorAll('[data-slot="popover-content"]')).toHaveLength(1);
+    });
+
+    await userEvent.click(canvasElement.getElementsByTagName('button')[0]!);
+    await waitFor(() => {
+      void expect(canvasElement.querySelector('[data-testid="second-picker"]')).toBeNull();
+      void expect(overlayRoot.querySelectorAll('[data-slot="popover-content"]')).toHaveLength(0);
+    });
+    void expect(ownerDocument.body.querySelectorAll('[data-yv-shadow-overlay-host]')).toHaveLength(
+      1,
+    );
+  },
+};
+
+export const MultiplePickersCoordinateInSharedOverlay: Story = {
+  tags: ['integration'],
+  render: () => (
+    <div>
+      <div data-testid="first-picker">
+        <IsolatedBibleVersionPicker />
+      </div>
+      <div data-testid="second-picker">
+        <IsolatedBibleVersionPicker />
+      </div>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const ownerDocument = canvasElement.ownerDocument;
+    const firstTrigger = await getNamedPickerTrigger(canvasElement, 'first-picker');
+    const secondTrigger = await getNamedPickerTrigger(canvasElement, 'second-picker');
+    const overlayRoot = await getOverlayRoot(ownerDocument);
+
+    await userEvent.click(firstTrigger);
+    await waitFor(() => {
+      void expect(firstTrigger).toHaveAttribute('aria-expanded', 'true');
+      void expect(secondTrigger).toHaveAttribute('aria-expanded', 'false');
+      void expect(overlayRoot.querySelectorAll('[data-slot="popover-content"]')).toHaveLength(1);
+    });
+
+    await userEvent.click(secondTrigger);
+    await waitFor(() => {
+      void expect(firstTrigger).toHaveAttribute('aria-expanded', 'false');
+      void expect(secondTrigger).toHaveAttribute('aria-expanded', 'true');
+      void expect(overlayRoot.querySelectorAll('[data-slot="popover-content"]')).toHaveLength(1);
+    });
+  },
+};

--- a/packages/ui/src/components/SignInDialog.shadow-isolation.stories.tsx
+++ b/packages/ui/src/components/SignInDialog.shadow-isolation.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { http, HttpResponse } from 'msw';
+import { expect, fn, waitFor } from 'storybook/test';
+import { ShadowRootHost } from '../lib/shadow-root-host';
+import { globalHandlers } from '../test/mocks/handlers';
+import { SignInDialog } from './sign-in-dialog';
+
+const meta = {
+  title: 'Spikes/SignInDialog Shadow DOM isolation',
+  component: SignInDialog,
+  tags: ['integration'],
+  parameters: {
+    msw: {
+      handlers: [
+        ...globalHandlers,
+        http.get('*/v1/fonts/1/stylesheet', () =>
+          HttpResponse.text('', { headers: { 'Content-Type': 'text/css' } }),
+        ),
+      ],
+    },
+  },
+  args: {
+    open: true,
+    onOpenChange: fn(),
+    appName: 'Example Bible App',
+    onConfirm: fn(),
+    onDecline: fn(),
+  },
+  render: (args) => (
+    <ShadowRootHost>
+      <SignInDialog {...args} />
+    </ShadowRootHost>
+  ),
+} satisfies Meta<typeof SignInDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const UsesSharedOverlayWithFocusAndAccessibleReferences: Story = {
+  play: async ({ canvasElement }) => {
+    const overlayRoot = await waitFor(() => {
+      const root = canvasElement.ownerDocument.body.querySelector<HTMLElement>(
+        '[data-yv-shadow-overlay-host]',
+      )?.shadowRoot;
+      if (!root) throw new Error('shared overlay shadow root not attached');
+      return root;
+    });
+    const dialog = await waitFor(() => {
+      const element = overlayRoot.querySelector<HTMLElement>('[role="dialog"]');
+      if (!element) throw new Error('sign-in dialog not rendered in shared overlay');
+      return element;
+    });
+
+    void expect(dialog.getRootNode()).toBe(overlayRoot);
+    void expect(
+      canvasElement.ownerDocument.body.querySelector(':scope > [role="dialog"]'),
+    ).toBeNull();
+
+    const titleId = dialog.getAttribute('aria-labelledby');
+    const descriptionId = dialog.getAttribute('aria-describedby');
+    void expect(titleId).toBeTruthy();
+    void expect(descriptionId).toBeTruthy();
+    void expect(overlayRoot.getElementById(titleId!)).not.toBeNull();
+    void expect(overlayRoot.getElementById(descriptionId!)).not.toBeNull();
+
+    await waitFor(() => {
+      const focusedElement = overlayRoot.activeElement;
+      void expect(focusedElement !== null && dialog.contains(focusedElement)).toBe(true);
+    });
+  },
+};

--- a/packages/ui/src/components/bible-version-picker.tsx
+++ b/packages/ui/src/components/bible-version-picker.tsx
@@ -933,7 +933,7 @@ export function BibleLanguagePickerContent({
           value={languageTab}
           onValueChange={setLanguageTab}
         >
-          <TabsList className="yv:mx-4 yv:w-[calc(100%-4*var(--spacing)*2)]">
+          <TabsList className="yv:mx-4 yv:w-[calc(100%-4*var(--yv-spacing)*2)]">
             <TabsTrigger className="yv:p-0" value="suggested">
               {t('suggestedTab')}
             </TabsTrigger>

--- a/packages/ui/src/components/ui/dialog.shadow-isolation.test.tsx
+++ b/packages/ui/src/components/ui/dialog.shadow-isolation.test.tsx
@@ -1,0 +1,26 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ShadowRootHost } from '../../lib/shadow-root-host';
+import { Dialog, DialogContent, DialogTitle } from './dialog';
+
+describe('DialogContent shadow isolation', () => {
+  it('portals into the shared shadow overlay when one is available', () => {
+    render(
+      <ShadowRootHost>
+        <Dialog open>
+          <DialogContent>
+            <DialogTitle>Isolated dialog</DialogTitle>
+          </DialogContent>
+        </Dialog>
+      </ShadowRootHost>,
+    );
+
+    const overlayRoot = document.body.querySelector<HTMLElement>(
+      '[data-yv-shadow-overlay-host]',
+    )?.shadowRoot;
+    const dialog = overlayRoot?.querySelector('[role="dialog"]');
+
+    expect(dialog).not.toBeNull();
+    expect(document.body.querySelector(':scope > [role="dialog"]')).toBeNull();
+  });
+});

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 
+import { useShadowPortalContainer } from '../../lib/shadow-root-host';
 import { cn } from '../../lib/utils';
 
 const Dialog = DialogPrimitive.Root;
@@ -24,8 +25,10 @@ function DialogContent({
   children,
   ...props
 }: DialogContentProps): React.ReactElement {
+  const shadowPortalContainer = useShadowPortalContainer();
+
   return (
-    <DialogPrimitive.Portal>
+    <DialogPrimitive.Portal container={shadowPortalContainer ?? undefined}>
       <DialogPrimitive.Overlay
         className={cn(
           'yv:fixed yv:inset-0 yv:z-50 yv:bg-black/50',

--- a/packages/ui/src/components/ui/popover.tsx
+++ b/packages/ui/src/components/ui/popover.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as PopoverPrimitive from '@radix-ui/react-popover';
 import { useTranslation } from 'react-i18next';
 import i18n from '@/i18n';
+import { useShadowPortalContainer } from '@/lib/shadow-root-host';
 import { Button } from './button';
 import { XIcon } from '../icons/x';
 
@@ -38,9 +39,10 @@ function PopoverContent({
   theme?: 'light' | 'dark';
 }): React.ReactNode {
   const { t } = useTranslation(undefined, { i18n });
+  const shadowPortalContainer = useShadowPortalContainer();
 
   return (
-    <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Portal container={shadowPortalContainer ?? undefined}>
       <PopoverPrimitive.Content
         data-slot="popover-content"
         data-yv-sdk
@@ -49,7 +51,7 @@ function PopoverContent({
         sideOffset={sideOffset}
         collisionPadding={16}
         className={cn(
-          'yv:bg-popover yv:text-popover-foreground yv:data-[state=open]:animate-in yv:data-[state=closed]:animate-out yv:data-[state=closed]:fade-out-0 yv:data-[state=open]:fade-in-0 yv:data-[state=closed]:zoom-out-95 yv:data-[state=open]:zoom-in-95 yv:data-[side=bottom]:slide-in-from-top-2 yv:data-[side=left]:slide-in-from-right-2 yv:data-[side=right]:slide-in-from-left-2 yv:data-[side=top]:slide-in-from-bottom-2 yv:z-50 yv:origin-(--radix-popover-content-transform-origin) yv:outline-hidden yv:grid yv:grid-rows-[auto_1fr_auto] yv:p-0 yv:h-full yv:max-h-[66svh] yv:max-sm:max-w-[calc(100vw-2rem)] yv:w-sm yv:sm:max-w-sm yv:overflow-hidden yv:rounded-2xl yv:border-0 yv:shadow-lg',
+          'yv:bg-popover yv:text-popover-foreground yv:data-[state=open]:animate-in yv:data-[state=closed]:animate-out yv:data-[state=closed]:fade-out-0 yv:data-[state=open]:fade-in-0 yv:data-[state=closed]:zoom-out-95 yv:data-[state=open]:zoom-in-95 yv:data-[side=bottom]:slide-in-from-top-2 yv:data-[side=left]:slide-in-from-right-2 yv:data-[side=right]:slide-in-from-left-2 yv:data-[side=top]:slide-in-from-bottom-2 yv:z-50 yv:origin-(--radix-popover-content-transform-origin) yv:outline-hidden yv:grid yv:grid-rows-[auto_1fr_auto] yv:p-0 yv:max-h-[min(66svh,var(--radix-popover-content-available-height))] yv:max-sm:max-w-[calc(100vw-2rem)] yv:w-sm yv:sm:max-w-sm yv:overflow-hidden yv:rounded-2xl yv:border-0 yv:shadow-lg',
           className,
         )}
         {...props}

--- a/packages/ui/src/components/ui/portal-fallback.test.tsx
+++ b/packages/ui/src/components/ui/portal-fallback.test.tsx
@@ -1,0 +1,42 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from './dialog';
+import { Popover, PopoverContent, PopoverTrigger } from './popover';
+
+describe('portal fallback without shadow isolation', () => {
+  it('renders popover content in the document without creating an overlay host', () => {
+    const overlayHostCount = document.body.querySelectorAll('[data-yv-shadow-overlay-host]').length;
+
+    render(
+      <Popover open>
+        <PopoverTrigger>Open</PopoverTrigger>
+        <PopoverContent heading="Versions">Content</PopoverContent>
+      </Popover>,
+    );
+
+    const content = document.body.querySelector('[data-slot="popover-content"]');
+    expect(content?.getRootNode()).toBe(document);
+    expect(document.body.querySelectorAll('[data-yv-shadow-overlay-host]')).toHaveLength(
+      overlayHostCount,
+    );
+  });
+
+  it('renders dialog content in the document without creating an overlay host', () => {
+    const overlayHostCount = document.body.querySelectorAll('[data-yv-shadow-overlay-host]').length;
+
+    render(
+      <Dialog open>
+        <DialogContent>
+          <DialogTitle>Title</DialogTitle>
+          <DialogDescription>Description</DialogDescription>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    const content = document.body.querySelector('[role="dialog"]');
+    expect(content?.getRootNode()).toBe(document);
+    expect(document.body.querySelectorAll('[data-yv-shadow-overlay-host]')).toHaveLength(
+      overlayHostCount,
+    );
+  });
+});

--- a/packages/ui/src/lib/shadow-root-host.test.tsx
+++ b/packages/ui/src/lib/shadow-root-host.test.tsx
@@ -93,34 +93,4 @@ describe('ShadowRootHost', () => {
       document.body.querySelectorAll('[data-yv-shadow-overlay-host]'),
     ).toHaveLength(1);
   });
-
-  it('reconnects the existing overlay root when its host is detached', () => {
-    render(
-      <ShadowRootHost>
-        <span>first</span>
-      </ShadowRootHost>,
-    );
-
-    const overlayHost = document.body.querySelector<HTMLElement>(
-      '[data-yv-shadow-overlay-host]',
-    );
-    const overlayRoot = overlayHost?.shadowRoot;
-    expect(overlayHost).not.toBeNull();
-    expect(overlayRoot).not.toBeNull();
-
-    overlayHost?.remove();
-    expect(overlayHost?.isConnected).toBe(false);
-
-    render(
-      <ShadowRootHost>
-        <span>second</span>
-      </ShadowRootHost>,
-    );
-
-    const reconnectedHost = document.body.querySelector<HTMLElement>(
-      '[data-yv-shadow-overlay-host]',
-    );
-    expect(reconnectedHost).toBe(overlayHost);
-    expect(reconnectedHost?.shadowRoot).toBe(overlayRoot);
-  });
 });

--- a/packages/ui/src/lib/shadow-root-host.test.tsx
+++ b/packages/ui/src/lib/shadow-root-host.test.tsx
@@ -60,4 +60,37 @@ describe('ShadowRootHost', () => {
     expect(style?.getAttribute('data-href')).toBe('yv-sdk-shadow-styles');
     expect(style?.getAttribute('data-precedence')).toBe('yv-sdk');
   });
+
+  it('reuses one document-level overlay root and keeps it available after unmount', () => {
+    const { unmount } = render(
+      <>
+        <ShadowRootHost>
+          <span>first</span>
+        </ShadowRootHost>
+        <ShadowRootHost>
+          <span>second</span>
+        </ShadowRootHost>
+      </>,
+    );
+
+    const overlayHosts = document.body.querySelectorAll<HTMLElement>(
+      '[data-yv-shadow-overlay-host]',
+    );
+    expect(overlayHosts).toHaveLength(1);
+
+    const overlayRoot = overlayHosts[0]?.shadowRoot;
+    expect(overlayRoot).not.toBeNull();
+
+    // jsdom does not implement constructable stylesheets, so the shared
+    // overlay root installs the direct <style> fallback.
+    expect(overlayRoot?.querySelector('style')).not.toBeNull();
+
+    unmount();
+
+    // The shared overlay root intentionally lives for the document lifetime
+    // so later isolated components can reuse it without recreating resources.
+    expect(
+      document.body.querySelectorAll('[data-yv-shadow-overlay-host]'),
+    ).toHaveLength(1);
+  });
 });

--- a/packages/ui/src/lib/shadow-root-host.test.tsx
+++ b/packages/ui/src/lib/shadow-root-host.test.tsx
@@ -93,4 +93,34 @@ describe('ShadowRootHost', () => {
       document.body.querySelectorAll('[data-yv-shadow-overlay-host]'),
     ).toHaveLength(1);
   });
+
+  it('reconnects the existing overlay root when its host is detached', () => {
+    render(
+      <ShadowRootHost>
+        <span>first</span>
+      </ShadowRootHost>,
+    );
+
+    const overlayHost = document.body.querySelector<HTMLElement>(
+      '[data-yv-shadow-overlay-host]',
+    );
+    const overlayRoot = overlayHost?.shadowRoot;
+    expect(overlayHost).not.toBeNull();
+    expect(overlayRoot).not.toBeNull();
+
+    overlayHost?.remove();
+    expect(overlayHost?.isConnected).toBe(false);
+
+    render(
+      <ShadowRootHost>
+        <span>second</span>
+      </ShadowRootHost>,
+    );
+
+    const reconnectedHost = document.body.querySelector<HTMLElement>(
+      '[data-yv-shadow-overlay-host]',
+    );
+    expect(reconnectedHost).toBe(overlayHost);
+    expect(reconnectedHost?.shadowRoot).toBe(overlayRoot);
+  });
 });

--- a/packages/ui/src/lib/shadow-root-host.tsx
+++ b/packages/ui/src/lib/shadow-root-host.tsx
@@ -1,11 +1,18 @@
-import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { createContext, useContext, useEffect, useRef, useState, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 
 declare const __YV_STYLES__: string;
 
 const sdkStyleSheets = new WeakMap<Document, CSSStyleSheet>();
+const sdkOverlayRoots = new WeakMap<Document, ShadowRoot>();
 const SDK_SHADOW_STYLE_HREF = 'yv-sdk-shadow-styles';
 const SDK_SHADOW_STYLE_PRECEDENCE = 'yv-sdk';
+const ShadowPortalContext = createContext<ShadowRoot | null>(null);
+
+/** @internal Returns the active SDK shadow root for nested portal primitives. */
+export function useShadowPortalContainer(): ShadowRoot | null {
+  return useContext(ShadowPortalContext);
+}
 
 function getStyleSheetConstructor(root: ShadowRoot): typeof CSSStyleSheet | undefined {
   return root.ownerDocument.defaultView?.CSSStyleSheet;
@@ -41,6 +48,28 @@ function resetHost(host: HTMLDivElement): void {
   host.style.setProperty('text-orientation', 'inherit', 'important');
 }
 
+function getOrCreateSdkOverlayRoot(ownerDocument: Document): ShadowRoot {
+  const existing = sdkOverlayRoots.get(ownerDocument);
+  if (existing?.host.isConnected) return existing;
+
+  const host = ownerDocument.createElement('div');
+  host.setAttribute('data-yv-shadow-overlay-host', '');
+  resetHost(host);
+
+  const root = host.attachShadow({ mode: 'open' });
+  if (supportsAdoptedStyleSheets(root)) {
+    root.adoptedStyleSheets = [getOrCreateSdkStyleSheet(root)];
+  } else {
+    const style = ownerDocument.createElement('style');
+    style.textContent = __YV_STYLES__;
+    root.append(style);
+  }
+
+  ownerDocument.body.append(host);
+  sdkOverlayRoots.set(ownerDocument, root);
+  return root;
+}
+
 interface ShadowRootHostProps {
   children: ReactNode;
 }
@@ -49,6 +78,7 @@ interface ShadowRootHostProps {
 export function ShadowRootHost({ children }: ShadowRootHostProps): ReactNode {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const [shadowRoot, setShadowRoot] = useState<ShadowRoot | null>(null);
+  const [portalContainer, setPortalContainer] = useState<ShadowRoot | null>(null);
   const [needsStyleFallback, setNeedsStyleFallback] = useState(false);
 
   useEffect(() => {
@@ -64,6 +94,7 @@ export function ShadowRootHost({ children }: ShadowRootHostProps): ReactNode {
     } else {
       setNeedsStyleFallback(true);
     }
+    setPortalContainer(getOrCreateSdkOverlayRoot(root.ownerDocument));
     setShadowRoot(root);
   }, []);
 
@@ -71,7 +102,7 @@ export function ShadowRootHost({ children }: ShadowRootHostProps): ReactNode {
     <div ref={hostRef} data-yv-shadow-host>
       {shadowRoot
         ? createPortal(
-            <>
+            <ShadowPortalContext.Provider value={portalContainer}>
               {needsStyleFallback ? (
                 <style href={SDK_SHADOW_STYLE_HREF} precedence={SDK_SHADOW_STYLE_PRECEDENCE}>
                   {__YV_STYLES__}
@@ -79,7 +110,7 @@ export function ShadowRootHost({ children }: ShadowRootHostProps): ReactNode {
               ) : null}
               {/* Host selectors cannot reach this reset boundary. */}
               <div style={{ all: 'initial', display: 'contents' }}>{children}</div>
-            </>,
+            </ShadowPortalContext.Provider>,
             shadowRoot,
           )
         : null}

--- a/packages/ui/src/lib/shadow-root-host.tsx
+++ b/packages/ui/src/lib/shadow-root-host.tsx
@@ -50,7 +50,12 @@ function resetHost(host: HTMLDivElement): void {
 
 function getOrCreateSdkOverlayRoot(ownerDocument: Document): ShadowRoot {
   const existing = sdkOverlayRoots.get(ownerDocument);
-  if (existing?.host.isConnected) return existing;
+  if (existing) {
+    if (!existing.host.isConnected) {
+      ownerDocument.body.append(existing.host);
+    }
+    return existing;
+  }
 
   const host = ownerDocument.createElement('div');
   host.setAttribute('data-yv-shadow-overlay-host', '');

--- a/packages/ui/src/lib/shadow-root-host.tsx
+++ b/packages/ui/src/lib/shadow-root-host.tsx
@@ -50,12 +50,7 @@ function resetHost(host: HTMLDivElement): void {
 
 function getOrCreateSdkOverlayRoot(ownerDocument: Document): ShadowRoot {
   const existing = sdkOverlayRoots.get(ownerDocument);
-  if (existing) {
-    if (!existing.host.isConnected) {
-      ownerDocument.body.append(existing.host);
-    }
-    return existing;
-  }
+  if (existing?.host.isConnected) return existing;
 
   const host = ownerDocument.createElement('div');
   host.setAttribute('data-yv-shadow-overlay-host', '');


### PR DESCRIPTION
## Summary

- add one shared, styled overlay shadow root for portalled SDK content
- route internal Radix Popover and Dialog portals to that root when rendered under ShadowRootHost
- prove the architecture with BibleVersionPicker and SignInDialog Storybook browser integration tests
- constrain popovers to Radix's available viewport height and namespace the picker spacing token
- preserve the existing document.body portal behavior outside shadow isolation
- record findings and remaining accessibility risks in ADR 0005

## Scope

This is an architecture spike, not a BibleVersionPicker rollout. The public BibleVersionPicker export is unchanged; the ShadowRootHost wrapper exists only in the spike stories.

## Findings

The Chromium proof covers host-CSS isolation, ancestor and viewport clipping, internal scrolling, positioning, focus, Escape and outside-click dismissal, shared-overlay reuse, and actual SignInDialog composition. Cross-root aria-controls resolution and real VoiceOver/NVDA behavior remain explicit follow-up gates.

## Verification

- UI unit suite: 408 tests passed
- Storybook Chromium integration: 11 tests passed
- UI build and style verification passed
- UI typecheck and lint passed
- git diff --check passed

The root pnpm test command could not complete locally because the core test setup requires YVP_API_HOST, which was not available. The complete UI suite passed independently.