### PR TITLE
feat(ui): mix highlight fills and replace apply palette (YPE-5058)

### DIFF
--- a/.changeset/ype-5058-highlight-palette-mix.md
+++ b/.changeset/ype-5058-highlight-palette-mix.md
@@ -3,4 +3,4 @@
 '@youversion/platform-react-ui': minor
 ---
 
-Replace the React highlight apply palette with six colors and paint fills with an sRGB mix against `--yv-background` (light identity, dark `p = 0.20`). Words of Christ stay unmixed (`#94000c` / `#e4bfc2`). Leftover `fffe00` still paints and clears.
+Replace the React highlight apply palette with six colors and paint fills with CSS `color-mix` against the live `--yv-background` / `--yv-card` tokens (light identity, dark `p = 0.20`). Words of Christ stay unmixed (`#94000c` / `#e4bfc2`). Leftover `fffe00` still paints and clears.

--- a/.changeset/ype-5058-highlight-palette-mix.md
+++ b/.changeset/ype-5058-highlight-palette-mix.md
@@ -1,0 +1,6 @@
+---
+'@youversion/platform-core': minor
+'@youversion/platform-react-ui': minor
+---
+
+Replace the React highlight apply palette with six colors and paint fills with an sRGB mix against `--yv-background` (light identity, dark `p = 0.20`). Words of Christ stay unmixed (`#94000c` / `#e4bfc2`). Leftover `fffe00` still paints and clears.

--- a/.changeset/ype-5058-highlight-palette-mix.md
+++ b/.changeset/ype-5058-highlight-palette-mix.md
@@ -3,4 +3,6 @@
 '@youversion/platform-react-ui': minor
 ---
 
-Replace the React highlight apply palette with six colors and paint fills with CSS `color-mix` against the live `--yv-background` / `--yv-card` tokens (light identity, dark `p = 0.20`). Words of Christ stay unmixed (`#94000c` / `#e4bfc2`). Leftover `fffe00` still paints and clears.
+Highlights mix into the reader background so they stay readable in light and dark. If a host sets a different `--yv-background` or `--yv-card`, the fill follows that token.
+
+The apply palette is six new colors. The stored hex stays unmixed. Dark mode uses 20% of the stored color. Words of Christ keep their own color (`#94000c` / `#e4bfc2`) so the red letters stay clear on the fill. Old `fffe00` highlights still paint and clear.

--- a/docs/adr/YPE-642-verse-action-popover.md
+++ b/docs/adr/YPE-642-verse-action-popover.md
@@ -78,8 +78,10 @@ needed: real YV colors (ADR-005), alpha fill (ADR-005), wire into BibleReader
 > **Superseded for React web by YPE-5058.** Apply is six hexes (`ffec5b`,
 > `b4ffc1`, `bbf4ff`, `ffdca7`, `ffcff8`, `dfdcff`). Fill is
 > `mixSrgb(stored, --yv-background, p)`: light `p = 1.00`, dark `p = 0.20`
-> against `#121212` (not popover `#1c1a1a`, not 0.3 alpha). Old `fffe00`
-> leftovers still paint and clear. This table is the YPE-642 as-built palette.
+> against `#121212` (not popover `#1c1a1a`, not 0.3 alpha). Drawer dots use
+> the same `p` against `--yv-card` (`#232121` dark / `#fcfafa` light). Old
+> `fffe00` leftovers still paint and clear. This table is the YPE-642
+> as-built palette.
 
 Theme tokens don't carry these exact colors (the iOS app hardcodes them), so the
 palette is hardcoded here too. Simpler than mapping to tokens.

--- a/docs/adr/YPE-642-verse-action-popover.md
+++ b/docs/adr/YPE-642-verse-action-popover.md
@@ -77,11 +77,12 @@ needed: real YV colors (ADR-005), alpha fill (ADR-005), wire into BibleReader
 ### ADR-005 — Hardcoded hex palette, matching the iOS app
 > **Superseded for React web by YPE-5058.** Apply is six hexes (`ffec5b`,
 > `b4ffc1`, `bbf4ff`, `ffdca7`, `ffcff8`, `dfdcff`). Fill is
-> `mixSrgb(stored, --yv-background, p)`: light `p = 1.00`, dark `p = 0.20`
-> against `#121212` (not popover `#1c1a1a`, not 0.3 alpha). Drawer dots use
-> the same `p` against `--yv-card` (`#232121` dark / `#fcfafa` light). Old
-> `fffe00` leftovers still paint and clear. This table is the YPE-642
-> as-built palette.
+> `color-mix(in srgb, stored calc(p * 100%), var(--yv-background))`: light
+> `p = 1.00`, dark `p = 0.20` via `--yv-highlight-mix-p` (not popover
+> `#1c1a1a`, not 0.3 alpha). Drawer dots use the same `p` against
+> `var(--yv-card)`. A host override of those surface tokens stays
+> authoritative. Old `fffe00` leftovers still paint and clear. This table
+> is the YPE-642 as-built palette.
 
 Theme tokens don't carry these exact colors (the iOS app hardcodes them), so the
 palette is hardcoded here too. Simpler than mapping to tokens.

--- a/docs/adr/YPE-642-verse-action-popover.md
+++ b/docs/adr/YPE-642-verse-action-popover.md
@@ -75,6 +75,12 @@ needed: real YV colors (ADR-005), alpha fill (ADR-005), wire into BibleReader
   blast radius is small, but it is a public prop on `BibleTextView`.
 
 ### ADR-005 — Hardcoded hex palette, matching the iOS app
+> **Superseded for React web by YPE-5058.** Apply is six hexes (`ffec5b`,
+> `b4ffc1`, `bbf4ff`, `ffdca7`, `ffcff8`, `dfdcff`). Fill is
+> `mixSrgb(stored, --yv-background, p)`: light `p = 1.00`, dark `p = 0.20`
+> against `#121212` (not popover `#1c1a1a`, not 0.3 alpha). Old `fffe00`
+> leftovers still paint and clear. This table is the YPE-642 as-built palette.
+
 Theme tokens don't carry these exact colors (the iOS app hardcodes them), so the
 palette is hardcoded here too. Simpler than mapping to tokens.
 

--- a/packages/core/src/styles/bible-reader-typography.test.ts
+++ b/packages/core/src/styles/bible-reader-typography.test.ts
@@ -166,4 +166,9 @@ describe('bible-reader phase-1 typography (Swift-adjusted tags)', () => {
     expect(themeCss).toContain('--yv-wj: #94000c;');
     expect(themeCss).toContain('--yv-wj: #e4bfc2;');
   });
+
+  it('sets highlight mix p to 1 in light and 0.2 in dark', () => {
+    expect(themeCss).toContain('--yv-highlight-mix-p: 1;');
+    expect(themeCss).toContain('--yv-highlight-mix-p: 0.2;');
+  });
 });

--- a/packages/core/src/styles/bible-reader-typography.test.ts
+++ b/packages/core/src/styles/bible-reader-typography.test.ts
@@ -3,6 +3,7 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const css = readFileSync(resolve(import.meta.dirname, './bible-reader.css'), 'utf8');
+const themeCss = readFileSync(resolve(import.meta.dirname, './theme.css'), 'utf8');
 const cssWithoutComments = css.replace(/\/\*[\s\S]*?\*\//g, '');
 
 function rulesForExactClass(cls: string): string {
@@ -149,7 +150,8 @@ describe('bible-reader phase-1 typography (Swift-adjusted tags)', () => {
     expect(css).not.toMatch(/&\s*\.note\s+\.fv\s*\{/);
 
     expect(rulesForExactClass('nd')).toContain('font-variant: small-caps');
-    expect(rulesForExactClass('wj')).toContain('color: var(--yv-red)');
+    expect(rulesForExactClass('wj')).toContain('color: var(--yv-wj)');
+    expect(rulesForExactClass('wj')).not.toContain('color: var(--yv-red)');
     expect(rulesForExactClass('it')).toContain('font-style: italic');
     expect(rulesForExactClass('add')).toContain('font-style: italic');
     expect(rulesForExactClass('qs')).toContain('font-style: italic');
@@ -158,5 +160,10 @@ describe('bible-reader phase-1 typography (Swift-adjusted tags)', () => {
     expect(css).not.toMatch(/&\s*\.p\s*\+\s*\.s1\b/);
     expect(css).not.toMatch(/&\s*\.q1\s*\+\s*\.p\b/);
     expect(css).not.toMatch(/&\s*\.p\s*\+\s*\.q1\b/);
+  });
+
+  it('keeps WOC text unmixed: #94000c light / #e4bfc2 dark', () => {
+    expect(themeCss).toContain('--yv-wj: #94000c;');
+    expect(themeCss).toContain('--yv-wj: #e4bfc2;');
   });
 });

--- a/packages/core/src/styles/bible-reader.css
+++ b/packages/core/src/styles/bible-reader.css
@@ -760,9 +760,9 @@
      CHARACTER STYLES
      ============================================================ */
 
-  /* \wj - Words of Jesus (red letter) */
+  /* \wj - Words of Jesus (red letter). Unmixed on highlight fills. */
   & .wj {
-    color: var(--yv-red);
+    color: var(--yv-wj);
   }
 
   /* \nd - Name of Deity (e.g. "LORD") — Smallcaps */

--- a/packages/core/src/styles/theme.css
+++ b/packages/core/src/styles/theme.css
@@ -118,6 +118,7 @@
   --yv-font-serif: 'Untitled Serif', 'Source Serif 4', serif;
   --yv-reader-font-family: var(--yv-font-serif), var(--yv-font-sans);
   --yv-wj: #94000c;
+  --yv-highlight-mix-p: 1;
 
   &[data-yv-theme='dark'] {
     /* Brand colors - Dark theme */
@@ -154,6 +155,7 @@
     --yv-sidebar-border: var(--yv-gray-35);
     --yv-sidebar-ring: var(--yv-blue-30-dm);
     --yv-wj: #e4bfc2;
+    --yv-highlight-mix-p: 0.2;
   }
 }
 

--- a/packages/core/src/styles/theme.css
+++ b/packages/core/src/styles/theme.css
@@ -117,6 +117,7 @@
   --yv-font-sans: 'Inter', sans-serif;
   --yv-font-serif: 'Untitled Serif', 'Source Serif 4', serif;
   --yv-reader-font-family: var(--yv-font-serif), var(--yv-font-sans);
+  --yv-wj: #94000c;
 
   &[data-yv-theme='dark'] {
     /* Brand colors - Dark theme */
@@ -152,6 +153,7 @@
     --yv-sidebar-accent-foreground: var(--yv-white);
     --yv-sidebar-border: var(--yv-gray-35);
     --yv-sidebar-ring: var(--yv-blue-30-dm);
+    --yv-wj: #e4bfc2;
   }
 }
 

--- a/packages/ui/src/components/bible-reader-controlled.test.tsx
+++ b/packages/ui/src/components/bible-reader-controlled.test.tsx
@@ -30,6 +30,7 @@ import type { HighlightedVerses } from '@/lib/highlight-colors';
 import { HIGHLIGHT_COLORS } from './verse-action-popover';
 import { buildVerseReference, buildVerseShareText, joinVerseTexts } from '@/lib/verse-share';
 
+import { fillFor } from '@/test/highlights-test-utils';
 import { installResizeObserverStub } from '@/test/dom-stubs';
 
 installResizeObserverStub();
@@ -192,18 +193,6 @@ function getVerseEl(container: HTMLElement, verse: number): HTMLElement {
 
 function selectVerse(container: HTMLElement, verse: number) {
   fireEvent.click(getVerseEl(container, verse));
-}
-
-/**
- * Color the reader paints for a highlight fill. These tests run in light mode
- * (theme mocked to 'light'), where the fill is full opacity (Swift parity);
- * jsdom serializes a fully opaque color to `rgb(...)`.
- */
-function fillFor(hex: string): string {
-  const r = parseInt(hex.slice(0, 2), 16);
-  const g = parseInt(hex.slice(2, 4), 16);
-  const b = parseInt(hex.slice(4, 6), 16);
-  return `rgb(${r}, ${g}, ${b})`;
 }
 
 function getApplyButtons() {

--- a/packages/ui/src/components/bible-reader-controlled.test.tsx
+++ b/packages/ui/src/components/bible-reader-controlled.test.tsx
@@ -93,7 +93,7 @@ function defaultOverrides(): HookOverrides {
         Promise.resolve({
           version_id: 111,
           passage_id: 'JHN.3.16',
-          color: 'fffe00',
+          color: 'ffec5b',
         }),
       deleteHighlight: () => Promise.resolve(),
     }),
@@ -120,8 +120,8 @@ function defaultOverrides(): HookOverrides {
   };
 }
 
-const YELLOW = HIGHLIGHT_COLORS[0]; // fffe00
-const GREEN = HIGHLIGHT_COLORS[1]; // 5dff79
+const YELLOW = HIGHLIGHT_COLORS[0];
+const GREEN = HIGHLIGHT_COLORS[1];
 
 const mockBooks: BibleBook[] = [
   {

--- a/packages/ui/src/components/bible-reader-highlights-machine.test.ts
+++ b/packages/ui/src/components/bible-reader-highlights-machine.test.ts
@@ -78,7 +78,7 @@ describe('bibleReaderHighlightsMachine — writeIntent lifecycle', () => {
     const { ref, refetch } = makeServices();
     const actor = startMachine(ref);
 
-    actor.send({ type: 'TAP_COLOR', color: 'FFFE00', verses: [16] });
+    actor.send({ type: 'TAP_COLOR', color: 'FFEC5B', verses: [16] });
     // Claimed synchronously before the write settles.
     expect(actor.getSnapshot().context.writeIntent.get(16)).toBeDefined();
 
@@ -86,7 +86,7 @@ describe('bibleReaderHighlightsMachine — writeIntent lifecycle', () => {
 
     const ctx = actor.getSnapshot().context;
     expect(ctx.writeIntent.has(16)).toBe(false);
-    expect(ctx.reconcile.get(16)).toEqual({ op: 'apply', color: 'fffe00' });
+    expect(ctx.reconcile.get(16)).toEqual({ op: 'apply', color: 'ffec5b' });
     actor.stop();
   });
 
@@ -96,9 +96,9 @@ describe('bibleReaderHighlightsMachine — writeIntent lifecycle', () => {
     const { ref, refetch } = makeServices({ createHighlight });
     const actor = startMachine(ref);
 
-    actor.send({ type: 'TAP_COLOR', color: 'FFFE00', verses: [16] });
+    actor.send({ type: 'TAP_COLOR', color: 'FFEC5B', verses: [16] });
     await vi.waitFor(() => expect(createHighlight).toHaveBeenCalled());
-    expect(actor.getSnapshot().context.overlay).toEqual({ 16: 'fffe00' });
+    expect(actor.getSnapshot().context.overlay).toEqual({ 16: 'ffec5b' });
 
     // Navigate to a new chapter while the old-scope write is still in flight.
     actor.send({ type: 'SCOPE_CHANGED', scope: scopeJHN4 });
@@ -127,17 +127,17 @@ describe('bibleReaderHighlightsMachine — writeIntent lifecycle', () => {
     const actor = startMachine(ref);
 
     // Write A: apply pink to verse 16 (goes in flight).
-    actor.send({ type: 'TAP_COLOR', color: 'ff95ef', verses: [16] });
+    actor.send({ type: 'TAP_COLOR', color: 'ffcff8', verses: [16] });
     await vi.waitFor(() => expect(createHighlight).toHaveBeenCalledTimes(1));
     const claimA = actor.getSnapshot().context.writeIntent.get(16);
     expect(claimA).toBeDefined();
 
     // Write B: re-claim verse 16 with green while A is still in flight (queued).
-    actor.send({ type: 'TAP_COLOR', color: '5dff79', verses: [16] });
+    actor.send({ type: 'TAP_COLOR', color: 'b4ffc1', verses: [16] });
     const claimB = actor.getSnapshot().context.writeIntent.get(16);
     expect(claimB).toBeDefined();
     expect(claimB).not.toBe(claimA);
-    expect(actor.getSnapshot().context.overlay).toEqual({ 16: '5dff79' });
+    expect(actor.getSnapshot().context.overlay).toEqual({ 16: 'b4ffc1' });
 
     // A settles: it must not delete B's claim or reconcile verse 16.
     first.resolve();
@@ -145,7 +145,7 @@ describe('bibleReaderHighlightsMachine — writeIntent lifecycle', () => {
     const afterA = actor.getSnapshot().context;
     expect(afterA.writeIntent.get(16)).toBe(claimB);
     expect(afterA.reconcile.has(16)).toBe(false);
-    expect(afterA.overlay).toEqual({ 16: '5dff79' });
+    expect(afterA.overlay).toEqual({ 16: 'b4ffc1' });
 
     // B settles: it cleans up its own claim and registers its reconcile entry.
     await vi.waitFor(() => expect(createHighlight).toHaveBeenCalledTimes(2));
@@ -153,7 +153,7 @@ describe('bibleReaderHighlightsMachine — writeIntent lifecycle', () => {
     await vi.waitFor(() => expect(refetch).toHaveBeenCalledTimes(2));
     const afterB = actor.getSnapshot().context;
     expect(afterB.writeIntent.has(16)).toBe(false);
-    expect(afterB.reconcile.get(16)).toEqual({ op: 'apply', color: '5dff79' });
+    expect(afterB.reconcile.get(16)).toEqual({ op: 'apply', color: 'b4ffc1' });
     actor.stop();
   });
 });
@@ -169,16 +169,16 @@ describe('bibleReaderHighlightsMachine — pending stash on lost permission', ()
     vi.spyOn(console, 'error').mockImplementation(vi.fn());
 
     // Both taps issued before either write settles: A is writing, B is queued.
-    actor.send({ type: 'TAP_COLOR', color: 'fffe00', verses: [1, 2, 3] });
-    actor.send({ type: 'TAP_COLOR', color: '5dff79', verses: [4, 5, 6] });
+    actor.send({ type: 'TAP_COLOR', color: 'ffec5b', verses: [1, 2, 3] });
+    actor.send({ type: 'TAP_COLOR', color: 'b4ffc1', verses: [4, 5, 6] });
 
     await vi.waitFor(() => expect(refetch).toHaveBeenCalledTimes(2));
 
     const stash = peekPendingHighlights();
     expect(stash).toHaveLength(2);
     // Verse-level ordering deterministic: first-queued (A) first.
-    expect(stash[0]).toMatchObject({ verses: [1, 2, 3], color: 'fffe00' });
-    expect(stash[1]).toMatchObject({ verses: [4, 5, 6], color: '5dff79' });
+    expect(stash[0]).toMatchObject({ verses: [1, 2, 3], color: 'ffec5b' });
+    expect(stash[1]).toMatchObject({ verses: [4, 5, 6], color: 'b4ffc1' });
     actor.stop();
   });
 
@@ -194,14 +194,14 @@ describe('bibleReaderHighlightsMachine — pending stash on lost permission', ()
     const actor = startMachine(ref);
     vi.spyOn(console, 'error').mockImplementation(vi.fn());
 
-    actor.send({ type: 'TAP_COLOR', color: 'fffe00', verses: [1, 2, 3] });
-    actor.send({ type: 'TAP_COLOR', color: '5dff79', verses: [4, 5, 6] });
+    actor.send({ type: 'TAP_COLOR', color: 'ffec5b', verses: [1, 2, 3] });
+    actor.send({ type: 'TAP_COLOR', color: 'b4ffc1', verses: [4, 5, 6] });
 
     await vi.waitFor(() => expect(refetch).toHaveBeenCalledTimes(2));
 
     const stash = peekPendingHighlights();
     expect(stash).toHaveLength(1);
-    expect(stash[0]).toMatchObject({ verses: [1, 2, 3], color: 'fffe00' });
+    expect(stash[0]).toMatchObject({ verses: [1, 2, 3], color: 'ffec5b' });
     // The 5xx write's verses were never stashed.
     expect(stash.some((entry) => entry.verses.includes(4))).toBe(false);
     actor.stop();
@@ -214,7 +214,7 @@ describe('bibleReaderHighlightsMachine — pending stash on lost permission', ()
     appendPendingHighlight(
       {
         verses: [1, 2, 3],
-        color: 'fffe00',
+        color: 'ffec5b',
         versionId: 111,
         book: 'JHN',
         chapter: '3',
@@ -225,7 +225,7 @@ describe('bibleReaderHighlightsMachine — pending stash on lost permission', ()
     appendPendingHighlight(
       {
         verses: [4, 5, 6],
-        color: '5dff79',
+        color: 'b4ffc1',
         versionId: 111,
         book: 'JHN',
         chapter: '3',
@@ -245,12 +245,12 @@ describe('bibleReaderHighlightsMachine — pending stash on lost permission', ()
     expect(passages).toEqual(['JHN.3.1-3', 'JHN.3.4-6']);
     // Both colors painted in the same-scope overlay.
     expect(actor.getSnapshot().context.overlay).toEqual({
-      1: 'fffe00',
-      2: 'fffe00',
-      3: 'fffe00',
-      4: '5dff79',
-      5: '5dff79',
-      6: '5dff79',
+      1: 'ffec5b',
+      2: 'ffec5b',
+      3: 'ffec5b',
+      4: 'b4ffc1',
+      5: 'b4ffc1',
+      6: 'b4ffc1',
     });
     // Pending consumed once resumed.
     expect(readPendingHighlights()).toEqual([]);

--- a/packages/ui/src/components/use-bible-reader-highlights.auth-flow.integration.test.tsx
+++ b/packages/ui/src/components/use-bible-reader-highlights.auth-flow.integration.test.tsx
@@ -88,7 +88,7 @@ describe('highlight auth flow — one-fell-swoop (signed out)', () => {
     const signIn = vi.spyOn(YouVersionAPIUsers, 'signIn').mockResolvedValue(undefined);
     const createHighlight = vi
       .spyOn(HighlightsClient.prototype, 'createHighlight')
-      .mockResolvedValue({ version_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' });
+      .mockResolvedValue({ version_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' });
 
     const { result, unmount } = renderHook(() => useBibleReaderHighlights(options), {
       wrapper: Providers,
@@ -98,12 +98,12 @@ describe('highlight auth flow — one-fell-swoop (signed out)', () => {
     // instead of redirecting immediately. It stashes the pending intent and does
     // NOT launch OAuth until the user confirms.
     act(() => {
-      expect(result.current.apply('FFFE00', [16])).toBe('flow');
+      expect(result.current.apply('FFEC5B', [16])).toBe('flow');
     });
 
     expect(result.current.signInDialogOpen).toBe(true);
     const pending = readPendingHighlights()[0];
-    expect(pending).toMatchObject({ verses: [16], color: 'fffe00', versionId: 111, chapter: '3' });
+    expect(pending).toMatchObject({ verses: [16], color: 'ffec5b', versionId: 111, chapter: '3' });
     expect(signIn).not.toHaveBeenCalled();
     expect(createHighlight).not.toHaveBeenCalled();
 
@@ -129,7 +129,7 @@ describe('highlight auth flow — one-fell-swoop (signed out)', () => {
       expect(createHighlight).toHaveBeenCalledWith({
         version_id: 111,
         passage_id: 'JHN.3.16',
-        color: 'fffe00',
+        color: 'ffec5b',
       });
     });
     // Pending consumed (the write is the proof it applied).
@@ -144,11 +144,11 @@ describe('highlight auth flow — sign-in dialog (signed out)', () => {
     const { result } = renderHook(() => useBibleReaderHighlights(options), { wrapper: Providers });
 
     act(() => {
-      expect(result.current.apply('fffe00', [16])).toBe('flow');
+      expect(result.current.apply('ffec5b', [16])).toBe('flow');
     });
 
     expect(result.current.signInDialogOpen).toBe(true);
-    expect(readPendingHighlights()[0]).toMatchObject({ verses: [16], color: 'fffe00' });
+    expect(readPendingHighlights()[0]).toMatchObject({ verses: [16], color: 'ffec5b' });
     expect(signIn).not.toHaveBeenCalled();
   });
 
@@ -158,7 +158,7 @@ describe('highlight auth flow — sign-in dialog (signed out)', () => {
     const { result } = renderHook(() => useBibleReaderHighlights(options), { wrapper: Providers });
 
     act(() => {
-      result.current.apply('fffe00', [16]);
+      result.current.apply('ffec5b', [16]);
     });
     expect(result.current.signInDialogOpen).toBe(true);
     expect(readPendingHighlights()).not.toHaveLength(0);
@@ -186,11 +186,11 @@ describe('highlight auth flow — just-in-time (signed in, no permission)', () =
     const { result } = renderHook(() => useBibleReaderHighlights(options), { wrapper: Providers });
 
     act(() => {
-      expect(result.current.apply('fffe00', [16])).toBe('flow');
+      expect(result.current.apply('ffec5b', [16])).toBe('flow');
     });
 
     expect(result.current.permissionDialogOpen).toBe(true);
-    expect(readPendingHighlights()[0]).toMatchObject({ verses: [16], color: 'fffe00' });
+    expect(readPendingHighlights()[0]).toMatchObject({ verses: [16], color: 'ffec5b' });
     expect(createHighlight).not.toHaveBeenCalled();
 
     await act(async () => {
@@ -210,7 +210,7 @@ describe('highlight auth flow — just-in-time (signed in, no permission)', () =
     const { result } = renderHook(() => useBibleReaderHighlights(options), { wrapper: Providers });
 
     act(() => {
-      result.current.apply('fffe00', [16]);
+      result.current.apply('ffec5b', [16]);
     });
     expect(readPendingHighlights()).not.toHaveLength(0);
 
@@ -231,7 +231,7 @@ describe('highlight auth flow — just-in-time (signed in, no permission)', () =
     });
 
     act(() => {
-      result.current.apply('fffe00', [16]);
+      result.current.apply('ffec5b', [16]);
     });
     expect(result.current.permissionDialogOpen).toBe(true);
     expect(readPendingHighlights()).toHaveLength(1);
@@ -265,7 +265,7 @@ describe('highlight auth flow — data-exchange return', () => {
     // Pre-stash a pending highlight as the confirm path would have.
     stashPendingHighlight({
       verses: [16],
-      color: 'fffe00',
+      color: 'ffec5b',
       versionId: 111,
       book: 'JHN',
       chapter: '3',
@@ -273,7 +273,7 @@ describe('highlight auth flow — data-exchange return', () => {
     });
     const createHighlight = vi
       .spyOn(HighlightsClient.prototype, 'createHighlight')
-      .mockResolvedValue({ version_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' });
+      .mockResolvedValue({ version_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' });
 
     const { rerender } = renderHook(() => useBibleReaderHighlights(options), {
       wrapper: Providers,
@@ -287,7 +287,7 @@ describe('highlight auth flow — data-exchange return', () => {
       expect(createHighlight).toHaveBeenCalledWith({
         version_id: 111,
         passage_id: 'JHN.3.16',
-        color: 'fffe00',
+        color: 'ffec5b',
       });
     });
     expect(YouVersionPlatformConfiguration.hasPermission('highlights')).toBe(true);
@@ -308,7 +308,7 @@ describe('highlight auth flow — data-exchange return', () => {
     YouVersionPlatformConfiguration.saveDataExchangeInitiator();
     stashPendingHighlight({
       verses: [16],
-      color: 'fffe00',
+      color: 'ffec5b',
       versionId: 111,
       book: 'JHN',
       chapter: '3',
@@ -332,14 +332,14 @@ describe('highlight auth flow — data-exchange return', () => {
     expect(createHighlight).toHaveBeenCalledWith({
       version_id: 111,
       passage_id: 'JHN.3.16',
-      color: 'fffe00',
+      color: 'ffec5b',
     });
     // Server truth wins: cache invalidated, and the pending is re-stashed from the
     // op's own scope so a post-grant confirm can resume it.
     expect(YouVersionPlatformConfiguration.hasPermission('highlights')).toBe(false);
     expect(readPendingHighlights()[0]).toMatchObject({
       verses: [16],
-      color: 'fffe00',
+      color: 'ffec5b',
       versionId: 111,
       chapter: '3',
     });
@@ -354,7 +354,7 @@ describe('highlight auth flow — data-exchange return', () => {
     setLocation('https://host.example/read?data_exchange_status=cancel');
     stashPendingHighlight({
       verses: [16],
-      color: 'fffe00',
+      color: 'ffec5b',
       versionId: 111,
       book: 'JHN',
       chapter: '3',
@@ -382,7 +382,7 @@ describe('highlight auth flow — data-exchange return', () => {
     setLocation('https://host.example/read?data_exchange_status=something-unexpected');
     stashPendingHighlight({
       verses: [16],
-      color: 'fffe00',
+      color: 'ffec5b',
       versionId: 111,
       book: 'JHN',
       chapter: '3',
@@ -418,7 +418,7 @@ describe('highlight auth flow — write failure routing', () => {
     const { result } = renderHook(() => useBibleReaderHighlights(options), { wrapper: Providers });
 
     act(() => {
-      expect(result.current.apply('fffe00', [16])).toBe('applied');
+      expect(result.current.apply('ffec5b', [16])).toBe('applied');
     });
 
     await waitFor(() => {
@@ -427,7 +427,7 @@ describe('highlight auth flow — write failure routing', () => {
     // Cache invalidated (server truth wins), overlay reverted, pending KEPT.
     expect(YouVersionPlatformConfiguration.hasPermission('highlights')).toBe(false);
     expect(result.current.highlightedVerses).toEqual({});
-    expect(readPendingHighlights()[0]).toMatchObject({ verses: [16], color: 'fffe00' });
+    expect(readPendingHighlights()[0]).toMatchObject({ verses: [16], color: 'ffec5b' });
   });
 
   it('5xx reverts the overlay, logs, and discards pending without re-prompting', async () => {
@@ -437,7 +437,7 @@ describe('highlight auth flow — write failure routing', () => {
     const { result } = renderHook(() => useBibleReaderHighlights(options), { wrapper: Providers });
 
     act(() => {
-      result.current.apply('fffe00', [16]);
+      result.current.apply('ffec5b', [16]);
     });
 
     await waitFor(() => {
@@ -470,7 +470,7 @@ describe('highlight auth flow — operation queue', () => {
       order.push('create:start');
       await createGate;
       order.push('create:end');
-      return { version_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' };
+      return { version_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' };
     });
     vi.spyOn(HighlightsClient.prototype, 'deleteHighlight').mockImplementation(async () => {
       order.push('delete:start');
@@ -481,10 +481,10 @@ describe('highlight auth flow — operation queue', () => {
 
     // Apply then immediately remove the same verse.
     act(() => {
-      result.current.apply('fffe00', [16]);
+      result.current.apply('ffec5b', [16]);
     });
     act(() => {
-      result.current.remove('fffe00', [16]);
+      result.current.remove('ffec5b', [16]);
     });
 
     // Optimistic: last-issued (remove) wins the visual state.

--- a/packages/ui/src/components/use-bible-reader-highlights.dom-vapor.test.tsx
+++ b/packages/ui/src/components/use-bible-reader-highlights.dom-vapor.test.tsx
@@ -49,7 +49,7 @@ function Reader({ removeRef }: { removeRef: { current: (() => void) | null } }) 
   const api = useBibleReaderHighlights(options);
   useEffect(() => {
     removeRef.current = () => {
-      api.remove('fffe00', selected);
+      api.remove('ffec5b', selected);
       // Popover close → selection clear on a SEPARATE tick (Radix close), so the
       // clear re-render lands after the optimistic overlay commit — modeling the
       // real reader rather than a single batched update.
@@ -70,7 +70,7 @@ describe('vapor flash — real Verse.Html DOM paint (MutationObserver on style)'
   // waitFor gates below use 5s each; the default 5s it() timeout can expire first
   // on a loaded CI runner and hide the real assertion.
   it('the verse-2 background is never repainted to yellow after the optimistic unpaint', async () => {
-    const withRow = () => collection([{ version_id: 111, passage_id: 'JHN.1.2', color: 'fffe00' }]);
+    const withRow = () => collection([{ version_id: 111, passage_id: 'JHN.1.2', color: 'ffec5b' }]);
     // The post-remove refetch is held unresolved to widen the settle→response
     // window the live flash lives in; it never settles.
     const heldRefetch = new Promise<Collection<Highlight>>(vi.fn());

--- a/packages/ui/src/components/use-bible-reader-highlights.integration.test.tsx
+++ b/packages/ui/src/components/use-bible-reader-highlights.integration.test.tsx
@@ -42,8 +42,8 @@ describe('useBibleReaderHighlights — real useHighlights/useApiData', () => {
   it('fetches and renders highlights when auth resolves after mount (enabled false→true)', async () => {
     const getHighlights = vi.spyOn(HighlightsClient.prototype, 'getHighlights').mockResolvedValue({
       data: [
-        { version_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' },
-        { version_id: 111, passage_id: 'JHN.3.17', color: '5dff79' },
+        { version_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' },
+        { version_id: 111, passage_id: 'JHN.3.17', color: 'b4ffc1' },
       ],
       next_page_token: null,
     });
@@ -62,7 +62,7 @@ describe('useBibleReaderHighlights — real useHighlights/useApiData', () => {
     rerender();
 
     await waitFor(() => {
-      expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00', 17: '5dff79' });
+      expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b', 17: 'b4ffc1' });
     });
     expect(getHighlights).toHaveBeenCalledTimes(1);
     expect(getHighlights).toHaveBeenCalledWith({ version_id: 111, passage_id: 'JHN.3' });
@@ -70,7 +70,7 @@ describe('useBibleReaderHighlights — real useHighlights/useApiData', () => {
 
   it('un-renders highlights immediately on sign-out and does not refetch', async () => {
     const getHighlights = vi.spyOn(HighlightsClient.prototype, 'getHighlights').mockResolvedValue({
-      data: [{ version_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' }],
+      data: [{ version_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' }],
       next_page_token: null,
     });
 
@@ -80,7 +80,7 @@ describe('useBibleReaderHighlights — real useHighlights/useApiData', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' });
+      expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' });
     });
 
     signedIn = false;
@@ -121,21 +121,21 @@ describe('useBibleReaderHighlights — write reconciliation (Fix 2/3/4)', () => 
       .mockResolvedValue(collection([]));
     const createHighlight = vi
       .spyOn(HighlightsClient.prototype, 'createHighlight')
-      .mockResolvedValue({ version_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' });
+      .mockResolvedValue({ version_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' });
 
     const { result } = mountFlipped();
     await waitFor(() => expect(getHighlights).toHaveBeenCalledTimes(1));
 
     act(() => {
-      result.current.apply('fffe00', [16]);
+      result.current.apply('ffec5b', [16]);
     });
-    expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' });
+    expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' });
 
     await waitFor(() => expect(createHighlight).toHaveBeenCalledTimes(1));
     // Exactly one coalesced refetch after the write.
     await waitFor(() => expect(getHighlights).toHaveBeenCalledTimes(2));
     // The GET is still empty, but the overlay wins — the highlight stays painted.
-    expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' });
+    expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' });
   });
 
   it('apply: once a GET reflects the write, the overlay retires and server truth renders', async () => {
@@ -143,43 +143,43 @@ describe('useBibleReaderHighlights — write reconciliation (Fix 2/3/4)', () => 
       .spyOn(HighlightsClient.prototype, 'getHighlights')
       .mockResolvedValueOnce(collection([]))
       .mockResolvedValue(
-        collection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' }]),
+        collection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' }]),
       );
     const createHighlight = vi
       .spyOn(HighlightsClient.prototype, 'createHighlight')
-      .mockResolvedValue({ version_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' });
+      .mockResolvedValue({ version_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' });
 
     const { result } = mountFlipped();
     await waitFor(() => expect(getHighlights).toHaveBeenCalledTimes(1));
 
     act(() => {
-      result.current.apply('fffe00', [16]);
+      result.current.apply('ffec5b', [16]);
     });
     await waitFor(() => expect(createHighlight).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(getHighlights).toHaveBeenCalledTimes(2));
 
     // The refetch reflects the write; the verse renders (now from server truth).
     await waitFor(() => {
-      expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' });
+      expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' });
     });
 
     // Distinguish retired-overlay from still-masking-overlay (both render
-    // fffe00 above): the server now reports verse 16 in a DIFFERENT color, and
+    // ffec5b above): the server now reports verse 16 in a DIFFERENT color, and
     // a write to another verse triggers the next fetch. If verse 16's entry
-    // were still pending, its overlay would keep masking with fffe00; retired,
+    // were still pending, its overlay would keep masking with ffec5b; retired,
     // the server's color must render.
     getHighlights.mockResolvedValue(
       collection([
-        { version_id: 111, passage_id: 'JHN.3.16', color: '00d6ff' },
-        { version_id: 111, passage_id: 'JHN.3.20', color: 'fffe00' },
+        { version_id: 111, passage_id: 'JHN.3.16', color: 'bbf4ff' },
+        { version_id: 111, passage_id: 'JHN.3.20', color: 'ffec5b' },
       ]),
     );
     act(() => {
-      result.current.apply('fffe00', [20]);
+      result.current.apply('ffec5b', [20]);
     });
     await waitFor(() => expect(getHighlights).toHaveBeenCalledTimes(3));
     await waitFor(() => {
-      expect(result.current.highlightedVerses).toEqual({ 16: '00d6ff', 20: 'fffe00' });
+      expect(result.current.highlightedVerses).toEqual({ 16: 'bbf4ff', 20: 'ffec5b' });
     });
   });
 
@@ -191,8 +191,8 @@ describe('useBibleReaderHighlights — write reconciliation (Fix 2/3/4)', () => 
       .mockResolvedValueOnce(collection([]))
       .mockResolvedValue(
         collection([
-          { version_id: 111, passage_id: 'JHN.3.2', color: 'fffe00' },
-          { version_id: 111, passage_id: 'JHN.3.3', color: 'fffe00' },
+          { version_id: 111, passage_id: 'JHN.3.2', color: 'ffec5b' },
+          { version_id: 111, passage_id: 'JHN.3.3', color: 'ffec5b' },
         ]),
       );
     const createHighlight = vi
@@ -206,10 +206,10 @@ describe('useBibleReaderHighlights — write reconciliation (Fix 2/3/4)', () => 
     await waitFor(() => expect(getHighlights).toHaveBeenCalledTimes(1));
 
     act(() => {
-      result.current.apply('fffe00', [2, 3, 5]);
+      result.current.apply('ffec5b', [2, 3, 5]);
     });
     // Optimistic: all three painted.
-    expect(result.current.highlightedVerses).toEqual({ 2: 'fffe00', 3: 'fffe00', 5: 'fffe00' });
+    expect(result.current.highlightedVerses).toEqual({ 2: 'ffec5b', 3: 'ffec5b', 5: 'ffec5b' });
 
     await waitFor(() => expect(createHighlight).toHaveBeenCalledTimes(2));
     // The refetch still fires despite the failure — exactly one for the batch.
@@ -219,7 +219,7 @@ describe('useBibleReaderHighlights — write reconciliation (Fix 2/3/4)', () => 
     // run [5] reverted. Before this fix the WHOLE batch reverted with no
     // refetch, erasing the persisted 2-3 until the next navigation/write.
     await waitFor(() => {
-      expect(result.current.highlightedVerses).toEqual({ 2: 'fffe00', 3: 'fffe00' });
+      expect(result.current.highlightedVerses).toEqual({ 2: 'ffec5b', 3: 'ffec5b' });
     });
     await act(async () => {
       await Promise.resolve();
@@ -233,9 +233,9 @@ describe('useBibleReaderHighlights — write reconciliation (Fix 2/3/4)', () => 
     // that still contains all three (read-after-write lag on the deletes).
     const getHighlights = vi.spyOn(HighlightsClient.prototype, 'getHighlights').mockResolvedValue(
       collection([
-        { version_id: 111, passage_id: 'JHN.3.2', color: '5dff79' },
-        { version_id: 111, passage_id: 'JHN.3.3', color: '5dff79' },
-        { version_id: 111, passage_id: 'JHN.3.4', color: '5dff79' },
+        { version_id: 111, passage_id: 'JHN.3.2', color: 'b4ffc1' },
+        { version_id: 111, passage_id: 'JHN.3.3', color: 'b4ffc1' },
+        { version_id: 111, passage_id: 'JHN.3.4', color: 'b4ffc1' },
       ]),
     );
     const deleteHighlight = vi
@@ -248,14 +248,14 @@ describe('useBibleReaderHighlights — write reconciliation (Fix 2/3/4)', () => 
     const { result } = mountFlipped();
     await waitFor(() =>
       expect(result.current.highlightedVerses).toEqual({
-        2: '5dff79',
-        3: '5dff79',
-        4: '5dff79',
+        2: 'b4ffc1',
+        3: 'b4ffc1',
+        4: 'b4ffc1',
       }),
     );
 
     act(() => {
-      result.current.remove('5dff79', [2, 3, 4]);
+      result.current.remove('b4ffc1', [2, 3, 4]);
     });
     expect(result.current.highlightedVerses).toEqual({});
 
@@ -267,7 +267,7 @@ describe('useBibleReaderHighlights — write reconciliation (Fix 2/3/4)', () => 
     // against the stale snapshot (no ghosts). Verse 3's DELETE failed: it
     // reverts and renders highlighted again from the fetched data.
     await waitFor(() => {
-      expect(result.current.highlightedVerses).toEqual({ 3: '5dff79' });
+      expect(result.current.highlightedVerses).toEqual({ 3: 'b4ffc1' });
     });
     await act(async () => {
       await Promise.resolve();
@@ -288,9 +288,9 @@ describe('useBibleReaderHighlights — write reconciliation (Fix 2/3/4)', () => 
     await waitFor(() => expect(getHighlights).toHaveBeenCalledTimes(1));
 
     act(() => {
-      result.current.apply('fffe00', [16, 17]);
+      result.current.apply('ffec5b', [16, 17]);
     });
-    expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00', 17: 'fffe00' });
+    expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b', 17: 'ffec5b' });
 
     await waitFor(() => {
       expect(result.current.highlightedVerses).toEqual({});
@@ -308,17 +308,17 @@ describe('useBibleReaderHighlights — write reconciliation (Fix 2/3/4)', () => 
     const getHighlights = vi
       .spyOn(HighlightsClient.prototype, 'getHighlights')
       .mockResolvedValue(
-        collection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' }]),
+        collection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' }]),
       );
     const deleteHighlight = vi
       .spyOn(HighlightsClient.prototype, 'deleteHighlight')
       .mockResolvedValue(undefined);
 
     const { result } = mountFlipped();
-    await waitFor(() => expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' }));
+    await waitFor(() => expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' }));
 
     act(() => {
-      result.current.remove('fffe00', [16]);
+      result.current.remove('ffec5b', [16]);
     });
     expect(result.current.highlightedVerses).toEqual({});
 
@@ -344,9 +344,9 @@ describe('useBibleReaderHighlights — write reconciliation (Fix 2/3/4)', () => 
     });
 
     act(() => {
-      result.current.apply('fffe00', [16]);
+      result.current.apply('ffec5b', [16]);
     });
-    expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' });
+    expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' });
 
     await waitFor(() => {
       expect(result.current.highlightedVerses).toEqual({});
@@ -359,25 +359,25 @@ describe('useBibleReaderHighlights — write reconciliation (Fix 2/3/4)', () => 
       .mockResolvedValue(collection([]));
     const createHighlight = vi
       .spyOn(HighlightsClient.prototype, 'createHighlight')
-      .mockResolvedValue({ version_id: 111, passage_id: 'JHN.3.2', color: 'fffe00' });
+      .mockResolvedValue({ version_id: 111, passage_id: 'JHN.3.2', color: 'ffec5b' });
 
     const { result } = mountFlipped();
     await waitFor(() => expect(getHighlights).toHaveBeenCalledTimes(1));
 
     act(() => {
-      result.current.apply('fffe00', [2, 3, 5]);
+      result.current.apply('ffec5b', [2, 3, 5]);
     });
 
     await waitFor(() => expect(createHighlight).toHaveBeenCalledTimes(2));
     expect(createHighlight).toHaveBeenCalledWith({
       version_id: 111,
       passage_id: 'JHN.3.2-3',
-      color: 'fffe00',
+      color: 'ffec5b',
     });
     expect(createHighlight).toHaveBeenCalledWith({
       version_id: 111,
       passage_id: 'JHN.3.5',
-      color: 'fffe00',
+      color: 'ffec5b',
     });
 
     // One refetch for the whole batch → 2 GETs total (mount + 1).
@@ -391,8 +391,8 @@ describe('useBibleReaderHighlights — write reconciliation (Fix 2/3/4)', () => 
   it('remove of a contiguous [2,3] issues per-verse DELETEs and one refetch (Fix 4 + 3)', async () => {
     const getHighlights = vi.spyOn(HighlightsClient.prototype, 'getHighlights').mockResolvedValue(
       collection([
-        { version_id: 111, passage_id: 'JHN.3.2', color: 'fffe00' },
-        { version_id: 111, passage_id: 'JHN.3.3', color: 'fffe00' },
+        { version_id: 111, passage_id: 'JHN.3.2', color: 'ffec5b' },
+        { version_id: 111, passage_id: 'JHN.3.3', color: 'ffec5b' },
       ]),
     );
     const deleteHighlight = vi
@@ -401,11 +401,11 @@ describe('useBibleReaderHighlights — write reconciliation (Fix 2/3/4)', () => 
 
     const { result } = mountFlipped();
     await waitFor(() =>
-      expect(result.current.highlightedVerses).toEqual({ 2: 'fffe00', 3: 'fffe00' }),
+      expect(result.current.highlightedVerses).toEqual({ 2: 'ffec5b', 3: 'ffec5b' }),
     );
 
     act(() => {
-      result.current.remove('fffe00', [2, 3]);
+      result.current.remove('ffec5b', [2, 3]);
     });
 
     await waitFor(() => expect(deleteHighlight).toHaveBeenCalledTimes(2));

--- a/packages/ui/src/components/use-bible-reader-highlights.strictmode-vapor.test.tsx
+++ b/packages/ui/src/components/use-bible-reader-highlights.strictmode-vapor.test.tsx
@@ -64,7 +64,7 @@ function Harness({
   // as BibleReader.handleClearHighlight → closeAndClearSelection does.
   useEffect(() => {
     removeRef.current = () => {
-      api.remove('fffe00', selected);
+      api.remove('ffec5b', selected);
       setSelected([]);
     };
   });
@@ -79,7 +79,7 @@ describe('vapor flash — StrictMode + server-truth remove + selection-clear + h
     // POST-remove refetch is the one we hold. Phase-gate the mock so every
     // mount fetch resolves server truth (verse 2) and the settle refetch stays
     // unresolved to widen the settle→response window the live repaint lives in.
-    const withRow = () => collection([{ version_id: 111, passage_id: 'JHN.1.2', color: 'fffe00' }]);
+    const withRow = () => collection([{ version_id: 111, passage_id: 'JHN.1.2', color: 'ffec5b' }]);
     // The post-remove refetch is held unresolved to widen the settle→response
     // window the live repaint lives in; it never settles.
     const heldRefetch = new Promise<Collection<Highlight>>(vi.fn());
@@ -106,7 +106,7 @@ describe('vapor flash — StrictMode + server-truth remove + selection-clear + h
     // Wait for server truth to render verse 2 highlighted.
     await waitFor(
       () => {
-        expect(frames.at(-1)).toEqual({ 2: 'fffe00' });
+        expect(frames.at(-1)).toEqual({ 2: 'ffec5b' });
       },
       { timeout: 5000 },
     );
@@ -135,7 +135,7 @@ describe('vapor flash — StrictMode + server-truth remove + selection-clear + h
     });
 
     const window = frames.slice(startFrame);
-    const resurrected = window.filter((f) => f[2] === 'fffe00');
+    const resurrected = window.filter((f) => f[2] === 'ffec5b');
     expect(
       resurrected,
       `verse 2 resurrected in ${resurrected.length}/${window.length} frame(s): ` +

--- a/packages/ui/src/components/use-bible-reader-highlights.test.tsx
+++ b/packages/ui/src/components/use-bible-reader-highlights.test.tsx
@@ -25,7 +25,7 @@ function defaultHighlightsResult(): UseHighlightsResult {
     createHighlight: vi.fn().mockResolvedValue({
       version_id: 111,
       passage_id: 'JHN.3.16',
-      color: 'fffe00',
+      color: 'ffec5b',
     }),
     deleteHighlight: vi.fn().mockResolvedValue(undefined),
   };
@@ -95,7 +95,7 @@ describe('useBibleReaderHighlights — flag off (dark launch)', () => {
   it('is fully inert: fetch disabled, empty map, writes are no-ops', () => {
     setHighlightsLive(false);
     const mocked = mockUseHighlights({
-      highlights: makeCollection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' }]),
+      highlights: makeCollection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' }]),
     });
 
     const { result } = renderHook(() => useBibleReaderHighlights(defaultOptions), {
@@ -111,8 +111,8 @@ describe('useBibleReaderHighlights — flag off (dark launch)', () => {
     expect(result.current.highlightedVerses).toEqual({});
 
     act(() => {
-      result.current.apply('fffe00', [16, 17]);
-      result.current.remove('fffe00', [16]);
+      result.current.apply('ffec5b', [16, 17]);
+      result.current.remove('ffec5b', [16]);
     });
     expect(mocked.createHighlight).not.toHaveBeenCalled();
     expect(mocked.deleteHighlight).not.toHaveBeenCalled();
@@ -136,7 +136,7 @@ describe('useBibleReaderHighlights — auth guarding', () => {
     expect(result.current.highlightedVerses).toEqual({});
 
     act(() => {
-      result.current.apply('fffe00', [16]);
+      result.current.apply('ffec5b', [16]);
     });
     expect(mocked.createHighlight).not.toHaveBeenCalled();
   });
@@ -167,13 +167,13 @@ describe('useBibleReaderHighlights — auth guarding', () => {
 
   it('clears rendered highlights immediately when the user signs out', () => {
     mockUseHighlights({
-      highlights: makeCollection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' }]),
+      highlights: makeCollection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' }]),
     });
 
     const { result, rerender } = renderHook(() => useBibleReaderHighlights(defaultOptions), {
       wrapper: AuthWrapper,
     });
-    expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' });
+    expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' });
 
     // Sign out: the mock still returns fetched data (like a not-yet-cleared
     // cache would), so this pins the hook's own render gate.
@@ -187,10 +187,10 @@ describe('useBibleReaderHighlights — fetched highlights', () => {
   it('maps per-verse USFMs for the current chapter into the verse map', () => {
     mockUseHighlights({
       highlights: makeCollection([
-        { version_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' },
-        { version_id: 111, passage_id: 'JHN.3.17', color: '5DFF79' }, // uppercase from server
-        { version_id: 111, passage_id: 'JHN.4.1', color: '00d6ff' }, // other chapter
-        { version_id: 999, passage_id: 'JHN.3.2', color: '00d6ff' }, // other version
+        { version_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' },
+        { version_id: 111, passage_id: 'JHN.3.17', color: 'B4FFC1' }, // uppercase from server
+        { version_id: 111, passage_id: 'JHN.4.1', color: 'bbf4ff' }, // other chapter
+        { version_id: 999, passage_id: 'JHN.3.2', color: 'bbf4ff' }, // other version
       ]),
     });
 
@@ -203,15 +203,15 @@ describe('useBibleReaderHighlights — fetched highlights', () => {
       { enabled: true },
     );
     expect(result.current.highlightedVerses).toEqual({
-      16: 'fffe00',
-      17: '5dff79',
+      16: 'ffec5b',
+      17: 'b4ffc1',
     });
   });
 
   it('drops invalid hex from the fetched server path (parseServerColors)', () => {
     mockUseHighlights({
       highlights: makeCollection([
-        { version_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' },
+        { version_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' },
         { version_id: 111, passage_id: 'JHN.3.17', color: 'gggggg' },
         { version_id: 111, passage_id: 'JHN.3.18', color: 'aabbcc' },
       ]),
@@ -222,7 +222,7 @@ describe('useBibleReaderHighlights — fetched highlights', () => {
     });
 
     expect(result.current.highlightedVerses).toEqual({
-      16: 'fffe00',
+      16: 'ffec5b',
       18: 'aabbcc',
     });
   });
@@ -237,15 +237,15 @@ describe('useBibleReaderHighlights — apply', () => {
     });
 
     act(() => {
-      result.current.apply('FFFE00', [16, 17, 18, 20]);
+      result.current.apply('FFEC5B', [16, 17, 18, 20]);
     });
 
     // Optimistic: rendered before any network round-trip settles.
     expect(result.current.highlightedVerses).toEqual({
-      16: 'fffe00',
-      17: 'fffe00',
-      18: 'fffe00',
-      20: 'fffe00',
+      16: 'ffec5b',
+      17: 'ffec5b',
+      18: 'ffec5b',
+      20: 'ffec5b',
     });
 
     await waitFor(() => {
@@ -254,12 +254,12 @@ describe('useBibleReaderHighlights — apply', () => {
     expect(mocked.createHighlight).toHaveBeenCalledWith({
       version_id: 111,
       passage_id: 'JHN.3.16-18',
-      color: 'fffe00', // lowercased on the wire
+      color: 'ffec5b', // lowercased on the wire
     });
     expect(mocked.createHighlight).toHaveBeenCalledWith({
       version_id: 111,
       passage_id: 'JHN.3.20',
-      color: 'fffe00',
+      color: 'ffec5b',
     });
     // Two POSTs (two runs) but a SINGLE coalesced refetch for the batch (Fix 3).
     expect(mocked.refetch).toHaveBeenCalledTimes(1);
@@ -276,9 +276,9 @@ describe('useBibleReaderHighlights — apply', () => {
     });
 
     act(() => {
-      result.current.apply('fffe00', [16, 17]);
+      result.current.apply('ffec5b', [16, 17]);
     });
-    expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00', 17: 'fffe00' });
+    expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b', 17: 'ffec5b' });
 
     await waitFor(() => {
       expect(result.current.highlightedVerses).toEqual({});
@@ -305,6 +305,44 @@ describe('useBibleReaderHighlights — apply', () => {
     expect(result.current.highlightedVerses).toEqual({});
     expect(mocked.createHighlight).not.toHaveBeenCalled();
   });
+
+  it('rejects the old five apply hexes without writing', () => {
+    const mocked = mockUseHighlights();
+
+    const { result } = renderHook(() => useBibleReaderHighlights(defaultOptions), {
+      wrapper: AuthWrapper,
+    });
+
+    act(() => {
+      expect(result.current.apply('fffe00', [16])).toBe('noop');
+      expect(result.current.apply('5dff79', [16])).toBe('noop');
+      expect(result.current.apply('00d6ff', [16])).toBe('noop');
+      expect(result.current.apply('ffc66f', [16])).toBe('noop');
+      expect(result.current.apply('ff95ef', [16])).toBe('noop');
+    });
+
+    expect(result.current.highlightedVerses).toEqual({});
+    expect(mocked.createHighlight).not.toHaveBeenCalled();
+  });
+
+  it('paints and clears leftover fffe00 without remapping', async () => {
+    const mocked = mockUseHighlights({
+      highlights: makeCollection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' }]),
+    });
+
+    const { result } = renderHook(() => useBibleReaderHighlights(defaultOptions), {
+      wrapper: AuthWrapper,
+    });
+    expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' });
+
+    act(() => {
+      result.current.remove('fffe00', [16]);
+    });
+    expect(result.current.highlightedVerses).toEqual({});
+    await waitFor(() => {
+      expect(mocked.deleteHighlight).toHaveBeenCalledTimes(1);
+    });
+  });
 });
 
 describe('useBibleReaderHighlights — overlay reconciliation (Fix 2)', () => {
@@ -316,9 +354,9 @@ describe('useBibleReaderHighlights — overlay reconciliation (Fix 2)', () => {
     });
 
     act(() => {
-      result.current.apply('fffe00', [16]);
+      result.current.apply('ffec5b', [16]);
     });
-    expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' });
+    expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' });
 
     // Let the write settle successfully.
     await waitFor(() => {
@@ -332,15 +370,15 @@ describe('useBibleReaderHighlights — overlay reconciliation (Fix 2)', () => {
     // write lag). The overlay must WIN — no flicker out and back.
     mockUseHighlights({ highlights: makeCollection([]) });
     rerender();
-    expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' });
+    expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' });
 
     // A later GET reflects the write (verse present in the written color).
     mockUseHighlights({
-      highlights: makeCollection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' }]),
+      highlights: makeCollection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' }]),
     });
     rerender();
     await waitFor(() => {
-      expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' });
+      expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' });
     });
 
     // Prove the overlay entry was retired: with the entry gone, server truth now
@@ -360,7 +398,7 @@ describe('useBibleReaderHighlights — overlay reconciliation (Fix 2)', () => {
     });
 
     act(() => {
-      result.current.apply('fffe00', [16]);
+      result.current.apply('ffec5b', [16]);
     });
     await waitFor(() => {
       expect(mocked.createHighlight).toHaveBeenCalledTimes(1);
@@ -372,13 +410,13 @@ describe('useBibleReaderHighlights — overlay reconciliation (Fix 2)', () => {
     // A GET returns the verse in a color that is NOT what we wrote. That doesn't
     // reflect our write, so the overlay is held rather than snapping to it.
     mockUseHighlights({
-      highlights: makeCollection([{ version_id: 111, passage_id: 'JHN.3.16', color: '00d6ff' }]),
+      highlights: makeCollection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'bbf4ff' }]),
     });
     rerender();
     await act(async () => {
       await Promise.resolve();
     });
-    expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' });
+    expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' });
   });
 });
 
@@ -390,16 +428,16 @@ describe('useBibleReaderHighlights — vapor bug (removed highlight resurrection
   // had nothing suppressing it, so the verse repainted until the next fetch.
   it('a stale fetch after a settled+reflected DELETE does not resurrect the removed highlight', async () => {
     const mocked = mockUseHighlights({
-      highlights: makeCollection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' }]),
+      highlights: makeCollection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' }]),
     });
 
     const { result, rerender } = renderHook(() => useBibleReaderHighlights(defaultOptions), {
       wrapper: AuthWrapper,
     });
-    expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' });
+    expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' });
 
     act(() => {
-      result.current.remove('fffe00', [16]);
+      result.current.remove('ffec5b', [16]);
     });
     // Optimistic removal.
     expect(result.current.highlightedVerses).toEqual({});
@@ -419,7 +457,7 @@ describe('useBibleReaderHighlights — vapor bug (removed highlight resurrection
     // Fetch B is a STALE read replica that still contains the removed highlight.
     // The removal overlay must be HELD so the highlight does not resurrect.
     mockUseHighlights({
-      highlights: makeCollection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' }]),
+      highlights: makeCollection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' }]),
     });
     rerender();
     expect(result.current.highlightedVerses).toEqual({});
@@ -435,9 +473,9 @@ describe('useBibleReaderHighlights — remove', () => {
   it('removes optimistically and DELETEs one passage-id per verse (never a range)', async () => {
     const mocked = mockUseHighlights({
       highlights: makeCollection([
-        { version_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' },
-        { version_id: 111, passage_id: 'JHN.3.17', color: 'fffe00' },
-        { version_id: 111, passage_id: 'JHN.3.18', color: '5dff79' }, // different color, stays
+        { version_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' },
+        { version_id: 111, passage_id: 'JHN.3.17', color: 'ffec5b' },
+        { version_id: 111, passage_id: 'JHN.3.18', color: 'b4ffc1' }, // different color, stays
       ]),
     });
 
@@ -446,11 +484,11 @@ describe('useBibleReaderHighlights — remove', () => {
     });
 
     act(() => {
-      result.current.remove('fffe00', [16, 17, 18]);
+      result.current.remove('ffec5b', [16, 17, 18]);
     });
 
     // Optimistic: yellow verses gone immediately, green untouched.
-    expect(result.current.highlightedVerses).toEqual({ 18: '5dff79' });
+    expect(result.current.highlightedVerses).toEqual({ 18: 'b4ffc1' });
 
     // Contiguous [16,17] must NOT collapse to `JHN.3.16-17` — range delete is
     // unsupported server-side (Fix 4). One DELETE per verse instead.
@@ -466,7 +504,7 @@ describe('useBibleReaderHighlights — remove', () => {
   it('reverts the optimistic removal and logs when the delete fails', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(vi.fn());
     mockUseHighlights({
-      highlights: makeCollection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' }]),
+      highlights: makeCollection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' }]),
       deleteHighlight: vi.fn().mockRejectedValue(new Error('network down')),
     });
 
@@ -475,12 +513,12 @@ describe('useBibleReaderHighlights — remove', () => {
     });
 
     act(() => {
-      result.current.remove('fffe00', [16]);
+      result.current.remove('ffec5b', [16]);
     });
     expect(result.current.highlightedVerses).toEqual({});
 
     await waitFor(() => {
-      expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' });
+      expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' });
     });
     expect(consoleError).toHaveBeenCalledWith(
       expect.stringContaining('Failed to remove highlight'),
@@ -491,7 +529,7 @@ describe('useBibleReaderHighlights — remove', () => {
 
   it('is a no-op when no selected verse is rendered in the given color', () => {
     const mocked = mockUseHighlights({
-      highlights: makeCollection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' }]),
+      highlights: makeCollection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' }]),
     });
 
     const { result } = renderHook(() => useBibleReaderHighlights(defaultOptions), {
@@ -499,10 +537,10 @@ describe('useBibleReaderHighlights — remove', () => {
     });
 
     act(() => {
-      result.current.remove('5dff79', [16]);
+      result.current.remove('b4ffc1', [16]);
     });
     expect(mocked.deleteHighlight).not.toHaveBeenCalled();
-    expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' });
+    expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' });
   });
 
   it('clears valid non-palette highlights on the selected verses', async () => {
@@ -510,7 +548,7 @@ describe('useBibleReaderHighlights — remove', () => {
     const mocked = mockUseHighlights({
       highlights: makeCollection([
         { version_id: 111, passage_id: 'JHN.3.16', color: custom },
-        { version_id: 111, passage_id: 'JHN.3.17', color: 'fffe00' },
+        { version_id: 111, passage_id: 'JHN.3.17', color: 'ffec5b' },
       ]),
     });
 
@@ -518,13 +556,13 @@ describe('useBibleReaderHighlights — remove', () => {
       wrapper: AuthWrapper,
     });
 
-    expect(result.current.highlightedVerses).toEqual({ 16: custom, 17: 'fffe00' });
+    expect(result.current.highlightedVerses).toEqual({ 16: custom, 17: 'ffec5b' });
 
     act(() => {
       result.current.remove(custom, [16, 17]);
     });
 
-    expect(result.current.highlightedVerses).toEqual({ 17: 'fffe00' });
+    expect(result.current.highlightedVerses).toEqual({ 17: 'ffec5b' });
 
     await waitFor(() => {
       expect(mocked.deleteHighlight).toHaveBeenCalledTimes(1);
@@ -547,9 +585,9 @@ describe('useBibleReaderHighlights — scope changes', () => {
     );
 
     act(() => {
-      result.current.apply('fffe00', [16]);
+      result.current.apply('ffec5b', [16]);
     });
-    expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' });
+    expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' });
 
     rerender({ versionId: 111, book: 'JHN', chapter: '4' });
     expect(result.current.highlightedVerses).toEqual({});
@@ -573,9 +611,9 @@ describe('useBibleReaderHighlights — scope changes', () => {
 
     // Highlight JHN.3.16 — write is in flight (deferred, has not settled).
     act(() => {
-      result.current.apply('fffe00', [16]);
+      result.current.apply('ffec5b', [16]);
     });
-    expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' });
+    expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' });
 
     // Navigate to JHN.4: the overlay resets. Give this chapter its own
     // never-settling write so its optimistic entry survives on its own terms.
@@ -587,18 +625,18 @@ describe('useBibleReaderHighlights — scope changes', () => {
 
     // Highlight JHN.4.16 — same verse number, different chapter.
     act(() => {
-      result.current.apply('fffe00', [16]);
+      result.current.apply('ffec5b', [16]);
     });
-    expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' });
+    expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' });
 
     // Chapter 3's stale write finally settles. It must NOT enroll verse 16 in
     // the confirmed set, because we have since left its scope.
     await act(async () => {
-      resolvePrevWrite({ version_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' });
+      resolvePrevWrite({ version_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' });
       await Promise.resolve();
       await Promise.resolve();
     });
-    expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' });
+    expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' });
 
     // A refetch lands for JHN.4 (new `highlights` identity fires the drain
     // effect). A leaked cross-scope confirmation would erase JHN.4.16 here.
@@ -608,7 +646,7 @@ describe('useBibleReaderHighlights — scope changes', () => {
     });
     rerender({ versionId: 111, book: 'JHN', chapter: '4' });
 
-    expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' });
+    expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' });
   });
 
   it("does not revert the new scope's optimistic overlay when a previous scope's write fails", async () => {
@@ -631,9 +669,9 @@ describe('useBibleReaderHighlights — scope changes', () => {
 
     // Highlight JHN.3.16 — write is in flight (deferred, will fail later).
     act(() => {
-      result.current.apply('fffe00', [16]);
+      result.current.apply('ffec5b', [16]);
     });
-    expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' });
+    expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' });
 
     // Navigate to JHN.4: the overlay resets. This chapter gets its own
     // never-settling write so its optimistic entry survives on its own terms.
@@ -645,9 +683,9 @@ describe('useBibleReaderHighlights — scope changes', () => {
 
     // Highlight JHN.4.16 — same verse number, different chapter.
     act(() => {
-      result.current.apply('fffe00', [16]);
+      result.current.apply('ffec5b', [16]);
     });
-    expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' });
+    expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' });
 
     // Chapter 3's stale write finally fails. Its snapshot ({}) lacks verse 16,
     // so an ungated revert would `delete` JHN.4.16's optimistic entry. The
@@ -658,7 +696,7 @@ describe('useBibleReaderHighlights — scope changes', () => {
       await Promise.resolve();
     });
 
-    expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' });
+    expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' });
     // The failure is still logged unconditionally.
     expect(consoleError).toHaveBeenCalledWith(
       expect.stringContaining('Failed to apply highlight'),
@@ -672,7 +710,7 @@ describe('useBibleReaderHighlights — controlled mode (YPE-3705)', () => {
   it('keeps the fetch disabled and projects from the host prop, even with the flag off', () => {
     setHighlightsLive(false);
     const mocked = mockUseHighlights({
-      highlights: makeCollection([{ version_id: 111, passage_id: 'JHN.3.16', color: '00d6ff' }]),
+      highlights: makeCollection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'bbf4ff' }]),
     });
 
     const { result } = renderHook(
@@ -681,8 +719,8 @@ describe('useBibleReaderHighlights — controlled mode (YPE-3705)', () => {
           ...defaultOptions,
           controlled: {
             highlights: [
-              { version_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' },
-              { version_id: 111, passage_id: 'JHN.3.17-18', color: '5dff79' },
+              { version_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' },
+              { version_id: 111, passage_id: 'JHN.3.17-18', color: 'b4ffc1' },
               { version_id: 111, passage_id: 'JHN.3.1', color: 'abcdef' }, // outside palette
             ],
           },
@@ -697,9 +735,9 @@ describe('useBibleReaderHighlights — controlled mode (YPE-3705)', () => {
     expect(mocked.createHighlight).not.toHaveBeenCalled();
     expect(result.current.highlightedVerses).toEqual({
       1: 'abcdef',
-      16: 'fffe00',
-      17: '5dff79',
-      18: '5dff79',
+      16: 'ffec5b',
+      17: 'b4ffc1',
+      18: 'b4ffc1',
     });
   });
 
@@ -717,18 +755,18 @@ describe('useBibleReaderHighlights — controlled mode (YPE-3705)', () => {
       {
         wrapper: AuthWrapper,
         initialProps: {
-          highlights: [{ version_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' }],
+          highlights: [{ version_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' }],
         },
       },
     );
 
-    expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' });
+    expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' });
 
     act(() => {
-      result.current.apply('5dff79', [17, 18]);
+      result.current.apply('b4ffc1', [17, 18]);
     });
     // Pure projection: paint waits for the host round-trip.
-    expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' });
+    expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' });
     expect(onApply).toHaveBeenCalledTimes(1);
     expect(onApply).toHaveBeenCalledWith({
       versionId: 111,
@@ -736,12 +774,12 @@ describe('useBibleReaderHighlights — controlled mode (YPE-3705)', () => {
       chapter: '3',
       verses: [17, 18],
       passageIds: ['JHN.3.17', 'JHN.3.18'],
-      color: '5dff79',
+      color: 'b4ffc1',
     });
     expect(mocked.createHighlight).not.toHaveBeenCalled();
 
     act(() => {
-      result.current.remove('fffe00', [16, 17]);
+      result.current.remove('ffec5b', [16, 17]);
     });
     expect(onRemove).toHaveBeenCalledTimes(1);
     expect(onRemove).toHaveBeenCalledWith({
@@ -750,11 +788,11 @@ describe('useBibleReaderHighlights — controlled mode (YPE-3705)', () => {
       chapter: '3',
       verses: [16],
       passageIds: ['JHN.3.16'],
-      color: 'fffe00',
+      color: 'ffec5b',
     });
     expect(mocked.deleteHighlight).not.toHaveBeenCalled();
     // Still no optimistic un-paint.
-    expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' });
+    expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' });
 
     // Host round-trip.
     rerender({ highlights: [] });

--- a/packages/ui/src/components/use-bible-reader-highlights.vapor.test.tsx
+++ b/packages/ui/src/components/use-bible-reader-highlights.vapor.test.tsx
@@ -81,7 +81,7 @@ describe('vapor flash — removed verse must never reappear at any frame', () =>
       .spyOn(HighlightsClient.prototype, 'getHighlights')
       // mount GET
       .mockResolvedValueOnce(
-        collection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' }]),
+        collection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' }]),
       )
       // post-DELETE refetch: controlled, resolves STALE (still has the row)
       .mockReturnValueOnce(getDeferred.promise);
@@ -91,11 +91,11 @@ describe('vapor flash — removed verse must never reappear at any frame', () =>
 
     const renderLog: Record<number, string>[] = [];
     const { result } = mountFlipped(renderLog);
-    await waitFor(() => expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' }));
+    await waitFor(() => expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' }));
 
     // The point at which we START watching for a resurrection.
     act(() => {
-      result.current.remove('fffe00', [16]);
+      result.current.remove('ffec5b', [16]);
     });
     expect(result.current.highlightedVerses).toEqual({});
 
@@ -106,14 +106,14 @@ describe('vapor flash — removed verse must never reappear at any frame', () =>
     await waitFor(() => expect(getHighlights).toHaveBeenCalledTimes(2));
     await act(async () => {
       getDeferred.resolve(
-        collection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' }]),
+        collection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' }]),
       );
       await Promise.resolve();
     });
 
     // Inspect EVERY committed frame from the remove onward.
     const frames = renderLog.slice(startFrame);
-    const resurrected = frames.filter((f) => f[16] === 'fffe00');
+    const resurrected = frames.filter((f) => f[16] === 'ffec5b');
     expect(
       resurrected,
       `verse 16 reappeared in ${resurrected.length} frame(s): ${JSON.stringify(frames)}`,
@@ -125,7 +125,7 @@ describe('vapor flash — removed verse must never reappear at any frame', () =>
     const getDeferred = deferred<Collection<Highlight>>();
     vi.spyOn(HighlightsClient.prototype, 'getHighlights')
       .mockResolvedValueOnce(
-        collection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' }]),
+        collection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' }]),
       )
       .mockReturnValueOnce(getDeferred.promise);
     const deleteHighlight = vi
@@ -134,10 +134,10 @@ describe('vapor flash — removed verse must never reappear at any frame', () =>
 
     const renderLog: Record<number, string>[] = [];
     const { result } = mountFlipped(renderLog);
-    await waitFor(() => expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' }));
+    await waitFor(() => expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' }));
 
     act(() => {
-      result.current.remove('fffe00', [16]);
+      result.current.remove('ffec5b', [16]);
     });
     const startFrame = renderLog.length;
 
@@ -148,7 +148,7 @@ describe('vapor flash — removed verse must never reappear at any frame', () =>
     });
 
     const frames = renderLog.slice(startFrame);
-    const resurrected = frames.filter((f) => f[16] === 'fffe00');
+    const resurrected = frames.filter((f) => f[16] === 'ffec5b');
     expect(resurrected, `verse 16 reappeared: ${JSON.stringify(frames)}`).toEqual([]);
     expect(result.current.highlightedVerses).toEqual({});
   });
@@ -165,7 +165,7 @@ describe('vapor flash — removed verse must never reappear at any frame', () =>
     // (mountFlipped seeds the bearer token the real client reads from localStorage.)
 
     // Wire format uses `bible_id` (mapped to `version_id` by the client).
-    const wireRow = { bible_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' };
+    const wireRow = { bible_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' };
     let deletedOnServer = false;
     const jsonHeaders = { 'content-type': 'application/json' };
 
@@ -191,10 +191,10 @@ describe('vapor flash — removed verse must never reappear at any frame', () =>
 
     const renderLog: Record<number, string>[] = [];
     const { result } = mountFlipped(renderLog);
-    await waitFor(() => expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' }));
+    await waitFor(() => expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' }));
 
     act(() => {
-      result.current.remove('fffe00', [16]);
+      result.current.remove('ffec5b', [16]);
     });
     expect(result.current.highlightedVerses).toEqual({});
     const startFrame = renderLog.length;
@@ -205,7 +205,7 @@ describe('vapor flash — removed verse must never reappear at any frame', () =>
     });
 
     const frames = renderLog.slice(startFrame);
-    const resurrected = frames.filter((f) => f[16] === 'fffe00');
+    const resurrected = frames.filter((f) => f[16] === 'ffec5b');
     expect(
       resurrected,
       `verse 16 resurrected in ${resurrected.length} frame(s): ${JSON.stringify(frames)}`,
@@ -223,30 +223,30 @@ describe('vapor flash — removed verse must never reappear at any frame', () =>
       .spyOn(HighlightsClient.prototype, 'getHighlights')
       // mount
       .mockResolvedValueOnce(
-        collection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' }]),
+        collection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' }]),
       )
       // refetch #1: fresh, reflects the DELETE of 16
       .mockResolvedValueOnce(collection([]))
       // refetch #2: STALE replica — verse 16 is back (plus the just-applied 20)
       .mockResolvedValue(
         collection([
-          { version_id: 111, passage_id: 'JHN.3.16', color: 'fffe00' },
-          { version_id: 111, passage_id: 'JHN.3.20', color: '5dff79' },
+          { version_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' },
+          { version_id: 111, passage_id: 'JHN.3.20', color: 'b4ffc1' },
         ]),
       );
     vi.spyOn(HighlightsClient.prototype, 'deleteHighlight').mockResolvedValue(undefined);
     vi.spyOn(HighlightsClient.prototype, 'createHighlight').mockResolvedValue({
       version_id: 111,
       passage_id: 'JHN.3.20',
-      color: '5dff79',
+      color: 'b4ffc1',
     });
 
     const renderLog: Record<number, string>[] = [];
     const { result } = mountFlipped(renderLog);
-    await waitFor(() => expect(result.current.highlightedVerses).toEqual({ 16: 'fffe00' }));
+    await waitFor(() => expect(result.current.highlightedVerses).toEqual({ 16: 'ffec5b' }));
 
     act(() => {
-      result.current.remove('fffe00', [16]);
+      result.current.remove('ffec5b', [16]);
     });
     expect(result.current.highlightedVerses).toEqual({});
     const startFrame = renderLog.length;
@@ -259,7 +259,7 @@ describe('vapor flash — removed verse must never reappear at any frame', () =>
 
     // A later apply on verse 20 fires refetch #2, which returns the stale replica.
     act(() => {
-      result.current.apply('5dff79', [20]);
+      result.current.apply('b4ffc1', [20]);
     });
     await waitFor(() => expect(getHighlights).toHaveBeenCalledTimes(3));
     await act(async () => {
@@ -267,7 +267,7 @@ describe('vapor flash — removed verse must never reappear at any frame', () =>
     });
 
     const frames = renderLog.slice(startFrame);
-    const resurrected = frames.filter((f) => f[16] === 'fffe00');
+    const resurrected = frames.filter((f) => f[16] === 'ffec5b');
     expect(
       resurrected,
       `verse 16 resurrected in ${resurrected.length} frame(s): ${JSON.stringify(frames)}`,

--- a/packages/ui/src/components/verse-action-popover.test.tsx
+++ b/packages/ui/src/components/verse-action-popover.test.tsx
@@ -1,18 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { fillFor } from '@/test/highlights-test-utils';
 import {
   VerseActionPopover,
   HIGHLIGHT_COLORS,
   computeScrollFade,
   type HighlightColor,
 } from './verse-action-popover';
-
-function fillFor(hex: string): string {
-  const r = parseInt(hex.slice(0, 2), 16);
-  const g = parseInt(hex.slice(2, 4), 16);
-  const b = parseInt(hex.slice(4, 6), 16);
-  return `rgb(${r}, ${g}, ${b})`;
-}
 
 describe('VerseActionPopover', () => {
   const defaultProps = {
@@ -52,9 +46,8 @@ describe('VerseActionPopover', () => {
 
       expect(applyButtons).toHaveLength(6);
       applyButtons.forEach((btn) => {
-        const bgColor = btn.style.backgroundColor;
-        // Swatches render via theme tokens (var(--yv-*-30-dm)), with a hex fallback.
-        expect(bgColor).toMatch(/^(#[a-fA-F0-9]{6}|rgb\(.*\)|var\(--.*\))$/);
+        expect(btn.style.backgroundColor).toContain('color-mix');
+        expect(btn.style.backgroundColor).toContain('var(--yv-card)');
       });
     });
   });
@@ -432,7 +425,7 @@ describe('VerseActionPopover', () => {
 
       const removeButtons = clearButtons();
       expect(removeButtons).toHaveLength(1);
-      expect(removeButtons[0]!.style.backgroundColor).toBe(fillFor(custom));
+      expect(removeButtons[0]!.style.backgroundColor).toBe(fillFor(custom, 'card'));
     });
 
     it('shows leftover fffe00 as a remove swatch, not an apply swatch', () => {
@@ -446,9 +439,9 @@ describe('VerseActionPopover', () => {
       );
 
       expect(clearButtons()).toHaveLength(1);
-      expect(clearButtons()[0]!.style.backgroundColor).toBe('rgb(255, 254, 0)');
+      expect(clearButtons()[0]!.style.backgroundColor).toBe(fillFor('fffe00', 'card'));
       expect(applyButtons().map((btn) => btn.style.backgroundColor)).not.toContain(
-        'rgb(255, 254, 0)',
+        fillFor('fffe00', 'card'),
       );
       expect(applyButtons()).toHaveLength(6);
     });
@@ -584,12 +577,13 @@ describe('VerseActionPopover', () => {
 
     it('paints drawer dots with the unmixed stored hex in light mode', () => {
       render(<VerseActionPopover {...defaultProps} theme="light" />);
-      expect(firstApplySwatch().style.backgroundColor).toBe('rgb(255, 236, 91)');
+      expect(firstApplySwatch().style.backgroundColor).toBe(fillFor(HIGHLIGHT_COLORS[0], 'card'));
     });
 
     it('paints drawer dots with the dark mix against the card surface', () => {
       render(<VerseActionPopover {...defaultProps} theme="dark" />);
-      expect(firstApplySwatch().style.backgroundColor).toBe('rgb(79, 74, 45)');
+      expect(firstApplySwatch().style.backgroundColor).toBe(fillFor(HIGHLIGHT_COLORS[0], 'card'));
+      expect(firstApplySwatch().style.backgroundColor).toContain('var(--yv-card)');
     });
 
     it('uses a dark inner stroke in light mode and a light one in dark mode', () => {

--- a/packages/ui/src/components/verse-action-popover.test.tsx
+++ b/packages/ui/src/components/verse-action-popover.test.tsx
@@ -33,24 +33,24 @@ describe('VerseActionPopover', () => {
   });
 
   describe('AC1: Basic popover display', () => {
-    it('should display 5 color circles when verse selected', () => {
+    it('should display 6 color circles when verse selected', () => {
       render(<VerseActionPopover {...defaultProps} />);
 
       const colorButtons = screen
         .getAllByRole('button')
         .filter((btn) => btn.getAttribute('aria-label')?.includes('Apply'));
 
-      expect(colorButtons).toHaveLength(5);
+      expect(colorButtons).toHaveLength(6);
     });
 
-    it('should render colors in correct order (yellow, green, blue, orange, pink)', () => {
+    it('should render the six apply colors', () => {
       render(<VerseActionPopover {...defaultProps} />);
 
       const applyButtons = screen
         .getAllByRole('button')
         .filter((btn) => btn.getAttribute('aria-label')?.includes('Apply'));
 
-      expect(applyButtons).toHaveLength(5);
+      expect(applyButtons).toHaveLength(6);
       applyButtons.forEach((btn) => {
         const bgColor = btn.style.backgroundColor;
         // Swatches render via theme tokens (var(--yv-*-30-dm)), with a hex fallback.
@@ -142,7 +142,7 @@ describe('VerseActionPopover', () => {
   });
 
   describe('AC5: Single highlighted verse', () => {
-    it('should show 5 circles: 1 remove + 4 apply (only inactive colors)', () => {
+    it('should show 6 circles: 1 remove + 5 apply (only inactive colors)', () => {
       const activeHighlights = new Set<HighlightColor>([HIGHLIGHT_COLORS[0]]);
       const selectedVerses = [1];
       const highlightedVerses = { 1: HIGHLIGHT_COLORS[0] };
@@ -165,7 +165,7 @@ describe('VerseActionPopover', () => {
         .filter((btn) => btn.getAttribute('aria-label')?.includes('Apply'));
 
       expect(removeButtons).toHaveLength(1);
-      expect(applyButtons).toHaveLength(4);
+      expect(applyButtons).toHaveLength(5);
     });
   });
 
@@ -197,7 +197,7 @@ describe('VerseActionPopover', () => {
   });
 
   describe('AC6: Mixed selection (highlighted + unhighlighted)', () => {
-    it('should show all 5 apply colors when there are unhighlighted verses', () => {
+    it('should show all 6 apply colors when there are unhighlighted verses', () => {
       const activeHighlights = new Set<HighlightColor>([HIGHLIGHT_COLORS[0]]);
       const selectedVerses = [1, 2];
       const highlightedVerses = { 1: HIGHLIGHT_COLORS[0] }; // verse 2 is unhighlighted
@@ -219,14 +219,14 @@ describe('VerseActionPopover', () => {
         .getAllByRole('button')
         .filter((btn) => btn.getAttribute('aria-label')?.includes('Apply'));
 
-      // 1 yellow remove + all 5 apply (because verse 2 is unhighlighted)
+      // 1 yellow remove + all 6 apply (because verse 2 is unhighlighted)
       expect(removeButtons).toHaveLength(1);
-      expect(applyButtons).toHaveLength(5);
+      expect(applyButtons).toHaveLength(6);
     });
   });
 
   describe('AC7: Multiple different highlights', () => {
-    it('should show all 5 apply colors when multiple colors are active', () => {
+    it('should show all 6 apply colors when multiple colors are active', () => {
       const activeHighlights = new Set<HighlightColor>([HIGHLIGHT_COLORS[0], HIGHLIGHT_COLORS[1]]);
       const selectedVerses = [1, 2];
       const highlightedVerses = { 1: HIGHLIGHT_COLORS[0], 2: HIGHLIGHT_COLORS[1] };
@@ -248,9 +248,9 @@ describe('VerseActionPopover', () => {
         .getAllByRole('button')
         .filter((btn) => btn.getAttribute('aria-label')?.includes('Apply'));
 
-      // 2 remove (X) + all 5 apply (because multiple colors)
+      // 2 remove + all 6 apply (because multiple colors)
       expect(removeButtons).toHaveLength(2);
-      expect(applyButtons).toHaveLength(5);
+      expect(applyButtons).toHaveLength(6);
     });
 
     it('should call onClearHighlight with color when clear swatch clicked', () => {
@@ -435,6 +435,24 @@ describe('VerseActionPopover', () => {
       expect(removeButtons[0]!.style.backgroundColor).toBe(fillFor(custom));
     });
 
+    it('shows leftover fffe00 as a remove swatch, not an apply swatch', () => {
+      render(
+        <VerseActionPopover
+          {...defaultProps}
+          activeHighlights={new Set(['fffe00'])}
+          selectedVerses={[1]}
+          highlightedVerses={{ 1: 'fffe00' }}
+        />,
+      );
+
+      expect(clearButtons()).toHaveLength(1);
+      expect(clearButtons()[0]!.style.backgroundColor).toBe('rgb(255, 254, 0)');
+      expect(applyButtons().map((btn) => btn.style.backgroundColor)).not.toContain(
+        'rgb(255, 254, 0)',
+      );
+      expect(applyButtons()).toHaveLength(6);
+    });
+
     it('should handle empty active highlights', () => {
       const activeHighlights = new Set<HighlightColor>();
 
@@ -444,19 +462,20 @@ describe('VerseActionPopover', () => {
         .getAllByRole('button')
         .filter((btn) => btn.getAttribute('aria-label')?.includes('Apply'));
 
-      // Should still show 5 apply colors
-      expect(applyButtons).toHaveLength(5);
+      // Should still show 6 apply colors
+      expect(applyButtons).toHaveLength(6);
     });
 
-    it('should handle all 5 colors highlighted', () => {
+    it('should handle all 6 colors highlighted', () => {
       const activeHighlights = new Set<HighlightColor>(HIGHLIGHT_COLORS);
-      const selectedVerses = [1, 2, 3, 4, 5];
+      const selectedVerses = [1, 2, 3, 4, 5, 6];
       const highlightedVerses = {
         1: HIGHLIGHT_COLORS[0],
         2: HIGHLIGHT_COLORS[1],
         3: HIGHLIGHT_COLORS[2],
         4: HIGHLIGHT_COLORS[3],
         5: HIGHLIGHT_COLORS[4],
+        6: HIGHLIGHT_COLORS[5],
       };
 
       render(
@@ -476,8 +495,8 @@ describe('VerseActionPopover', () => {
         .getAllByRole('button')
         .filter((btn) => btn.getAttribute('aria-label')?.includes('Apply'));
 
-      // 5 remove (X) + 0 apply (all colors already active) = 5 total
-      expect(removeButtons).toHaveLength(5);
+      // 6 remove + 0 apply (all colors already active)
+      expect(removeButtons).toHaveLength(6);
       expect(applyButtons).toHaveLength(0);
     });
 
@@ -511,9 +530,9 @@ describe('VerseActionPopover', () => {
         .getAllByRole('button')
         .filter((btn) => btn.getAttribute('aria-label')?.includes('Apply'));
 
-      // 3 remove (X for Y, B, G) + all 5 apply (yellow, green, blue, orange, pink) = 8 total
+      // 3 remove + all 6 apply
       expect(removeButtons).toHaveLength(3);
-      expect(applyButtons).toHaveLength(5);
+      expect(applyButtons).toHaveLength(6);
     });
   });
 
@@ -558,24 +577,19 @@ describe('VerseActionPopover', () => {
   });
 
   describe('Swatch fill preview (theme-aware)', () => {
-    // The first apply swatch (no active highlights) is the first canonical color,
-    // yellow `fffe00` → rgb(255, 254, 0).
+    // First apply swatch is `ffec5b`. Light is identity; dark is the #121212 mix.
     function firstApplySwatch() {
       return applyButtons()[0]!;
     }
 
-    it('paints swatches at full opacity in light mode (matches the applied fill)', () => {
+    it('paints drawer dots with the unmixed stored hex in light mode', () => {
       render(<VerseActionPopover {...defaultProps} theme="light" />);
-      const bg = firstApplySwatch().style.backgroundColor;
-      // Full-strength: never the dimmed dark-mode alpha.
-      expect(bg).not.toContain('0.3');
-      expect(bg).toBeTruthy();
+      expect(firstApplySwatch().style.backgroundColor).toBe('rgb(255, 236, 91)');
     });
 
-    it('dims swatches to the dark-mode alpha (0.3) in dark mode', () => {
+    it('paints drawer dots with the same dark mix as reader fill', () => {
       render(<VerseActionPopover {...defaultProps} theme="dark" />);
-      // Same 0.3 alpha the applied highlight paints in dark mode (verse.tsx).
-      expect(firstApplySwatch().style.backgroundColor).toBe('rgba(255, 254, 0, 0.3)');
+      expect(firstApplySwatch().style.backgroundColor).toBe('rgb(65, 62, 33)');
     });
 
     it('uses a dark inner stroke in light mode and a light one in dark mode', () => {

--- a/packages/ui/src/components/verse-action-popover.test.tsx
+++ b/packages/ui/src/components/verse-action-popover.test.tsx
@@ -577,7 +577,7 @@ describe('VerseActionPopover', () => {
   });
 
   describe('Swatch fill preview (theme-aware)', () => {
-    // First apply swatch is `ffec5b`. Light is identity; dark is the #121212 mix.
+    // First apply swatch is `ffec5b`. Light is identity; dark mixes against the card.
     function firstApplySwatch() {
       return applyButtons()[0]!;
     }
@@ -587,9 +587,9 @@ describe('VerseActionPopover', () => {
       expect(firstApplySwatch().style.backgroundColor).toBe('rgb(255, 236, 91)');
     });
 
-    it('paints drawer dots with the same dark mix as reader fill', () => {
+    it('paints drawer dots with the dark mix against the card surface', () => {
       render(<VerseActionPopover {...defaultProps} theme="dark" />);
-      expect(firstApplySwatch().style.backgroundColor).toBe('rgb(65, 62, 33)');
+      expect(firstApplySwatch().style.backgroundColor).toBe('rgb(79, 74, 45)');
     });
 
     it('uses a dark inner stroke in light mode and a light one in dark mode', () => {

--- a/packages/ui/src/components/verse-action-popover.tsx
+++ b/packages/ui/src/components/verse-action-popover.tsx
@@ -6,7 +6,7 @@ import { cn } from '../lib/utils';
 import { BoxStackIcon } from './icons/box-stack';
 import { Share } from './icons/share';
 import { CheckIcon } from './icons/check';
-import { buildVerseActionSwatches, highlightFillHex } from '@/lib/highlight-colors';
+import { buildVerseActionSwatches, highlightFillColorMix } from '@/lib/highlight-colors';
 import { isDarkHighlightHex } from './verse';
 
 /** Re-export for back-compat; prefer `@/lib/highlight-colors` for new code. */
@@ -98,10 +98,9 @@ type ColorCircleProps = {
 
 function ColorCircle({ color, showRemove, label, onClick, theme }: ColorCircleProps) {
   const isDark = theme === 'dark';
-  // Dots sit on `yv:bg-card` (`--yv-gray-2` `#fcfafa` / `--yv-gray-45` `#232121`),
-  // not `--yv-background`. Same `p` as the reader; different surfaceBg.
-  const cardSurfaceBg = isDark ? '232121' : 'fcfafa';
-  const backgroundColor = `#${highlightFillHex(color, theme, cardSurfaceBg)}`;
+  // Dots sit on `yv:bg-card`. Same `--yv-highlight-mix-p` as the reader;
+  // mix against `--yv-card` so a host card override stays authoritative.
+  const backgroundColor = highlightFillColorMix(color, 'card') ?? undefined;
   // Inner border matches the Figma "highlight stroke" (#121212 @ 20%), giving
   // pale swatches definition on the light popover. On the dark popover a dark
   // stroke would vanish against the dimmed fill, so flip it to a light stroke.

--- a/packages/ui/src/components/verse-action-popover.tsx
+++ b/packages/ui/src/components/verse-action-popover.tsx
@@ -98,7 +98,10 @@ type ColorCircleProps = {
 
 function ColorCircle({ color, showRemove, label, onClick, theme }: ColorCircleProps) {
   const isDark = theme === 'dark';
-  const backgroundColor = `#${highlightFillHex(color, isDark ? 'dark' : 'light')}`;
+  // Dots sit on `yv:bg-card` (`--yv-gray-2` `#fcfafa` / `--yv-gray-45` `#232121`),
+  // not `--yv-background`. Same `p` as the reader; different surfaceBg.
+  const cardSurfaceBg = isDark ? '232121' : 'fcfafa';
+  const backgroundColor = `#${highlightFillHex(color, theme, cardSurfaceBg)}`;
   // Inner border matches the Figma "highlight stroke" (#121212 @ 20%), giving
   // pale swatches definition on the light popover. On the dark popover a dark
   // stroke would vanish against the dimmed fill, so flip it to a light stroke.

--- a/packages/ui/src/components/verse-action-popover.tsx
+++ b/packages/ui/src/components/verse-action-popover.tsx
@@ -6,8 +6,8 @@ import { cn } from '../lib/utils';
 import { BoxStackIcon } from './icons/box-stack';
 import { Share } from './icons/share';
 import { CheckIcon } from './icons/check';
-import { buildVerseActionSwatches } from '@/lib/highlight-colors';
-import { hexToRgba, HIGHLIGHT_FILL_OPACITY_DARK, isDarkHighlightHex } from './verse';
+import { buildVerseActionSwatches, highlightFillHex } from '@/lib/highlight-colors';
+import { isDarkHighlightHex } from './verse';
 
 /** Re-export for back-compat; prefer `@/lib/highlight-colors` for new code. */
 export { HIGHLIGHT_COLORS, type HighlightColor } from '@/lib/highlight-colors';
@@ -98,11 +98,7 @@ type ColorCircleProps = {
 
 function ColorCircle({ color, showRemove, label, onClick, theme }: ColorCircleProps) {
   const isDark = theme === 'dark';
-  // Preview the fill the way it will actually paint: full-strength in light mode,
-  // faded to the dark-mode alpha in dark mode (mirrors the applied-highlight
-  // treatment in verse.tsx). Light mode keeps the bare `#hex` so it serializes as
-  // a solid swatch.
-  const backgroundColor = isDark ? hexToRgba(color, HIGHLIGHT_FILL_OPACITY_DARK) : `#${color}`;
+  const backgroundColor = `#${highlightFillHex(color, isDark ? 'dark' : 'light')}`;
   // Inner border matches the Figma "highlight stroke" (#121212 @ 20%), giving
   // pale swatches definition on the light popover. On the dark popover a dark
   // stroke would vanish against the dimmed fill, so flip it to a light stroke.

--- a/packages/ui/src/components/verse.stories.tsx
+++ b/packages/ui/src/components/verse.stories.tsx
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, screen, userEvent, waitFor, within } from 'storybook/test';
 import React from 'react';
 
+import { useTheme } from '@youversion/platform-react-hooks';
+
 import { type BibleTextViewProps, BibleTextView, Verse, getCleanVerseText } from './verse';
 import { VerseActionPopover } from './verse-action-popover';
 import { buildVerseShareText } from '@/lib/verse-share';
@@ -396,6 +398,7 @@ export const FootnotePopoverThemeDark: Story = {
 };
 
 function VerseSelectionDemo(props: BibleTextViewProps) {
+  const providerTheme = useTheme();
   const containerRef = React.useRef<HTMLDivElement>(null);
   // Captured as state (not a ref) so the popover's docking observer re-subscribes
   // once the scroll container mounts.
@@ -541,6 +544,7 @@ function VerseSelectionDemo(props: BibleTextViewProps) {
         onClearHighlight={handleClearHighlight}
         onCopy={handleCopy}
         onShare={handleShare}
+        theme={props.theme ?? providerTheme}
       />
     </div>
   );

--- a/packages/ui/src/components/verse.test.tsx
+++ b/packages/ui/src/components/verse.test.tsx
@@ -621,7 +621,7 @@ describe('Verse.Html - Highlight fill (theme-aware, Swift parity)', () => {
     </div>
   `;
 
-  it('paints the stored hex unmixed in light mode', async () => {
+  it('paints the stored hex mixed against --yv-background in light mode', async () => {
     const { container } = render(
       <Verse.Html html={highlightHtml} theme="light" highlightedVerses={{ 1: 'ffec5b' }} />,
     );
@@ -629,11 +629,11 @@ describe('Verse.Html - Highlight fill (theme-aware, Swift parity)', () => {
     await waitFor(() => {
       const verse = container.querySelector<HTMLElement>('.yv-v[v="1"]');
       expect(verse).not.toBeNull();
-      expect(verse!.style.backgroundColor).toBe('rgb(255, 236, 91)');
+      expect(verse!.style.backgroundColor).toBe(fillFor('ffec5b'));
     });
   });
 
-  it('paints the dark mix (p = 0.20 against #121212)', async () => {
+  it('paints the dark mix against the live --yv-background token', async () => {
     const { container } = render(
       <Verse.Html html={highlightHtml} theme="dark" highlightedVerses={{ 1: 'ffec5b' }} />,
     );
@@ -641,7 +641,27 @@ describe('Verse.Html - Highlight fill (theme-aware, Swift parity)', () => {
     await waitFor(() => {
       const verse = container.querySelector<HTMLElement>('.yv-v[v="1"]');
       expect(verse).not.toBeNull();
-      expect(verse!.style.backgroundColor).toBe('rgb(65, 62, 33)');
+      expect(verse!.style.backgroundColor).toBe(fillFor('ffec5b'));
+      expect(verse!.style.backgroundColor).toContain('var(--yv-background)');
+    });
+  });
+
+  it('sets --yv-highlight-mix-p from the theme prop', async () => {
+    const { container, rerender } = render(
+      <Verse.Html html={highlightHtml} theme="light" highlightedVerses={{ 1: 'ffec5b' }} />,
+    );
+
+    await waitFor(() => {
+      const section = container.querySelector<HTMLElement>('[data-slot="yv-bible-renderer"]');
+      expect(section).not.toBeNull();
+      expect(section!.style.getPropertyValue('--yv-highlight-mix-p')).toBe('1');
+    });
+
+    rerender(<Verse.Html html={highlightHtml} theme="dark" highlightedVerses={{ 1: 'ffec5b' }} />);
+
+    await waitFor(() => {
+      const section = container.querySelector<HTMLElement>('[data-slot="yv-bible-renderer"]');
+      expect(section!.style.getPropertyValue('--yv-highlight-mix-p')).toBe('0.2');
     });
   });
 
@@ -653,7 +673,7 @@ describe('Verse.Html - Highlight fill (theme-aware, Swift parity)', () => {
     await waitFor(() => {
       const verse = container.querySelector<HTMLElement>('.yv-v[v="1"]');
       expect(verse).not.toBeNull();
-      expect(verse!.style.backgroundColor).toBe('rgb(0, 0, 0)');
+      expect(verse!.style.backgroundColor).toBe(fillFor('000000'));
       expect(verse!.style.color).toBe('rgb(255, 255, 255)');
     });
 
@@ -678,7 +698,7 @@ describe('Verse.Html - Highlight fill (theme-aware, Swift parity)', () => {
     });
   });
 
-  it('paints leftover fffe00 at the dark mix, not 0.3 alpha', async () => {
+  it('paints leftover fffe00 with color-mix, not 0.3 alpha', async () => {
     const { container } = render(
       <Verse.Html html={highlightHtml} theme="dark" highlightedVerses={{ 1: 'fffe00' }} />,
     );
@@ -686,7 +706,9 @@ describe('Verse.Html - Highlight fill (theme-aware, Swift parity)', () => {
     await waitFor(() => {
       const verse = container.querySelector<HTMLElement>('.yv-v[v="1"]');
       expect(verse).not.toBeNull();
-      expect(verse!.style.backgroundColor).toBe('rgb(65, 65, 14)');
+      expect(verse!.style.backgroundColor).toBe(fillFor('fffe00'));
+      expect(verse!.style.backgroundColor).toContain('color-mix');
+      expect(verse!.style.backgroundColor).not.toContain('0.3');
     });
   });
 
@@ -751,7 +773,7 @@ describe('Verse.Html - Highlight fill (theme-aware, Swift parity)', () => {
 
     await waitFor(() => {
       const verse = container.querySelector<HTMLElement>('.yv-v[v="1"]');
-      expect(verse!.style.backgroundColor).toBe('rgb(65, 65, 14)');
+      expect(verse!.style.backgroundColor).toBe(fillFor('fffe00'));
       const label = container.querySelector<HTMLElement>('.yv-v[v="1"] .yv-vlbl');
       expect(label!.style.color).toBe('inherit');
     });
@@ -765,43 +787,32 @@ describe('Verse.Html - Highlight fill (theme-aware, Swift parity)', () => {
       expect(label!.style.color).toBe('');
     });
   });
-});
-
-describe('Verse.Html - leftover fffe00 paint and clear', () => {
-  const leftoverHtml = `
-    <div class="p">
-      <span class="yv-v" v="1"></span><span class="yv-vlbl">1</span>In the beginning was the Word.
-    </div>
-  `;
 
   it('paints leftover fffe00 in light and clears it without remapping', async () => {
     const { container, rerender } = render(
-      <Verse.Html html={leftoverHtml} theme="light" highlightedVerses={{ 1: 'fffe00' }} />,
+      <Verse.Html html={highlightHtml} theme="light" highlightedVerses={{ 1: 'fffe00' }} />,
     );
 
     await waitFor(() => {
       const verse = container.querySelector<HTMLElement>('.yv-v[v="1"]');
-      expect(verse!.style.backgroundColor).toBe('rgb(255, 254, 0)');
+      expect(verse!.style.backgroundColor).toBe(fillFor('fffe00'));
     });
 
-    rerender(<Verse.Html html={leftoverHtml} theme="light" highlightedVerses={{}} />);
+    rerender(<Verse.Html html={highlightHtml} theme="light" highlightedVerses={{}} />);
 
     await waitFor(() => {
       const verse = container.querySelector<HTMLElement>('.yv-v[v="1"]');
       expect(verse!.style.backgroundColor).toBe('');
     });
   });
-});
-
-describe('Verse.Html - Words of Christ on a mixed fill', () => {
-  const wocHtml = `
-    <div class="p">
-      <span class="yv-v" v="1"></span><span class="yv-vlbl">1</span>
-      <span class="wj">Very truly I tell you</span>
-    </div>
-  `;
 
   it('leaves WOC text unmixed on a mixed fill', async () => {
+    const wocHtml = `
+      <div class="p">
+        <span class="yv-v" v="1"></span><span class="yv-vlbl">1</span>
+        <span class="wj">Very truly I tell you</span>
+      </div>
+    `;
     const { container, rerender } = render(
       <Verse.Html html={wocHtml} theme="light" highlightedVerses={{ 1: 'ffec5b' }} />,
     );
@@ -809,7 +820,7 @@ describe('Verse.Html - Words of Christ on a mixed fill', () => {
     await waitFor(() => {
       const verse = container.querySelector<HTMLElement>('.yv-v[v="1"]');
       const woc = container.querySelector<HTMLElement>('.wj');
-      expect(verse!.style.backgroundColor).toBe('rgb(255, 236, 91)');
+      expect(verse!.style.backgroundColor).toBe(fillFor('ffec5b'));
       expect(woc).not.toBeNull();
       expect(woc!.style.color).toBe('');
       expect(woc!.style.backgroundColor).toBe('');
@@ -820,13 +831,19 @@ describe('Verse.Html - Words of Christ on a mixed fill', () => {
     await waitFor(() => {
       const verse = container.querySelector<HTMLElement>('.yv-v[v="1"]');
       const woc = container.querySelector<HTMLElement>('.wj');
-      expect(verse!.style.backgroundColor).toBe('rgb(65, 62, 33)');
+      expect(verse!.style.backgroundColor).toBe(fillFor('ffec5b'));
       expect(woc!.style.color).toBe('');
       expect(woc!.style.backgroundColor).toBe('');
     });
   });
 
   it('does not mix WOC when a dark leftover fill flips wrapper text', async () => {
+    const wocHtml = `
+      <div class="p">
+        <span class="yv-v" v="1"></span><span class="yv-vlbl">1</span>
+        <span class="wj">Very truly I tell you</span>
+      </div>
+    `;
     const { container } = render(
       <Verse.Html html={wocHtml} theme="light" highlightedVerses={{ 1: '000000' }} />,
     );

--- a/packages/ui/src/components/verse.test.tsx
+++ b/packages/ui/src/components/verse.test.tsx
@@ -621,16 +621,27 @@ describe('Verse.Html - Highlight fill (theme-aware, Swift parity)', () => {
     </div>
   `;
 
-  it('paints the fill at full opacity in light mode', async () => {
+  it('paints the stored hex unmixed in light mode', async () => {
     const { container } = render(
-      <Verse.Html html={highlightHtml} theme="light" highlightedVerses={{ 1: 'fffe00' }} />,
+      <Verse.Html html={highlightHtml} theme="light" highlightedVerses={{ 1: 'ffec5b' }} />,
     );
 
     await waitFor(() => {
       const verse = container.querySelector<HTMLElement>('.yv-v[v="1"]');
       expect(verse).not.toBeNull();
-      // rgba(255, 254, 0, 1) — jsdom serializes full alpha as rgb().
-      expect(verse!.style.backgroundColor).toBe('rgb(255, 254, 0)');
+      expect(verse!.style.backgroundColor).toBe('rgb(255, 236, 91)');
+    });
+  });
+
+  it('paints the dark mix (p = 0.20 against #121212)', async () => {
+    const { container } = render(
+      <Verse.Html html={highlightHtml} theme="dark" highlightedVerses={{ 1: 'ffec5b' }} />,
+    );
+
+    await waitFor(() => {
+      const verse = container.querySelector<HTMLElement>('.yv-v[v="1"]');
+      expect(verse).not.toBeNull();
+      expect(verse!.style.backgroundColor).toBe('rgb(65, 62, 33)');
     });
   });
 
@@ -667,7 +678,7 @@ describe('Verse.Html - Highlight fill (theme-aware, Swift parity)', () => {
     });
   });
 
-  it('paints the fill at 0.3 alpha in dark mode', async () => {
+  it('paints leftover fffe00 at the dark mix, not 0.3 alpha', async () => {
     const { container } = render(
       <Verse.Html html={highlightHtml} theme="dark" highlightedVerses={{ 1: 'fffe00' }} />,
     );
@@ -675,7 +686,7 @@ describe('Verse.Html - Highlight fill (theme-aware, Swift parity)', () => {
     await waitFor(() => {
       const verse = container.querySelector<HTMLElement>('.yv-v[v="1"]');
       expect(verse).not.toBeNull();
-      expect(verse!.style.backgroundColor).toBe('rgba(255, 254, 0, 0.3)');
+      expect(verse!.style.backgroundColor).toBe('rgb(65, 65, 14)');
     });
   });
 
@@ -740,7 +751,7 @@ describe('Verse.Html - Highlight fill (theme-aware, Swift parity)', () => {
 
     await waitFor(() => {
       const verse = container.querySelector<HTMLElement>('.yv-v[v="1"]');
-      expect(verse!.style.backgroundColor).toBe('rgba(255, 254, 0, 0.3)');
+      expect(verse!.style.backgroundColor).toBe('rgb(65, 65, 14)');
       const label = container.querySelector<HTMLElement>('.yv-v[v="1"] .yv-vlbl');
       expect(label!.style.color).toBe('inherit');
     });
@@ -752,6 +763,79 @@ describe('Verse.Html - Highlight fill (theme-aware, Swift parity)', () => {
       expect(verse!.style.backgroundColor).toBe('');
       const label = container.querySelector<HTMLElement>('.yv-v[v="1"] .yv-vlbl');
       expect(label!.style.color).toBe('');
+    });
+  });
+});
+
+describe('Verse.Html - leftover fffe00 paint and clear', () => {
+  const leftoverHtml = `
+    <div class="p">
+      <span class="yv-v" v="1"></span><span class="yv-vlbl">1</span>In the beginning was the Word.
+    </div>
+  `;
+
+  it('paints leftover fffe00 in light and clears it without remapping', async () => {
+    const { container, rerender } = render(
+      <Verse.Html html={leftoverHtml} theme="light" highlightedVerses={{ 1: 'fffe00' }} />,
+    );
+
+    await waitFor(() => {
+      const verse = container.querySelector<HTMLElement>('.yv-v[v="1"]');
+      expect(verse!.style.backgroundColor).toBe('rgb(255, 254, 0)');
+    });
+
+    rerender(<Verse.Html html={leftoverHtml} theme="light" highlightedVerses={{}} />);
+
+    await waitFor(() => {
+      const verse = container.querySelector<HTMLElement>('.yv-v[v="1"]');
+      expect(verse!.style.backgroundColor).toBe('');
+    });
+  });
+});
+
+describe('Verse.Html - Words of Christ on a mixed fill', () => {
+  const wocHtml = `
+    <div class="p">
+      <span class="yv-v" v="1"></span><span class="yv-vlbl">1</span>
+      <span class="wj">Very truly I tell you</span>
+    </div>
+  `;
+
+  it('leaves WOC text unmixed on a mixed fill', async () => {
+    const { container, rerender } = render(
+      <Verse.Html html={wocHtml} theme="light" highlightedVerses={{ 1: 'ffec5b' }} />,
+    );
+
+    await waitFor(() => {
+      const verse = container.querySelector<HTMLElement>('.yv-v[v="1"]');
+      const woc = container.querySelector<HTMLElement>('.wj');
+      expect(verse!.style.backgroundColor).toBe('rgb(255, 236, 91)');
+      expect(woc).not.toBeNull();
+      expect(woc!.style.color).toBe('');
+      expect(woc!.style.backgroundColor).toBe('');
+    });
+
+    rerender(<Verse.Html html={wocHtml} theme="dark" highlightedVerses={{ 1: 'ffec5b' }} />);
+
+    await waitFor(() => {
+      const verse = container.querySelector<HTMLElement>('.yv-v[v="1"]');
+      const woc = container.querySelector<HTMLElement>('.wj');
+      expect(verse!.style.backgroundColor).toBe('rgb(65, 62, 33)');
+      expect(woc!.style.color).toBe('');
+      expect(woc!.style.backgroundColor).toBe('');
+    });
+  });
+
+  it('does not mix WOC when a dark leftover fill flips wrapper text', async () => {
+    const { container } = render(
+      <Verse.Html html={wocHtml} theme="light" highlightedVerses={{ 1: '000000' }} />,
+    );
+
+    await waitFor(() => {
+      const verse = container.querySelector<HTMLElement>('.yv-v[v="1"]');
+      const woc = container.querySelector<HTMLElement>('.wj');
+      expect(verse!.style.color).toBe('rgb(255, 255, 255)');
+      expect(woc!.style.color).toBe('');
     });
   });
 });

--- a/packages/ui/src/components/verse.tsx
+++ b/packages/ui/src/components/verse.tsx
@@ -30,7 +30,7 @@ import {
   clipUsfmForHighlightPaint,
 } from '@/lib/highlight-projection';
 import { useHighlightsControlledLatch, warnOnce } from '@/lib/use-highlights-controlled-latch';
-import { highlightFillHex } from '@/lib/highlight-colors';
+import { highlightFillColorMix, highlightMixP } from '@/lib/highlight-colors';
 import { useScriptureHighlightPaint } from '@/lib/use-scripture-highlight-paint';
 
 const LETTERS = 'abcdefghijklmnopqrstuvwxyz';
@@ -341,21 +341,22 @@ function BibleTextHtml({
   // Toggle selection underline + paint highlight fills on verse wrappers.
   // A verse can map to multiple `.yv-v[v="N"]` wrappers; each is painted so the
   // highlight reads as one solid block across line/paragraph breaks.
-  // Fill is mixSrgb(stored, --yv-background, p): light p = 1.00, dark p = 0.20
-  // against #121212. Theme flip re-paints only. In dark mode a highlighted
-  // verse's number label inherits the body text so it stays legible; both are
-  // cleared on removal.
+  // Fill is color-mix(stored, --yv-background, --yv-highlight-mix-p):
+  // light p = 1.00, dark p = 0.20. Theme flip updates p; the browser re-mixes
+  // against the live surface token. In dark mode a highlighted verse's number
+  // label inherits the body text so it stays legible; both are cleared on removal.
   useLayoutEffect(() => {
     if (!contentRef.current) return;
     const isDark = currentTheme === 'dark';
-    const fillTheme = isDark ? 'dark' : 'light';
     contentRef.current.querySelectorAll('.yv-v[v]').forEach((el) => {
       if (!(el instanceof HTMLElement)) return;
       const verseNum = parseInt(el.getAttribute('v') || '0', 10);
       el.classList.toggle('yv-v-selected', selectedVerses.includes(verseNum));
       const color = highlightedVerses[verseNum];
       const isHighlighted = Boolean(color);
-      el.style.backgroundColor = color ? `#${highlightFillHex(color, fillTheme)}` : '';
+      const fill = color ? highlightFillColorMix(color) : null;
+      if (fill === null) el.style.removeProperty('background-color');
+      else el.style.setProperty('background-color', fill);
       // Light mode paints fills at full strength. A dark non-palette hex
       // (YPE-4494) would sit under the reader's dark body text and go
       // illegible, so flip the wrapper to white; labels and footnote icons
@@ -519,8 +520,11 @@ export const Verse = {
         '--yv-reader-font-family'?: string;
         '--yv-reader-font-size'?: string;
         '--yv-reader-line-height'?: string | number;
+        '--yv-highlight-mix-p'?: number;
       };
-      const readerStyle: ReaderStyleVars = {};
+      const readerStyle: ReaderStyleVars = {
+        '--yv-highlight-mix-p': highlightMixP(currentTheme === 'dark' ? 'dark' : 'light'),
+      };
       if (fontFamily) readerStyle['--yv-reader-font-family'] = fontFamily;
       if (fontSize) readerStyle['--yv-reader-font-size'] = `${fontSize}px`;
       if (lineHeight) readerStyle['--yv-reader-line-height'] = lineHeight;

--- a/packages/ui/src/components/verse.tsx
+++ b/packages/ui/src/components/verse.tsx
@@ -30,6 +30,7 @@ import {
   clipUsfmForHighlightPaint,
 } from '@/lib/highlight-projection';
 import { useHighlightsControlledLatch, warnOnce } from '@/lib/use-highlights-controlled-latch';
+import { highlightFillHex } from '@/lib/highlight-colors';
 import { useScriptureHighlightPaint } from '@/lib/use-scripture-highlight-paint';
 
 const LETTERS = 'abcdefghijklmnopqrstuvwxyz';
@@ -151,25 +152,8 @@ function getVerseHtmlFromDom(container: HTMLElement, verseNum: string): string {
 }
 
 /**
- * Verse highlight fill opacity, matched to the Swift SDK (cross-SDK parity is the
- * UX baseline). Light mode paints the highlight hex at full strength; dark mode
- * fades it so the fill sits behind the text without overpowering it. See
- * `docs/adr/YPE-642-verse-action-popover.md` (ADR-005 as-built).
- */
-export const HIGHLIGHT_FILL_OPACITY_LIGHT = 1.0;
-export const HIGHLIGHT_FILL_OPACITY_DARK = 0.3;
-
-/** Converts a 6-digit hex (no `#`) to an `rgba()` string at the given alpha. */
-export function hexToRgba(hex: string, alpha: number): string {
-  const r = parseInt(hex.slice(0, 2), 16);
-  const g = parseInt(hex.slice(2, 4), 16);
-  const b = parseInt(hex.slice(4, 6), 16);
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
-}
-
-/**
  * Rec. 601 luma. Dark fills (e.g. `000000`) need light text in light mode;
- * the five SDK palette colors all sit above this cutoff.
+ * the six SDK palette colors all sit above this cutoff.
  */
 export function isDarkHighlightHex(hex: string): boolean {
   const r = parseInt(hex.slice(0, 2), 16);
@@ -357,20 +341,21 @@ function BibleTextHtml({
   // Toggle selection underline + paint highlight fills on verse wrappers.
   // A verse can map to multiple `.yv-v[v="N"]` wrappers; each is painted so the
   // highlight reads as one solid block across line/paragraph breaks.
-  // Theme-aware fill opacity mirrors the Swift SDK: full strength in light mode,
-  // faded in dark mode. In dark mode a highlighted verse's number label renders
-  // white so it stays legible over the fill; both are cleared on removal.
+  // Fill is mixSrgb(stored, --yv-background, p): light p = 1.00, dark p = 0.20
+  // against #121212. Theme flip re-paints only. In dark mode a highlighted
+  // verse's number label inherits the body text so it stays legible; both are
+  // cleared on removal.
   useLayoutEffect(() => {
     if (!contentRef.current) return;
     const isDark = currentTheme === 'dark';
-    const fillOpacity = isDark ? HIGHLIGHT_FILL_OPACITY_DARK : HIGHLIGHT_FILL_OPACITY_LIGHT;
+    const fillTheme = isDark ? 'dark' : 'light';
     contentRef.current.querySelectorAll('.yv-v[v]').forEach((el) => {
       if (!(el instanceof HTMLElement)) return;
       const verseNum = parseInt(el.getAttribute('v') || '0', 10);
       el.classList.toggle('yv-v-selected', selectedVerses.includes(verseNum));
       const color = highlightedVerses[verseNum];
       const isHighlighted = Boolean(color);
-      el.style.backgroundColor = color ? hexToRgba(color, fillOpacity) : '';
+      el.style.backgroundColor = color ? `#${highlightFillHex(color, fillTheme)}` : '';
       // Light mode paints fills at full strength. A dark non-palette hex
       // (YPE-4494) would sit under the reader's dark body text and go
       // illegible, so flip the wrapper to white; labels and footnote icons

--- a/packages/ui/src/lib/highlight-colors.test.ts
+++ b/packages/ui/src/lib/highlight-colors.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   HIGHLIGHT_COLORS,
   buildVerseActionSwatches,
+  highlightFillHex,
   isPaletteHighlightColor,
   isValidHighlightHex,
   mixSrgb,
@@ -155,6 +156,18 @@ describe('highlight-colors', () => {
     expect(mixSrgb('ffcff8', '121212', 0.2)).toBe('413840');
     expect(mixSrgb('dfdcff', '121212', 0.2)).toBe('3b3a41');
     expect(mixSrgb('fffe00', '121212', 0.2)).toBe('41410e');
+  });
+
+  it('highlightFillHex defaults to the reader surface', () => {
+    expect(highlightFillHex('ffec5b', 'light')).toBe('ffec5b');
+    expect(highlightFillHex('ffec5b', 'dark')).toBe('413e21');
+  });
+
+  it('highlightFillHex mixes dark p = 0.20 against a card surface', () => {
+    // `--yv-card` dark is `--yv-gray-45` `#232121`. Same p, different surface.
+    expect(mixSrgb('ffec5b', '232121', 0.2)).toBe('4f4a2d');
+    expect(highlightFillHex('ffec5b', 'dark', '232121')).toBe('4f4a2d');
+    expect(highlightFillHex('ffec5b', 'light', 'fcfafa')).toBe('ffec5b');
   });
 
   it('leftover fffe00 is not an apply swatch and still clears', () => {

--- a/packages/ui/src/lib/highlight-colors.test.ts
+++ b/packages/ui/src/lib/highlight-colors.test.ts
@@ -4,6 +4,7 @@ import {
   buildVerseActionSwatches,
   isPaletteHighlightColor,
   isValidHighlightHex,
+  mixSrgb,
   normalizeHighlightHex,
 } from './highlight-colors';
 
@@ -30,11 +31,35 @@ describe('highlight-colors', () => {
     expect(normalizeHighlightHex('not-a-color')).toBeNull();
   });
 
-  it('isPaletteHighlightColor recognizes the five SDK palette colors only', () => {
-    expect(isPaletteHighlightColor('fffe00')).toBe(true);
-    expect(isPaletteHighlightColor('FFFE00')).toBe(true);
+  it('HIGHLIGHT_COLORS is the six apply swatches', () => {
+    expect(HIGHLIGHT_COLORS).toEqual([
+      'ffec5b',
+      'b4ffc1',
+      'bbf4ff',
+      'ffdca7',
+      'ffcff8',
+      'dfdcff',
+    ]);
+  });
+
+  it('isPaletteHighlightColor accepts the six apply colors only', () => {
+    expect(isPaletteHighlightColor('ffec5b')).toBe(true);
+    expect(isPaletteHighlightColor('FFEC5B')).toBe(true);
+    expect(isPaletteHighlightColor('b4ffc1')).toBe(true);
+    expect(isPaletteHighlightColor('bbf4ff')).toBe(true);
+    expect(isPaletteHighlightColor('ffdca7')).toBe(true);
+    expect(isPaletteHighlightColor('ffcff8')).toBe(true);
+    expect(isPaletteHighlightColor('dfdcff')).toBe(true);
     expect(isPaletteHighlightColor('abcdef')).toBe(false);
     expect(isPaletteHighlightColor('invalid')).toBe(false);
+  });
+
+  it('isPaletteHighlightColor rejects the old five apply hexes', () => {
+    expect(isPaletteHighlightColor('fffe00')).toBe(false);
+    expect(isPaletteHighlightColor('5dff79')).toBe(false);
+    expect(isPaletteHighlightColor('00d6ff')).toBe(false);
+    expect(isPaletteHighlightColor('ffc66f')).toBe(false);
+    expect(isPaletteHighlightColor('ff95ef')).toBe(false);
   });
 
   it('buildVerseActionSwatches includes remove swatches for valid non-palette colors at exact hex', () => {
@@ -105,14 +130,54 @@ describe('highlight-colors', () => {
 
   it('normalizes uppercase and #‑prefixed palette colors into the remove row', () => {
     const swatches = buildVerseActionSwatches({
-      activeHighlights: new Set(['#FFFE00', '5DFF79']),
+      activeHighlights: new Set(['#FFEC5B', 'B4FFC1']),
       selectedVerses: [1, 2],
-      highlightedVerses: { 1: 'fffe00', 2: '5dff79' },
+      highlightedVerses: { 1: 'ffec5b', 2: 'b4ffc1' },
     });
 
     expect(swatches.filter((swatch) => swatch.showRemove).map((swatch) => swatch.color)).toEqual([
       HIGHLIGHT_COLORS[0],
       HIGHLIGHT_COLORS[1],
+    ]);
+  });
+
+  it('mixSrgb is identity in light (p = 1.00)', () => {
+    expect(mixSrgb('ffec5b', 'ffffff', 1)).toBe('ffec5b');
+    expect(mixSrgb('#ffec5b', '#ffffff', 1)).toBe('ffec5b');
+    expect(mixSrgb('fffe00', 'ffffff', 1)).toBe('fffe00');
+  });
+
+  it('mixSrgb mixes dark p = 0.20 against #121212', () => {
+    expect(mixSrgb('ffec5b', '121212', 0.2)).toBe('413e21');
+    expect(mixSrgb('b4ffc1', '#121212', 0.2)).toBe('324135');
+    expect(mixSrgb('bbf4ff', '121212', 0.2)).toBe('343f41');
+    expect(mixSrgb('ffdca7', '121212', 0.2)).toBe('413a30');
+    expect(mixSrgb('ffcff8', '121212', 0.2)).toBe('413840');
+    expect(mixSrgb('dfdcff', '121212', 0.2)).toBe('3b3a41');
+    expect(mixSrgb('fffe00', '121212', 0.2)).toBe('41410e');
+  });
+
+  it('leftover fffe00 is not an apply swatch and still clears', () => {
+    const empty = buildVerseActionSwatches({
+      activeHighlights: new Set(),
+      selectedVerses: [1],
+      highlightedVerses: {},
+    });
+    expect(empty.filter((swatch) => !swatch.showRemove).map((swatch) => swatch.color)).toEqual([
+      ...HIGHLIGHT_COLORS,
+    ]);
+    expect(empty.some((swatch) => swatch.color === 'fffe00')).toBe(false);
+
+    const leftover = buildVerseActionSwatches({
+      activeHighlights: new Set(['fffe00']),
+      selectedVerses: [1],
+      highlightedVerses: { 1: 'fffe00' },
+    });
+    expect(leftover.filter((swatch) => swatch.showRemove)).toEqual([
+      { color: 'fffe00', showRemove: true, key: 'fffe00-clear' },
+    ]);
+    expect(leftover.filter((swatch) => !swatch.showRemove).map((swatch) => swatch.color)).toEqual([
+      ...HIGHLIGHT_COLORS,
     ]);
   });
 

--- a/packages/ui/src/lib/highlight-colors.test.ts
+++ b/packages/ui/src/lib/highlight-colors.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it } from 'vitest';
 import {
   HIGHLIGHT_COLORS,
   buildVerseActionSwatches,
-  highlightFillHex,
+  highlightFillColorMix,
+  highlightMixP,
   isPaletteHighlightColor,
   isValidHighlightHex,
-  mixSrgb,
   normalizeHighlightHex,
 } from './highlight-colors';
 
@@ -142,32 +142,31 @@ describe('highlight-colors', () => {
     ]);
   });
 
-  it('mixSrgb is identity in light (p = 1.00)', () => {
-    expect(mixSrgb('ffec5b', 'ffffff', 1)).toBe('ffec5b');
-    expect(mixSrgb('#ffec5b', '#ffffff', 1)).toBe('ffec5b');
-    expect(mixSrgb('fffe00', 'ffffff', 1)).toBe('fffe00');
+  it('highlightFillColorMix mixes the stored hex against the live surface token', () => {
+    expect(highlightFillColorMix('ffec5b')).toBe(
+      'color-mix(in srgb, #ffec5b calc(var(--yv-highlight-mix-p) * 100%), var(--yv-background))',
+    );
+    expect(highlightFillColorMix('#FFEC5B')).toBe(
+      'color-mix(in srgb, #ffec5b calc(var(--yv-highlight-mix-p) * 100%), var(--yv-background))',
+    );
+    expect(highlightFillColorMix('fffe00')).toBe(
+      'color-mix(in srgb, #fffe00 calc(var(--yv-highlight-mix-p) * 100%), var(--yv-background))',
+    );
   });
 
-  it('mixSrgb mixes dark p = 0.20 against #121212', () => {
-    expect(mixSrgb('ffec5b', '121212', 0.2)).toBe('413e21');
-    expect(mixSrgb('b4ffc1', '#121212', 0.2)).toBe('324135');
-    expect(mixSrgb('bbf4ff', '121212', 0.2)).toBe('343f41');
-    expect(mixSrgb('ffdca7', '121212', 0.2)).toBe('413a30');
-    expect(mixSrgb('ffcff8', '121212', 0.2)).toBe('413840');
-    expect(mixSrgb('dfdcff', '121212', 0.2)).toBe('3b3a41');
-    expect(mixSrgb('fffe00', '121212', 0.2)).toBe('41410e');
+  it('highlightFillColorMix mixes drawer dots against --yv-card', () => {
+    expect(highlightFillColorMix('ffec5b', 'card')).toBe(
+      'color-mix(in srgb, #ffec5b calc(var(--yv-highlight-mix-p) * 100%), var(--yv-card))',
+    );
   });
 
-  it('highlightFillHex defaults to the reader surface', () => {
-    expect(highlightFillHex('ffec5b', 'light')).toBe('ffec5b');
-    expect(highlightFillHex('ffec5b', 'dark')).toBe('413e21');
+  it('highlightFillColorMix drops invalid hex', () => {
+    expect(highlightFillColorMix('not-a-color')).toBeNull();
   });
 
-  it('highlightFillHex mixes dark p = 0.20 against a card surface', () => {
-    // `--yv-card` dark is `--yv-gray-45` `#232121`. Same p, different surface.
-    expect(mixSrgb('ffec5b', '232121', 0.2)).toBe('4f4a2d');
-    expect(highlightFillHex('ffec5b', 'dark', '232121')).toBe('4f4a2d');
-    expect(highlightFillHex('ffec5b', 'light', 'fcfafa')).toBe('ffec5b');
+  it('highlightMixP is 1 in light and 0.2 in dark', () => {
+    expect(highlightMixP('light')).toBe(1);
+    expect(highlightMixP('dark')).toBe(0.2);
   });
 
   it('leftover fffe00 is not an apply swatch and still clears', () => {

--- a/packages/ui/src/lib/highlight-colors.ts
+++ b/packages/ui/src/lib/highlight-colors.ts
@@ -44,53 +44,48 @@ export function isPaletteHighlightColor(color: string): boolean {
   return HIGHLIGHT_COLOR_SET.has(normalized);
 }
 
-/** `--yv-background` in light (`#ffffff`) and dark (`#121212`). Not popover `#1c1a1a`. */
-const HIGHLIGHT_SURFACE_BG = {
-  light: 'ffffff',
-  dark: '121212',
-} as const;
-
 /** Light identity. Dark `p = 0.20`. Black-theme `p = 0.25` is unused. */
-const HIGHLIGHT_MIX_P = {
+export const HIGHLIGHT_MIX_P = {
   light: 1,
   dark: 0.2,
 } as const;
 
-function hexChannel(hex: string, offset: number): number {
-  return parseInt(stripHighlightHexPrefix(hex).slice(offset, offset + 2), 16);
-}
+export type HighlightFillSurface = 'background' | 'card';
 
-function byteToHex(value: number): string {
-  return Math.round(value).toString(16).padStart(2, '0');
-}
+const HIGHLIGHT_FILL_SURFACE_VAR = {
+  background: 'var(--yv-background)',
+  card: 'var(--yv-card)',
+} as const;
 
-/** `stored * p + surfaceBg * (1 - p)`. Returns unmixed-format lowercase hex, no `#`. */
-export function mixSrgb(stored: string, surfaceBg: string, p: number): string {
-  const q = 1 - p;
-  const r = hexChannel(stored, 0) * p + hexChannel(surfaceBg, 0) * q;
-  const g = hexChannel(stored, 2) * p + hexChannel(surfaceBg, 2) * q;
-  const b = hexChannel(stored, 4) * p + hexChannel(surfaceBg, 4) * q;
-  return `${byteToHex(r)}${byteToHex(g)}${byteToHex(b)}`;
+export function highlightMixP(theme: 'light' | 'dark'): number {
+  switch (theme) {
+    case 'light':
+      return HIGHLIGHT_MIX_P.light;
+    case 'dark':
+      return HIGHLIGHT_MIX_P.dark;
+    default: {
+      const _exhaustive: never = theme;
+      return _exhaustive;
+    }
+  }
 }
 
 /**
- * Mixed fill hex (no `#`) for painting a stored highlight.
- * Defaults to the reader surface (`--yv-background`). Pass a different
- * `surfaceBg` (e.g. `--yv-card` `#232121` / `#fcfafa`) to mix against
- * another surface. `p` still comes from `theme` (light 1.00, dark 0.20).
+ * Token-aware sRGB fill. `p` is `--yv-highlight-mix-p` (light 1.00, dark 0.20).
+ * Reader fills mix against `--yv-background`; drawer dots pass `'card'`.
  */
-export function highlightFillHex(
+export function highlightFillColorMix(
   stored: string,
-  theme: 'light' | 'dark',
-  surfaceBg?: string,
-): string {
-  switch (theme) {
-    case 'light':
-      return mixSrgb(stored, surfaceBg ?? HIGHLIGHT_SURFACE_BG.light, HIGHLIGHT_MIX_P.light);
-    case 'dark':
-      return mixSrgb(stored, surfaceBg ?? HIGHLIGHT_SURFACE_BG.dark, HIGHLIGHT_MIX_P.dark);
+  surface: HighlightFillSurface = 'background',
+): string | null {
+  const hex = normalizeHighlightHex(stored);
+  if (hex === null) return null;
+  switch (surface) {
+    case 'background':
+    case 'card':
+      return `color-mix(in srgb, #${hex} calc(var(--yv-highlight-mix-p) * 100%), ${HIGHLIGHT_FILL_SURFACE_VAR[surface]})`;
     default: {
-      const _exhaustive: never = theme;
+      const _exhaustive: never = surface;
       return _exhaustive;
     }
   }

--- a/packages/ui/src/lib/highlight-colors.ts
+++ b/packages/ui/src/lib/highlight-colors.ts
@@ -73,12 +73,22 @@ export function mixSrgb(stored: string, surfaceBg: string, p: number): string {
   return `${byteToHex(r)}${byteToHex(g)}${byteToHex(b)}`;
 }
 
-export function highlightFillHex(stored: string, theme: 'light' | 'dark'): string {
+/**
+ * Mixed fill hex (no `#`) for painting a stored highlight.
+ * Defaults to the reader surface (`--yv-background`). Pass a different
+ * `surfaceBg` (e.g. `--yv-card` `#232121` / `#fcfafa`) to mix against
+ * another surface. `p` still comes from `theme` (light 1.00, dark 0.20).
+ */
+export function highlightFillHex(
+  stored: string,
+  theme: 'light' | 'dark',
+  surfaceBg?: string,
+): string {
   switch (theme) {
     case 'light':
-      return mixSrgb(stored, HIGHLIGHT_SURFACE_BG.light, HIGHLIGHT_MIX_P.light);
+      return mixSrgb(stored, surfaceBg ?? HIGHLIGHT_SURFACE_BG.light, HIGHLIGHT_MIX_P.light);
     case 'dark':
-      return mixSrgb(stored, HIGHLIGHT_SURFACE_BG.dark, HIGHLIGHT_MIX_P.dark);
+      return mixSrgb(stored, surfaceBg ?? HIGHLIGHT_SURFACE_BG.dark, HIGHLIGHT_MIX_P.dark);
     default: {
       const _exhaustive: never = theme;
       return _exhaustive;

--- a/packages/ui/src/lib/highlight-colors.ts
+++ b/packages/ui/src/lib/highlight-colors.ts
@@ -3,8 +3,15 @@
  * accept any valid 6-digit API hex; invalid hex is dropped everywhere.
  */
 
-/** Canonical apply palette — yellow, green, blue, orange, pink (matches iOS). */
-export const HIGHLIGHT_COLORS = ['fffe00', '5dff79', '00d6ff', 'ffc66f', 'ff95ef'] as const;
+/** Canonical apply palette (YPE-5058). Persist unmixed lowercase hex, no `#`. */
+export const HIGHLIGHT_COLORS = [
+  'ffec5b',
+  'b4ffc1',
+  'bbf4ff',
+  'ffdca7',
+  'ffcff8',
+  'dfdcff',
+] as const;
 
 export type HighlightColor = (typeof HIGHLIGHT_COLORS)[number];
 
@@ -30,11 +37,53 @@ export function normalizeHighlightHex(color: string): string | null {
   return stripHighlightHexPrefix(color).toLowerCase();
 }
 
-/** Whether `color` is one of the five SDK apply swatches (valid hex required). */
+/** Whether `color` is one of the six SDK apply swatches (valid hex required). */
 export function isPaletteHighlightColor(color: string): boolean {
   const normalized = normalizeHighlightHex(color);
   if (normalized === null) return false;
   return HIGHLIGHT_COLOR_SET.has(normalized);
+}
+
+/** `--yv-background` in light (`#ffffff`) and dark (`#121212`). Not popover `#1c1a1a`. */
+export const HIGHLIGHT_SURFACE_BG = {
+  light: 'ffffff',
+  dark: '121212',
+} as const;
+
+/** Light identity. Dark `p = 0.20`. Black-theme `p = 0.25` is unused. */
+export const HIGHLIGHT_MIX_P = {
+  light: 1,
+  dark: 0.2,
+} as const;
+
+function hexChannel(hex: string, offset: number): number {
+  return parseInt(stripHighlightHexPrefix(hex).slice(offset, offset + 2), 16);
+}
+
+function byteToHex(value: number): string {
+  return Math.round(value).toString(16).padStart(2, '0');
+}
+
+/** `stored * p + surfaceBg * (1 - p)`. Returns unmixed-format lowercase hex, no `#`. */
+export function mixSrgb(stored: string, surfaceBg: string, p: number): string {
+  const q = 1 - p;
+  const r = hexChannel(stored, 0) * p + hexChannel(surfaceBg, 0) * q;
+  const g = hexChannel(stored, 2) * p + hexChannel(surfaceBg, 2) * q;
+  const b = hexChannel(stored, 4) * p + hexChannel(surfaceBg, 4) * q;
+  return `${byteToHex(r)}${byteToHex(g)}${byteToHex(b)}`;
+}
+
+export function highlightFillHex(stored: string, theme: 'light' | 'dark'): string {
+  switch (theme) {
+    case 'light':
+      return mixSrgb(stored, HIGHLIGHT_SURFACE_BG.light, HIGHLIGHT_MIX_P.light);
+    case 'dark':
+      return mixSrgb(stored, HIGHLIGHT_SURFACE_BG.dark, HIGHLIGHT_MIX_P.dark);
+    default: {
+      const _exhaustive: never = theme;
+      return _exhaustive;
+    }
+  }
 }
 
 export type VerseActionSwatch = {

--- a/packages/ui/src/lib/highlight-colors.ts
+++ b/packages/ui/src/lib/highlight-colors.ts
@@ -45,13 +45,13 @@ export function isPaletteHighlightColor(color: string): boolean {
 }
 
 /** `--yv-background` in light (`#ffffff`) and dark (`#121212`). Not popover `#1c1a1a`. */
-export const HIGHLIGHT_SURFACE_BG = {
+const HIGHLIGHT_SURFACE_BG = {
   light: 'ffffff',
   dark: '121212',
 } as const;
 
 /** Light identity. Dark `p = 0.20`. Black-theme `p = 0.25` is unused. */
-export const HIGHLIGHT_MIX_P = {
+const HIGHLIGHT_MIX_P = {
   light: 1,
   dark: 0.2,
 } as const;

--- a/packages/ui/src/lib/pending-highlight.test.ts
+++ b/packages/ui/src/lib/pending-highlight.test.ts
@@ -16,7 +16,7 @@ const STORAGE_KEY = 'youversion-platform:pending-highlight';
 
 const base: PendingHighlight = {
   verses: [16, 17],
-  color: 'fffe00',
+  color: 'ffec5b',
   versionId: 111,
   book: 'JHN',
   chapter: '3',

--- a/packages/ui/src/test/highlights-test-utils.tsx
+++ b/packages/ui/src/test/highlights-test-utils.tsx
@@ -1,11 +1,15 @@
+import type { ReactElement, ReactNode } from 'react';
+import { vi } from 'vitest';
 import { YouVersionUserInfo, type Collection, type Highlight } from '@youversion/platform-core';
 import {
   YouVersionAuthContext,
   YouVersionContext,
   type HookOverrides,
 } from '@youversion/platform-react-hooks';
-import type { ReactElement, ReactNode } from 'react';
-import { vi } from 'vitest';
+import {
+  highlightFillColorMix,
+  type HighlightFillSurface,
+} from '@/lib/highlight-colors';
 
 /** Wraps a highlight list in the paginated collection envelope the clients return. */
 export function collection(data: Highlight[]): Collection<Highlight> {
@@ -47,15 +51,9 @@ export function getVerseEl(container: HTMLElement, verse: number): HTMLElement {
   return el;
 }
 
-/**
- * Color the renderer paints for a highlight fill in light mode (full opacity;
- * jsdom serializes a fully opaque color to `rgb(...)`).
- */
-export function fillFor(hex: string): string {
-  const r = parseInt(hex.slice(0, 2), 16);
-  const g = parseInt(hex.slice(2, 4), 16);
-  const b = parseInt(hex.slice(4, 6), 16);
-  return `rgb(${r}, ${g}, ${b})`;
+/** Color the renderer or drawer-dot paints for a stored highlight hex. */
+export function fillFor(hex: string, surface: HighlightFillSurface = 'background'): string {
+  return highlightFillColorMix(hex, surface) ?? '';
 }
 
 /** Minimal signed-in user the auth context needs; only `id`/`name` are read. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
[YPE-5058](https://lifechurch.atlassian.net/browse/YPE-5058). React web only.

The grilled spec locked the six apply hexes, unmixed persist, leftover `fffe00` paint/clear, and unmixed Words of Christ. Review then changed the fill path. We no longer JS-mix against pinned `#121212` / `#232121`. Fills are CSS `color-mix` against the live `--yv-background` and `--yv-card` tokens.

## What changed
- Apply palette is `ffec5b`, `b4ffc1`, `bbf4ff`, `ffdca7`, `ffcff8`, `dfdcff`.
- Apply stays palette-only (YPE-4494). Persist the unmixed lowercase hex, no `#`.
- Reader fill is `color-mix(in srgb, #stored calc(var(--yv-highlight-mix-p) * 100%), var(--yv-background))`. Light `p = 1`. Dark `p = 0.20`. `--yv-highlight-mix-p` lives in `theme.css` and on the reader when the theme prop wins.
- Drawer dots use the same `p` against `var(--yv-card)`.
- A host override of `--yv-background` or `--yv-card` changes the fill. Default dark still looks like the old 20% mix against `#121212` (reader) / `#232121` (dots).
- Leftover `fffe00` still paints and clears. It is not an apply swatch and is not remapped.
- Words of Christ stay unmixed: `--yv-wj` is `#94000c` light / `#e4bfc2` dark.

## Out of scope
YPE-5059 (Expo), YPE-5116 (Kotlin), a black theme, remapping stored hexes, mixing WOC, persisting mixed hexes.

## Tests
1. Palette is the six. Apply rejects the old five.
2. `highlightFillColorMix` emits `color-mix` against `var(--yv-background)` or `var(--yv-card)`. Invalid hex is dropped. `--yv-highlight-mix-p` is `1` / `0.2`.
3. Verse paint and drawer dots use that helper. Theme flip updates `p`.
4. Old `fffe00` paints and clears. No apply swatch.
5. WOC text stays unmixed on a mixed fill.

## Review
Start at `packages/ui/src/lib/highlight-colors.ts` (`HIGHLIGHT_COLORS`, `highlightFillColorMix`), then `verse.tsx` and `verse-action-popover.tsx`. Mix `p` and `--yv-wj` live in `packages/core/src/styles/theme.css`.

## Visual comparison

Storybook `VerseSelection`. Before is `main`. After shots were taken on this branch against the default tokens, so dark fills still match the 20% mix on `#121212` / `#232121`. Highlighted shots apply the first swatch.

### Verse action bar, light

| Before | After |
|:------:|:-----:|
| ![Verse action bar in light mode before: five saturated swatches](https://litter.catbox.moe/1bjv6k.png) | ![Verse action bar in light mode after: six softer palette swatches](https://litter.catbox.moe/kgqksh.png) |

### Verse action bar, dark

| Before | After |
|:------:|:-----:|
| ![Verse action bar in dark mode before: five swatches on the dark popover](https://litter.catbox.moe/9j3so4.png) | ![Verse action bar in dark mode after: six swatches mixed against the card](https://litter.catbox.moe/ihz9h8.png) |

### Highlighted verse, light

| Before | After |
|:------:|:-----:|
| ![John 1:1 highlighted in light mode before with neon yellow fffe00](https://litter.catbox.moe/pd0c41.png) | ![John 1:1 highlighted in light mode after with palette yellow ffec5b](https://litter.catbox.moe/36qz7l.png) |

### Highlighted verse, dark

| Before | After |
|:------:|:-----:|
| ![John 1:1 highlighted in dark mode before with translucent old yellow](https://litter.catbox.moe/ztl324.png) | ![John 1:1 highlighted in dark mode after with 20 percent mix on the default dark background](https://litter.catbox.moe/m6wp95.png) |

### Words of Christ, John 5:8 NIV, light

Red letters stay unmixed on the fill. Before uses `--yv-red` (`#ff3d4d`). After uses `--yv-wj` (`#94000c`).

| Before | After |
|:------:|:-----:|
| ![John 5:8 NIV highlighted in light mode before](https://litter.catbox.moe/l8exog.png) | ![John 5:8 NIV highlighted in light mode after](https://litter.catbox.moe/5imvnb.png) |

### Words of Christ, John 5:8 NIV, dark

Before keeps `--yv-red` on a 30% yellow overlay. After keeps `--yv-wj` (`#e4bfc2`) on the mixed fill.

| Before | After |
|:------:|:-----:|
| ![John 5:8 NIV highlighted in dark mode before](https://litter.catbox.moe/3y6umb.png) | ![John 5:8 NIV highlighted in dark mode after](https://litter.catbox.moe/ix32fe.png) |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04c77a96-7e41-4534-aa8f-53ad070ec61c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04c77a96-7e41-4534-aa8f-53ad070ec61c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>









[YPE-5058]: https://lifechurch.atlassian.net/browse/YPE-5058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces the React web highlight palette and changes highlight rendering to token-aware CSS color mixing while preserving stored colors and legacy-highlight removal.
- Adds six apply colors and retains lowercase, unmixed persistence.
- Mixes reader fills against `--yv-background` and popover dots against `--yv-card`.
- Adds light and dark mix-strength tokens and dedicated Words of Christ colors.
- Updates tests, stories, documentation, and release notes for the new behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/ui/src/lib/highlight-colors.ts | Defines the six-color apply palette, normalization rules, theme mix strengths, and token-aware CSS fill expressions. |
| packages/ui/src/components/verse.tsx | Replaces RGBA highlight painting with CSS color mixing and supplies the reader’s theme-specific mix-strength variable. |
| packages/ui/src/components/verse-action-popover.tsx | Updates highlight dots to mix stored colors against the live card surface token. |
| packages/core/src/styles/theme.css | Adds scoped light and dark highlight-mix and Words of Christ theme values. |
| packages/core/src/styles/bible-reader.css | Moves Words of Christ styling from the general red token to the dedicated theme-aware token. |
| .changeset/ype-5058-highlight-palette-mix.md | Records the coordinated core and UI minor release and describes the highlight presentation changes. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Stored lowercase highlight hex] --> B[Highlight projection]
  B --> C[Reader verse fill]
  B --> D[Popover color dot]
  P[--yv-highlight-mix-p] --> C
  P --> D
  BG[--yv-background] --> C
  CARD[--yv-card] --> D
  C --> E[CSS color-mix reader highlight]
  D --> F[CSS color-mix swatch preview]
```

<sub>Reviews (5): Last reviewed commit: ["docs: explain why highlight fills mix in..."](https://github.com/youversion/platform-sdk-react/commit/e96e10bd1cbcac983d2ba682412f9cbb0398c260) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56683657)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Bible HTML transformation and browser styles](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/core-html-styling.md)
- Knowledge Base — [Scripture highlighting interactions](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/ui-highlights.md)
- Knowledge Base — [Bible content widgets](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/ui-content-components.md)
- Knowledge Base — [Package delivery workflows](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/delivery-workflows.md)
</details>


<!-- /greptile_comment -->