### PR TITLE
fix(ui): write generated i18n resources atomically

### DIFF
--- a/.changeset/small-rules-exist.md
+++ b/.changeset/small-rules-exist.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal generator fix so parallel CI typecheck/build cannot truncate `resources.generated.ts`.

--- a/packages/ui/scripts/generate-i18n-resources.mjs
+++ b/packages/ui/scripts/generate-i18n-resources.mjs
@@ -6,7 +6,7 @@
  *   node scripts/generate-i18n-resources.mjs          # one-shot (build / CI)
  *   node scripts/generate-i18n-resources.mjs --watch   # watch locale dir in dev
  */
-import { readdirSync, watch, writeFileSync } from 'node:fs';
+import { readFileSync, readdirSync, renameSync, unlinkSync, watch, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -70,8 +70,39 @@ ${resourceEntries}
 export const supportedLngs = Object.keys(resources);
 `;
 
-  writeFileSync(outputPath, content, 'utf8');
+  writeGeneratedFile(content);
   console.log(`Generated ${outputPath} (${locales.length} locales: ${locales.join(', ')})`);
+}
+
+/**
+ * Replace resources.generated.ts without truncating it in place.
+ *
+ * CI runs UI typecheck and UI build in parallel; both call this generator.
+ * writeFileSync empties the destination first, so tsc can read a zero-length
+ * module and fail with TS2305 (no exported member 'resources' / 'supportedLngs').
+ * Skip the write when content is unchanged so parallel no-op runs do not race.
+ */
+function writeGeneratedFile(content) {
+  try {
+    if (readFileSync(outputPath, 'utf8') === content) {
+      return;
+    }
+  } catch {
+    // Missing or unreadable — write a fresh copy.
+  }
+
+  const tempPath = `${outputPath}.${process.pid}.tmp`;
+  writeFileSync(tempPath, content, 'utf8');
+  try {
+    renameSync(tempPath, outputPath);
+  } catch (error) {
+    try {
+      unlinkSync(tempPath);
+    } catch {
+      // Best-effort cleanup; the rename error is the one to surface.
+    }
+    throw error;
+  }
 }
 
 function shouldRegenerate(filename) {


### PR DESCRIPTION
## Summary
- Fixes the Type Check failure on #351 (`TS2305: Module "./resources.generated" has no exported member 'resources'`).
- UI typecheck and UI build both regenerate `resources.generated.ts` in parallel. `writeFileSync` truncates that file first, so `tsc` can read an empty module and report missing exports.
- The generator now skips the write when content is unchanged and otherwise replaces the file via temp + rename so readers never see a truncated copy.

## Test plan
- [ ] Confirm Type Check is green on this PR
- [ ] Confirm Type Check is green on #351 after this lands on main (re-run or wait for the changeset action to rebase)
- [ ] Optional: `pnpm --filter @youversion/platform-react-ui typecheck` locally still passes

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents concurrent i18n generation from exposing a truncated TypeScript module by skipping unchanged output and replacing changed output through a same-directory temporary file.
- Adds an intentional empty changeset for the internal tooling fix.
- Reads the existing generated file before writing to avoid unnecessary replacements.
- Writes changed resources to a process-specific temporary path and renames it over the destination.
- Cleans up the temporary file when replacement fails.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the generated resource now replaced atomically instead of being transiently truncated.

The changed writer preserves a complete destination for concurrent readers, avoids no-op write races, surfaces replacement errors, and does not introduce a reachable build, runtime, or security failure.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/scripts/generate-i18n-resources.mjs | Replaces truncate-in-place generation with unchanged-content detection and atomic temporary-file replacement; no actionable changed-code defect was established. |
| .changeset/small-rules-exist.md | Adds the required empty changeset documenting this internal generator fix without triggering a package release. |

<sub>Reviews (1): Last reviewed commit: ["fix(ui): write generated i18n resources ..."](https://github.com/youversion/platform-sdk-react/commit/cedb864ff7f2d07522e66845980e910dc5259f87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55275446)</sub>

**Context used:**

- Knowledge Base — [packages/ui](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/ui-package.md)

<!-- /greptile_comment -->