### PR TITLE
feat(ui): validate shadow DOM dialog top layer

### DIFF
--- a/.changeset/validate-shadow-dialog.md
+++ b/.changeset/validate-shadow-dialog.md
@@ -1,0 +1,5 @@
+---
+'@youversion/platform-react-ui': patch
+---
+
+Validate shadow-local top-layer Dialog behavior, including focus containment and modal background inertness.

--- a/docs/adr/0005-prototype-shadow-dom-style-isolation.md
+++ b/docs/adr/0005-prototype-shadow-dom-style-isolation.md
@@ -98,6 +98,52 @@ panel's layout rectangle extends beyond the constrained ancestor, but
 hit-testing beyond the ancestor cannot reach it. The equivalent top-layer panel
 is reachable at the same point.
 
+## Dialog top-layer validation
+
+The shared Radix `Dialog` uses the same lazy, shadow-local top-layer container
+when rendered inside an opted-in `ShadowRootHost`. Its overlay and content stay
+in the dialog's shadow tree, so their title and description ID relationships
+remain resolvable while the backdrop escapes ancestor clipping.
+
+Modal behavior requires coordination beyond portal placement. Radix keeps its
+overlay and content mounted independently through exit animations, so the
+ordinary shadow content wrapper becomes inert from actual modal DOM presence,
+not merely from the Dialog's `open` state. The wrapper remains inert until both
+nodes have unmounted, while Radix continues to suppress interaction with the
+outer document.
+
+Radix's document-level focus tracking sees the shadow host instead of the real
+focused descendant. The isolated Dialog therefore uses `focusin` with
+`composedPath()` to redirect programmatic focus escapes. While the modal content
+is mounted inside a shadow root, the shadow-specific focus hook also owns Tab and
+Shift+Tab traversal: it uses `tabbable` to calculate browser-like candidate
+ordering, including radio-group and `tabindex` rules, and wraps traversal within
+the content. Radix continues to own the dialog lifecycle and dismissal behavior.
+A `popover="manual"` top-layer container does not provide the focus containment
+of a native modal dialog. During an overlay-only exit interval, focus is held on
+the overlay instead of escaping to background content. Focus restoration
+captures the real opener from the owning shadow root when present, falls back to
+the document for an external opener, and waits until both modal nodes have
+unmounted before restoring either opener.
+
+The focused Chromium story verifies shadow-root containment, Chromium's resolved
+title and description element relationships, initial focus, forward and reverse
+Tab cycling across ordinary buttons, a radio group, and a negative-tabindex
+control, programmatic-focus redirection, background inertness while open and
+through staggered content and overlay exit animations, full-viewport backdrop
+coverage and hit testing, Escape and backdrop-click dismissal, and restoration
+after the exit animation unmounts.
+
+Concurrent independent overlays in one shadow root remain deliberately
+unsupported. Nested dialogs and overlays launched from an open dialog are also
+unsupported: the prototype defines no stacking, focus-ownership, or dismissal
+contract for them, and consumers must not rely on incidental Radix behavior.
+Production rollout needs an explicit ownership model for nested or competing
+modal and non-modal overlays. Radix's development-only title and description
+checks also query the document and emit warnings for valid relationships inside
+a shadow root; this is known console noise, not evidence that the IDs are
+missing.
+
 ## Compatibility impact
 
 Although the React props API is unchanged, the rendered DOM structure is not.
@@ -111,9 +157,7 @@ detail.
 ## Deliberately deferred
 
 - Rollout to all exported components.
-- Dialog portal placement, modal background inertness, and focus management.
-- Modal-overlay coordination, including ownership and nested-overlay behavior,
-  if Dialog support is added later.
+- Support and coordination for nested or competing modal and non-modal overlays.
 - Form association when controls live outside their form's tree scope.
 - SSR/hydration and the first client paint.
 - A package-wide custom-property audit. `all: initial` does not reset custom
@@ -134,7 +178,9 @@ detail.
 - A full browser and assistive-technology matrix; current browser verification is
   Chromium-focused. Chromium's `ariaControlsElements` confirms DOM relationship
   resolution, but this spike does not verify screen-reader announcement or
-  navigation through Shadow DOM and the native top layer.
+  navigation through Shadow DOM and the native top layer. The Dialog checks verify
+  Chromium's reflected element relationships and focus behavior, not an
+  accessibility-tree snapshot or screen-reader announcement.
 - Consumer test-query migration guidance and a component-by-component rollout.
 - An audit of components that use Radix Popover directly instead of the shared
   `ui/popover.tsx` wrapper (`VerseActionPopover` is a confirmed example) and are
@@ -144,10 +190,10 @@ detail.
 
 - **What's validated in Chromium as an internal opt-in prototype**: the
   `ShadowRootHost` + `portalStrategy` + `useShadowPortalTarget` plumbing,
-  exercised through the shared Popover primitive and the focused story harness.
-  Portal placement changes only for an isolated component that requests a local
-  strategy. One shared correction also affects unisolated consumers: the Popover
-  now respects Radix's available-height measurement.
+  exercised through the shared Popover and Dialog primitives and their focused
+  story harnesses. Portal placement changes only for an isolated component that
+  requests a local strategy. One shared correction also affects unisolated
+  consumers: the Popover now respects Radix's available-height measurement.
 - **Blocking next steps, not "someday" items**: the package-wide custom-
   property audit (now with concrete evidence a real rule was silently broken
   by it) and the direct-Radix-primitive audit (so rollout doesn't create a
@@ -155,12 +201,12 @@ detail.
 - **What must be true before a public export could default to isolation**:
   an SSR/hydration story (the shadow root currently attaches in `useEffect`,
   so server output is an empty host and the first paint is post-hydration —
-  represented above as a breaking change, not an implementation detail), and
-  a decision on whether isolation is opt-in per component instance or a
-  package-wide toggle.
+  represented above as a breaking change, not an implementation detail), an
+  overlay-ownership decision, and a decision on whether isolation is opt-in per
+  component instance or a package-wide toggle.
 - This spike enables no automatic isolation for any public export, including
-  `BibleVersionPicker`. Rollout is a separate, later change with its own ADR
-  and PR.
+  `BibleVersionPicker` or `SignInDialog`. Rollout is a separate, later change
+  with its own ADR and PR.
 
 This prototype should be reviewed as an architectural checkpoint, not as a
 complete solution ready for release.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -63,6 +63,7 @@
     "i18next": "^26.0.0",
     "radix-ui": "^1.4.3",
     "react-i18next": "^17.0.0",
+    "tabbable": "6.5.0",
     "tailwind-merge": "3.3.1",
     "tw-animate-css": "1.4.0",
     "xstate": "5.32.4"

--- a/packages/ui/src/components/sign-in-dialog.shadow-isolation.stories.tsx
+++ b/packages/ui/src/components/sign-in-dialog.shadow-isolation.stories.tsx
@@ -1,0 +1,297 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { http, HttpResponse } from 'msw';
+import { useState } from 'react';
+import { expect, userEvent, waitFor } from 'storybook/test';
+import { ShadowRootHost } from '../lib/shadow-root-host';
+import { requireShadowRoot } from '../test/dom-stubs';
+import { SignInDialog } from './sign-in-dialog';
+
+function SignInDialogHarness(): React.ReactNode {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 24 }}>
+      <button type="button" data-testid="outside-control" onClick={() => setOpen(true)}>
+        Open dialog
+      </button>
+      <div
+        data-testid="clipping-container"
+        style={{ inlineSize: 180, blockSize: 56, overflow: 'hidden', transform: 'translateZ(0)' }}
+      >
+        <ShadowRootHost portalStrategy="local-top-layer">
+          <button type="button" data-testid="inside-control" onClick={() => setOpen(true)}>
+            Inside-island control
+          </button>
+          <SignInDialog
+            open={open}
+            onOpenChange={setOpen}
+            appName="Example Bible App"
+            onConfirm={() => setOpen(false)}
+            onDecline={() => setOpen(false)}
+          />
+        </ShadowRootHost>
+      </div>
+    </div>
+  );
+}
+
+const meta = {
+  title: 'Spikes/SignInDialog Shadow DOM isolation',
+  component: SignInDialogHarness,
+  tags: ['integration'],
+  parameters: {
+    layout: 'centered',
+    msw: {
+      handlers: [
+        http.get('*/v1/fonts/1/stylesheet', () =>
+          HttpResponse.text('', { headers: { 'Content-Type': 'text/css' } }),
+        ),
+      ],
+    },
+  },
+} satisfies Meta<typeof SignInDialogHarness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function styleSnapshot(element: HTMLElement) {
+  const styles = getComputedStyle(element);
+  return {
+    backgroundColor: styles.backgroundColor,
+    borderRadius: styles.borderRadius,
+    color: styles.color,
+    fontFamily: styles.fontFamily,
+    padding: styles.padding,
+    position: styles.position,
+  };
+}
+
+export const IsolatesFocusInertnessBackdropAndRestoration: Story = {
+  play: async ({ canvasElement }) => {
+    const { outsideControl, clippingContainer } = await waitFor(() => {
+      const outside = canvasElement.querySelector<HTMLButtonElement>(
+        '[data-testid="outside-control"]',
+      );
+      const clipping = canvasElement.querySelector<HTMLElement>(
+        '[data-testid="clipping-container"]',
+      );
+      if (!outside || !clipping) throw new Error('dialog harness not rendered');
+      return { outsideControl: outside, clippingContainer: clipping };
+    });
+
+    const root = await waitFor(() => requireShadowRoot(canvasElement));
+    const exitAnimationStyle = canvasElement.ownerDocument.createElement('style');
+    exitAnimationStyle.textContent = `
+      [role='dialog'][data-state='closed'] { animation-duration: 400ms !important; }
+      [data-slot='dialog-overlay'][data-state='closed'] { animation-duration: 800ms !important; }
+    `;
+    root.append(exitAnimationStyle);
+    const insideControl = root.querySelector<HTMLButtonElement>('[data-testid="inside-control"]');
+    if (!insideControl) throw new Error('inside-island control not rendered');
+    void expect(root.querySelector('[data-yv-shadow-local-overlay]')).toBeNull();
+    insideControl.focus();
+    await userEvent.click(insideControl);
+    const dialog = await waitFor(() => {
+      const element = root.querySelector<HTMLElement>('[role="dialog"]');
+      if (!element) throw new Error('sign-in dialog not rendered in the component shadow root');
+      return element;
+    });
+    const topLayer = root.querySelector<HTMLElement>('[data-yv-shadow-local-overlay]');
+    const contentWrapper = root.querySelector<HTMLElement>('[data-yv-shadow-content-wrapper]');
+    if (!topLayer || !contentWrapper) throw new Error('shadow modal coordination not rendered');
+
+    void expect(dialog.getRootNode()).toBe(root);
+    void expect(topLayer.getRootNode()).toBe(root);
+    void expect(canvasElement.ownerDocument.body.querySelector('[role="dialog"]')).toBeNull();
+    await waitFor(() => void expect(topLayer.matches(':popover-open')).toBe(true));
+
+    const titleId = dialog.getAttribute('aria-labelledby');
+    const descriptionId = dialog.getAttribute('aria-describedby');
+    void expect(titleId).toBeTruthy();
+    void expect(descriptionId).toBeTruthy();
+    const title = root.getElementById(titleId!);
+    const description = root.getElementById(descriptionId!);
+    void expect(title).not.toBeNull();
+    void expect(description).not.toBeNull();
+    // SAFETY: This Chromium-only story checks that both reflected properties exist before use.
+    const reflectedDialog = dialog as HTMLElement & {
+      ariaLabelledByElements?: readonly Element[];
+      ariaDescribedByElements?: readonly Element[];
+    };
+    if (!reflectedDialog.ariaLabelledByElements || !reflectedDialog.ariaDescribedByElements) {
+      throw new Error('Chromium did not expose the dialog ARIA element relationships');
+    }
+    void expect(reflectedDialog.ariaLabelledByElements).toEqual([title]);
+    void expect(reflectedDialog.ariaDescribedByElements).toEqual([description]);
+
+    await waitFor(() => {
+      const focused = root.activeElement;
+      void expect(focused !== null && dialog.contains(focused)).toBe(true);
+    });
+
+    const hiddenWrapper = canvasElement.ownerDocument.createElement('div');
+    hiddenWrapper.style.display = 'none';
+    const hiddenButton = canvasElement.ownerDocument.createElement('button');
+    hiddenButton.textContent = 'Hidden decoy';
+    hiddenWrapper.append(hiddenButton);
+    dialog.append(hiddenWrapper);
+
+    const dialogButtons = Array.from(
+      dialog.querySelectorAll<HTMLButtonElement>('button[data-slot="button"]'),
+    );
+    void expect(dialogButtons).toHaveLength(2);
+    const [confirmButton, declineButton] = dialogButtons;
+    if (!confirmButton || !declineButton) throw new Error('sign-in dialog actions not rendered');
+
+    const negativeTabIndexButton = canvasElement.ownerDocument.createElement('button');
+    negativeTabIndexButton.tabIndex = -2;
+    negativeTabIndexButton.textContent = 'Programmatic-only control';
+    const firstRadio = canvasElement.ownerDocument.createElement('input');
+    firstRadio.type = 'radio';
+    firstRadio.name = 'shadow-dialog-story-choice';
+    firstRadio.checked = true;
+    firstRadio.setAttribute('aria-label', 'First choice');
+    const secondRadio = canvasElement.ownerDocument.createElement('input');
+    secondRadio.type = 'radio';
+    secondRadio.name = 'shadow-dialog-story-choice';
+    secondRadio.setAttribute('aria-label', 'Second choice');
+    confirmButton.after(negativeTabIndexButton, firstRadio, secondRadio);
+
+    confirmButton.focus();
+    await userEvent.tab();
+    void expect(root.activeElement).toBe(firstRadio);
+    await userEvent.tab();
+    void expect(root.activeElement).toBe(declineButton);
+    await userEvent.tab();
+    await waitFor(() => void expect(root.activeElement).toBe(confirmButton));
+    await userEvent.tab({ shift: true });
+    await waitFor(() => void expect(root.activeElement).toBe(declineButton));
+    void expect(root.activeElement).not.toBe(negativeTabIndexButton);
+    void expect(root.activeElement).not.toBe(secondRadio);
+
+    void expect(getComputedStyle(outsideControl).pointerEvents).toBe('none');
+
+    outsideControl.focus();
+    await waitFor(() => {
+      const focused = root.activeElement;
+      void expect(focused !== null && dialog.contains(focused)).toBe(true);
+    });
+    void expect(canvasElement.ownerDocument.activeElement).not.toBe(outsideControl);
+
+    void expect(insideControl.closest('[inert]')).not.toBeNull();
+
+    insideControl.focus();
+    void expect(root.activeElement).not.toBe(insideControl);
+
+    const overlay = dialog.previousElementSibling;
+    if (!(overlay instanceof HTMLElement)) throw new Error('dialog overlay not rendered');
+    const overlayRect = overlay.getBoundingClientRect();
+    const clippingRect = clippingContainer.getBoundingClientRect();
+    const viewport = canvasElement.ownerDocument.defaultView;
+    if (!viewport) throw new Error('story window not available');
+    void expect(overlayRect.width).toBeGreaterThanOrEqual(viewport.innerWidth - 1);
+    void expect(overlayRect.height).toBeGreaterThanOrEqual(viewport.innerHeight - 1);
+    const sampleX =
+      clippingRect.right + 4 < viewport.innerWidth ? clippingRect.right + 4 : clippingRect.left - 4;
+    const sampleY = Math.min(viewport.innerHeight - 4, Math.max(4, clippingRect.top + 4));
+    const escapedHit = root.elementFromPoint(sampleX, sampleY);
+    void expect(
+      escapedHit === overlay || (escapedHit !== null && overlay.contains(escapedHit)),
+    ).toBe(true);
+
+    const dialogStyles = styleSnapshot(dialog);
+    const overlayStyles = styleSnapshot(overlay);
+    const hostileStyle = canvasElement.ownerDocument.createElement('style');
+    hostileStyle.textContent = `
+      button, [role='dialog'], [data-state='open'] {
+        background: rgb(185, 28, 28) !important;
+        border: 10px dashed lime !important;
+        border-radius: 0 !important;
+        color: yellow !important;
+        font: 32px/1 fantasy !important;
+        padding: 40px !important;
+        position: static !important;
+      }
+    `;
+    try {
+      canvasElement.ownerDocument.head.append(hostileStyle);
+      await waitFor(
+        () =>
+          void expect(getComputedStyle(outsideControl).backgroundColor).toBe('rgb(185, 28, 28)'),
+      );
+      void expect(styleSnapshot(dialog)).toEqual(dialogStyles);
+      void expect(styleSnapshot(overlay)).toEqual(overlayStyles);
+    } finally {
+      hostileStyle.remove();
+    }
+
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => {
+      void expect(dialog).toHaveAttribute('data-state', 'closed');
+      void expect(topLayer).toContainElement(dialog);
+      void expect(contentWrapper.inert).toBe(true);
+      void expect(getComputedStyle(outsideControl).pointerEvents).toBe('none');
+      void expect(topLayer.matches(':popover-open')).toBe(true);
+    });
+    outsideControl.focus();
+    await waitFor(() => {
+      const focused = root.activeElement;
+      void expect(focused !== null && dialog.contains(focused)).toBe(true);
+    });
+    void expect(canvasElement.ownerDocument.activeElement).not.toBe(outsideControl);
+    await waitFor(() => {
+      void expect(topLayer.querySelector('[role="dialog"]')).toBeNull();
+      void expect(topLayer.querySelector('[data-slot="dialog-overlay"]')).not.toBeNull();
+      void expect(contentWrapper.inert).toBe(true);
+      void expect(root.activeElement).toBe(overlay);
+    });
+    await waitFor(() => {
+      void expect(topLayer.childElementCount).toBe(0);
+      void expect(topLayer.matches(':popover-open')).toBe(false);
+      void expect(contentWrapper.inert).toBe(false);
+      void expect(root.activeElement).toBe(insideControl);
+    });
+
+    await userEvent.click(outsideControl);
+    const reopenedDialog = await waitFor(() => {
+      const element = root.querySelector<HTMLElement>('[role="dialog"]');
+      if (!element) throw new Error('dialog did not reopen');
+      return element;
+    });
+    const reopenedOverlay = reopenedDialog.previousElementSibling;
+    if (!(reopenedOverlay instanceof HTMLElement)) {
+      throw new Error('reopened dialog overlay not rendered');
+    }
+    await userEvent.click(reopenedOverlay);
+    await waitFor(() => {
+      void expect(reopenedDialog).toHaveAttribute('data-state', 'closed');
+      void expect(contentWrapper.inert).toBe(true);
+      void expect(getComputedStyle(outsideControl).pointerEvents).toBe('none');
+      void expect(topLayer.matches(':popover-open')).toBe(true);
+    });
+    outsideControl.focus();
+    await waitFor(() => {
+      const focused = root.activeElement;
+      void expect(focused !== null && reopenedDialog.contains(focused)).toBe(true);
+    });
+    void expect(canvasElement.ownerDocument.activeElement).not.toBe(outsideControl);
+    await waitFor(() => {
+      void expect(topLayer.querySelector('[role="dialog"]')).toBeNull();
+      void expect(topLayer.querySelector('[data-slot="dialog-overlay"]')).not.toBeNull();
+      void expect(contentWrapper.inert).toBe(true);
+      void expect(root.activeElement).toBe(reopenedOverlay);
+    });
+    outsideControl.focus();
+    await waitFor(() => {
+      void expect(canvasElement.ownerDocument.activeElement).not.toBe(outsideControl);
+      void expect(root.activeElement).toBe(reopenedOverlay);
+    });
+    await waitFor(() => {
+      void expect(topLayer.childElementCount).toBe(0);
+      void expect(topLayer.matches(':popover-open')).toBe(false);
+      void expect(contentWrapper.inert).toBe(false);
+      void expect(canvasElement.ownerDocument.activeElement).toBe(outsideControl);
+    });
+    exitAnimationStyle.remove();
+  },
+};

--- a/packages/ui/src/components/ui/dialog.test.tsx
+++ b/packages/ui/src/components/ui/dialog.test.tsx
@@ -1,0 +1,130 @@
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { ShadowRootHost } from '@/lib/shadow-root-host';
+import { requireShadowRoot } from '@/test/dom-stubs';
+import { Dialog, DialogContent, DialogTitle } from './dialog';
+
+describe('Dialog shadow portal coordination', () => {
+  it('preserves controlled and uncontrolled Radix behavior without a shadow portal', async () => {
+    const defaultOpenRender = render(
+      <Dialog defaultOpen>
+        <DialogContent>
+          <DialogTitle>Uncontrolled title</DialogTitle>
+          <button type="button">Inside</button>
+        </DialogContent>
+      </Dialog>,
+    );
+    await waitFor(() => {
+      expect(document.body.querySelector('[role="dialog"]')).toHaveTextContent(
+        'Uncontrolled title',
+      );
+    });
+    defaultOpenRender.unmount();
+
+    const onOpenChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Dialog open onOpenChange={onOpenChange}>
+        <DialogContent>
+          <DialogTitle>Controlled title</DialogTitle>
+          <button type="button">Inside</button>
+        </DialogContent>
+      </Dialog>,
+    );
+    await user.keyboard('{Escape}');
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(document.body.querySelector('[role="dialog"]')).toHaveTextContent('Controlled title');
+  });
+
+  it('renders initially open content in its component shadow root', async () => {
+    const { container } = render(
+      <ShadowRootHost portalStrategy="local-inline">
+        <Dialog open>
+          <DialogContent>
+            <DialogTitle>Title</DialogTitle>
+          </DialogContent>
+        </Dialog>
+      </ShadowRootHost>,
+    );
+
+    const shadowRoot = requireShadowRoot(container);
+    await waitFor(() => {
+      expect(shadowRoot.querySelector('[role="dialog"]')).not.toBeNull();
+    });
+    expect(document.body.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it('keeps sibling shadow content inert until all modal DOM unmounts', async () => {
+    const { container, rerender } = render(
+      <ShadowRootHost portalStrategy="local-inline">
+        <button type="button">Background</button>
+        <Dialog open>
+          <DialogContent>
+            <DialogTitle>Title</DialogTitle>
+          </DialogContent>
+        </Dialog>
+      </ShadowRootHost>,
+    );
+
+    const shadowRoot = requireShadowRoot(container);
+    const wrapper = shadowRoot.querySelector<HTMLElement>('[data-yv-shadow-content-wrapper]');
+    expect(wrapper).not.toBeNull();
+    await waitFor(() => {
+      expect(shadowRoot.querySelector('[role="dialog"]')).not.toBeNull();
+      expect(wrapper?.inert).toBe(true);
+    });
+
+    rerender(
+      <ShadowRootHost portalStrategy="local-inline">
+        <button type="button">Background</button>
+        <Dialog open={false}>
+          <DialogContent>
+            <DialogTitle>Title</DialogTitle>
+          </DialogContent>
+        </Dialog>
+      </ShadowRootHost>,
+    );
+
+    await waitFor(() => {
+      expect(shadowRoot.querySelector('[role="dialog"]')).toBeNull();
+    });
+    expect(wrapper?.inert).toBe(false);
+  });
+
+  it('redirects a programmatic focus escape back into an open modal dialog', async () => {
+    const { container } = render(
+      <>
+        <button type="button" data-testid="outside">
+          Outside
+        </button>
+        <ShadowRootHost portalStrategy="local-inline">
+          <Dialog open>
+            <DialogContent>
+              <DialogTitle>Title</DialogTitle>
+              <button type="button">Inside</button>
+            </DialogContent>
+          </Dialog>
+        </ShadowRootHost>
+      </>,
+    );
+
+    const shadowRoot = requireShadowRoot(container);
+    const dialog = await waitFor(() => {
+      const element = shadowRoot.querySelector<HTMLElement>('[role="dialog"]');
+      if (!element) throw new Error('dialog not rendered');
+      return element;
+    });
+    const outside = container.querySelector<HTMLButtonElement>('[data-testid="outside"]');
+    expect(outside).not.toBeNull();
+
+    outside?.focus();
+
+    await waitFor(() => {
+      const focused = shadowRoot.activeElement;
+      expect(focused !== null && dialog.contains(focused)).toBe(true);
+    });
+    expect(document.activeElement).not.toBe(outside);
+  });
+});

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -1,9 +1,51 @@
 import * as React from 'react';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 
-import { cn } from '../../lib/utils';
+import { cn } from '@/lib/utils';
+import { useShadowDialogFocus } from './use-shadow-dialog-focus';
+import { useShadowPortalState } from './use-shadow-portal-state';
 
-const Dialog = DialogPrimitive.Root;
+interface DialogPortalState {
+  container: HTMLElement | null | undefined;
+  modal: boolean;
+  open: boolean;
+}
+
+const DialogPortalContext = React.createContext<DialogPortalState>({
+  container: undefined,
+  modal: true,
+  open: false,
+});
+
+function Dialog({
+  open,
+  defaultOpen,
+  modal = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>): React.ReactNode {
+  const portal = useShadowPortalState({
+    open,
+    defaultOpen,
+    onOpenChange: (value) => props.onOpenChange?.(value),
+  });
+  const portalState = React.useMemo<DialogPortalState>(
+    () => ({ container: portal.container, modal, open: portal.open }),
+    [modal, portal.container, portal.open],
+  );
+
+  return (
+    <DialogPortalContext.Provider value={portalState}>
+      <DialogPrimitive.Root
+        data-slot="dialog"
+        modal={modal}
+        {...props}
+        open={portal.open}
+        onOpenChange={portal.onOpenChange}
+      />
+    </DialogPortalContext.Provider>
+  );
+}
+
 const DialogTitle = DialogPrimitive.Title;
 const DialogDescription = DialogPrimitive.Description;
 
@@ -22,11 +64,38 @@ function DialogContent({
   className,
   theme = 'light',
   children,
+  onCloseAutoFocus,
+  ref,
   ...props
-}: DialogContentProps): React.ReactElement {
+}: DialogContentProps): React.ReactNode {
+  const portal = React.useContext(DialogPortalContext);
+  const [overlayNode, setOverlayNode] = React.useState<HTMLDivElement | null>(null);
+  const [contentNode, setContentNode] = React.useState<HTMLDivElement | null>(null);
+  const contentRef = React.useCallback(
+    (node: HTMLDivElement | null): void => {
+      setContentNode(node);
+      if (!ref) return;
+      if ('current' in ref) ref.current = node;
+      else ref(node);
+    },
+    [ref],
+  );
+  const shadowFocus = useShadowDialogFocus({
+    container: portal.container,
+    content: contentNode,
+    modal: portal.modal,
+    open: portal.open,
+    overlay: overlayNode,
+  });
+
+  if (portal.open && portal.container === null) return null;
+
   return (
-    <DialogPrimitive.Portal>
+    <DialogPrimitive.Portal container={portal.container ?? undefined}>
       <DialogPrimitive.Overlay
+        ref={setOverlayNode}
+        data-slot="dialog-overlay"
+        tabIndex={-1}
         className={cn(
           'yv:fixed yv:inset-0 yv:z-50 yv:bg-black/50',
           'yv:data-[state=open]:animate-in yv:data-[state=closed]:animate-out',
@@ -34,8 +103,13 @@ function DialogContent({
         )}
       />
       <DialogPrimitive.Content
+        ref={contentRef}
         data-yv-sdk
         data-yv-theme={theme}
+        onCloseAutoFocus={(event) => {
+          onCloseAutoFocus?.(event);
+          shadowFocus.onCloseAutoFocus(event);
+        }}
         className={cn(
           'yv:fixed yv:left-1/2 yv:top-1/2 yv:z-50 yv:-translate-x-1/2 yv:-translate-y-1/2',
           'yv:w-[calc(100vw-2rem)] yv:max-w-sm',

--- a/packages/ui/src/components/ui/popover.tsx
+++ b/packages/ui/src/components/ui/popover.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import * as PopoverPrimitive from '@radix-ui/react-popover';
-import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { useTranslation } from 'react-i18next';
 import i18n from '@/i18n';
-import { useShadowPortalTarget } from '@/lib/shadow-root-host';
 import { Button } from './button';
+import { useShadowPortalState } from './use-shadow-portal-state';
 import { XIcon } from '../icons/x';
 
 import { cn } from '@/lib/utils';
@@ -25,23 +24,22 @@ function Popover({
   onOpenChange,
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Root>): React.ReactNode {
-  const [actualOpen, setActualOpen] = useControllableState({
-    prop: open,
-    defaultProp: defaultOpen ?? false,
-    onChange: onOpenChange,
+  const portal = useShadowPortalState({
+    open,
+    defaultOpen,
+    onOpenChange,
   });
-  const portalContainer = useShadowPortalTarget(actualOpen);
   const portalState = React.useMemo<PopoverPortalState>(
-    () => ({ container: portalContainer, open: actualOpen }),
-    [actualOpen, portalContainer],
+    () => ({ container: portal.container, open: portal.open }),
+    [portal.container, portal.open],
   );
 
   return (
     <PopoverPortalContext.Provider value={portalState}>
       <PopoverPrimitive.Root
         data-slot="popover"
-        open={actualOpen}
-        onOpenChange={setActualOpen}
+        open={portal.open}
+        onOpenChange={portal.onOpenChange}
         {...props}
       />
     </PopoverPortalContext.Provider>

--- a/packages/ui/src/components/ui/use-shadow-dialog-focus.ts
+++ b/packages/ui/src/components/ui/use-shadow-dialog-focus.ts
@@ -1,0 +1,150 @@
+import * as React from 'react';
+import { tabbable } from 'tabbable';
+
+import {
+  getOwnShadowRoot,
+  isElementFromOwnerDocument,
+  useShadowModalPresence,
+} from '@/lib/shadow-root-host';
+
+interface ShadowDialogFocusOptions {
+  container: HTMLElement | null | undefined;
+  content: HTMLElement | null;
+  modal: boolean;
+  open: boolean;
+  overlay: HTMLElement | null;
+}
+
+interface ShadowDialogFocus {
+  onCloseAutoFocus: (event: Event) => void;
+}
+
+function useShadowDialogFocusContainment(
+  active: boolean,
+  content: HTMLElement | null,
+  overlay: HTMLElement | null,
+): void {
+  const lastFocusedElementRef = React.useRef<Element | null>(null);
+  const hadContentRef = React.useRef(false);
+
+  React.useLayoutEffect(() => {
+    const hadContent = hadContentRef.current;
+    if (!active) {
+      hadContentRef.current = false;
+      return;
+    }
+    if (content) hadContentRef.current = true;
+
+    const containmentTarget = content ?? overlay;
+    if (!containmentTarget || !getOwnShadowRoot(containmentTarget)) return;
+
+    if (!content && hadContent) containmentTarget.focus();
+
+    const redirectFocus = (): void => {
+      const remembered = lastFocusedElementRef.current;
+      if (
+        content &&
+        isElementFromOwnerDocument(remembered, content, 'HTMLElement') &&
+        remembered.isConnected &&
+        content.contains(remembered)
+      ) {
+        remembered.focus();
+        return;
+      }
+
+      containmentTarget.focus();
+    };
+
+    const handleFocusIn = (event: FocusEvent): void => {
+      const [realTarget] = event.composedPath();
+      if (!isElementFromOwnerDocument(realTarget, containmentTarget, 'Element')) return;
+
+      if (content?.contains(realTarget)) {
+        lastFocusedElementRef.current = realTarget;
+        return;
+      }
+      if (!content && realTarget === overlay) return;
+
+      redirectFocus();
+    };
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key !== 'Tab' || event.defaultPrevented || !content) return;
+
+      const candidates = tabbable(content, { getShadowRoot: true });
+      if (candidates.length === 0) {
+        event.preventDefault();
+        content.focus();
+        return;
+      }
+
+      const [realTarget] = event.composedPath();
+      const currentIndex = candidates.findIndex((candidate) => candidate === realTarget);
+      let nextIndex = 0;
+      if (event.shiftKey) {
+        nextIndex = currentIndex <= 0 ? candidates.length - 1 : currentIndex - 1;
+      } else if (currentIndex !== -1 && currentIndex !== candidates.length - 1) {
+        nextIndex = currentIndex + 1;
+      }
+
+      event.preventDefault();
+      candidates[nextIndex]?.focus();
+    };
+
+    const ownerDocument = containmentTarget.ownerDocument;
+    ownerDocument.addEventListener('focusin', handleFocusIn);
+    content?.addEventListener('keydown', handleKeyDown);
+    return () => {
+      ownerDocument.removeEventListener('focusin', handleFocusIn);
+      content?.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [active, content, overlay]);
+}
+
+/** @internal Owns the Shadow DOM-specific modal focus lifecycle for Dialog. */
+export function useShadowDialogFocus({
+  container,
+  content,
+  modal,
+  open,
+  overlay,
+}: ShadowDialogFocusOptions): ShadowDialogFocus {
+  const modalPresent = modal && (overlay !== null || content !== null);
+  useShadowDialogFocusContainment(modalPresent, content, overlay);
+  const restoreFocusWhenModalReleased = useShadowModalPresence(modalPresent);
+  const restoreFocusRef = React.useRef<HTMLElement | null>(null);
+  const capturedRestoreFocusRef = React.useRef(false);
+
+  React.useLayoutEffect(() => {
+    if (!open) {
+      capturedRestoreFocusRef.current = false;
+      return;
+    }
+    if (!container || capturedRestoreFocusRef.current) return;
+
+    const shadowRoot = getOwnShadowRoot(container);
+    const activeElement = shadowRoot
+      ? (shadowRoot.activeElement ?? container.ownerDocument.activeElement)
+      : container.ownerDocument.activeElement;
+    if (isElementFromOwnerDocument(activeElement, container, 'HTMLElement')) {
+      restoreFocusRef.current = activeElement;
+    }
+    capturedRestoreFocusRef.current = true;
+  }, [container, open]);
+
+  const onCloseAutoFocus = React.useCallback(
+    (event: Event): void => {
+      if (event.defaultPrevented || container === undefined) return;
+
+      event.preventDefault();
+      const restoreFocusTo = restoreFocusRef.current;
+      restoreFocusRef.current = null;
+      if (restoreFocusTo && restoreFocusWhenModalReleased) {
+        restoreFocusWhenModalReleased(restoreFocusTo);
+      }
+    },
+    [container, restoreFocusWhenModalReleased],
+  );
+
+  return { onCloseAutoFocus };
+}

--- a/packages/ui/src/components/ui/use-shadow-portal-state.ts
+++ b/packages/ui/src/components/ui/use-shadow-portal-state.ts
@@ -1,0 +1,30 @@
+import { useControllableState } from '@radix-ui/react-use-controllable-state';
+import { useShadowPortalTarget } from '@/lib/shadow-root-host';
+
+interface ShadowPortalStateOptions {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+interface ShadowPortalState {
+  container: HTMLElement | null | undefined;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/** @internal Keeps a Radix primitive's open state synchronized with its shadow portal. */
+export function useShadowPortalState({
+  open,
+  defaultOpen,
+  onOpenChange,
+}: ShadowPortalStateOptions): ShadowPortalState {
+  const [actualOpen, setActualOpen] = useControllableState({
+    prop: open,
+    defaultProp: defaultOpen ?? false,
+    onChange: onOpenChange,
+  });
+  const container = useShadowPortalTarget(actualOpen);
+
+  return { container, open: actualOpen, onOpenChange: setActualOpen };
+}

--- a/packages/ui/src/lib/shadow-root-host.tsx
+++ b/packages/ui/src/lib/shadow-root-host.tsx
@@ -23,6 +23,8 @@ interface ShadowPortalController {
   container: HTMLElement | null;
   prepareOpen: (instanceId: string) => void;
   requestClose: (instanceId: string) => void;
+  setModalPresent: (instanceId: string, present: boolean) => void;
+  restoreFocusWhenModalReleased: (target: HTMLElement) => void;
 }
 
 const ShadowPortalContext = createContext<ShadowPortalController | null>(null);
@@ -46,6 +48,45 @@ export function useShadowPortalTarget(open: boolean): HTMLElement | null | undef
   }, [instanceId, open, prepareOpen, requestClose]);
 
   return controller?.container;
+}
+
+/**
+ * @internal Keeps sibling shadow content inert while mounted modal UI is present
+ * and returns the host-owned focus restoration function.
+ */
+export function useShadowModalPresence(
+  present: boolean,
+): ShadowPortalController['restoreFocusWhenModalReleased'] | undefined {
+  const controller = useContext(ShadowPortalContext);
+  const instanceId = useId();
+  const setModalPresent = controller?.setModalPresent;
+
+  useLayoutEffect(() => {
+    if (!present || !setModalPresent) return;
+
+    setModalPresent(instanceId, true);
+    return () => setModalPresent(instanceId, false);
+  }, [instanceId, present, setModalPresent]);
+
+  return controller?.restoreFocusWhenModalReleased;
+}
+
+/** @internal Returns the node's own ShadowRoot, or null when it isn't attached inside one. */
+export function getOwnShadowRoot(node: Node): ShadowRoot | null {
+  const root = node.getRootNode();
+  const ShadowRootConstructor = node.ownerDocument?.defaultView?.ShadowRoot;
+  return ShadowRootConstructor && root instanceof ShadowRootConstructor ? root : null;
+}
+
+/** @internal Checks an Element subtype against the node's owner realm. */
+export function isElementFromOwnerDocument<Kind extends 'Element' | 'HTMLElement'>(
+  value: EventTarget | null | undefined,
+  node: Node,
+  kind: Kind,
+): value is Kind extends 'HTMLElement' ? HTMLElement : Element {
+  const ownerWindow = node.ownerDocument?.defaultView;
+  const ElementConstructor = ownerWindow?.[kind];
+  return Boolean(ElementConstructor && value instanceof ElementConstructor);
 }
 
 function getStyleSheetConstructor(root: ShadowRoot): typeof CSSStyleSheet | undefined {
@@ -98,6 +139,9 @@ export function ShadowRootHost({ children, portalStrategy }: ShadowRootHostProps
   const portalContainerRef = useRef<HTMLElement | null>(null);
   const portalObserverRef = useRef<MutationObserver | null>(null);
   const activePortalIdsRef = useRef(new Set<string>());
+  const contentWrapperRef = useRef<HTMLDivElement | null>(null);
+  const presentModalIdsRef = useRef(new Set<string>());
+  const pendingFocusTargetRef = useRef<HTMLElement | null>(null);
   const [shadowRoot, setShadowRoot] = useState<ShadowRoot | null>(null);
   const [portalContainer, setPortalContainer] = useState<HTMLElement | null>(null);
   const [needsStyleFallback, setNeedsStyleFallback] = useState(false);
@@ -177,12 +221,51 @@ export function ShadowRootHost({ children, portalStrategy }: ShadowRootHostProps
     [hideIfIdle],
   );
 
+  const setModalPresent = useCallback(
+    (instanceId: string, present: boolean): void => {
+      const ids = presentModalIdsRef.current;
+      if (present) ids.add(instanceId);
+      else ids.delete(instanceId);
+
+      const wrapper = contentWrapperRef.current;
+      if (wrapper) wrapper.inert = ids.size > 0;
+      if (ids.size > 0) return;
+
+      const target = pendingFocusTargetRef.current;
+      pendingFocusTargetRef.current = null;
+      if (target?.isConnected) target.focus();
+    },
+    [],
+  );
+
+  const restoreFocusWhenModalReleased = useCallback((target: HTMLElement): void => {
+    if (presentModalIdsRef.current.size > 0) {
+      pendingFocusTargetRef.current = target;
+      return;
+    }
+
+    if (target.isConnected) target.focus();
+  }, []);
+
   const portalController = useMemo<ShadowPortalController | null>(
     () =>
       portalStrategy
-        ? { container: portalContainer, prepareOpen, requestClose }
+        ? {
+            container: portalContainer,
+            prepareOpen,
+            requestClose,
+            setModalPresent,
+            restoreFocusWhenModalReleased,
+          }
         : null,
-    [portalContainer, portalStrategy, prepareOpen, requestClose],
+    [
+      portalContainer,
+      portalStrategy,
+      prepareOpen,
+      requestClose,
+      restoreFocusWhenModalReleased,
+      setModalPresent,
+    ],
   );
 
   useEffect(() => {
@@ -212,6 +295,9 @@ export function ShadowRootHost({ children, portalStrategy }: ShadowRootHostProps
       hidePopoverIfOpen(container);
       container?.remove();
       portalContainerRef.current = null;
+      presentModalIdsRef.current.clear();
+      pendingFocusTargetRef.current = null;
+      if (contentWrapperRef.current) contentWrapperRef.current.inert = false;
     };
   }, []);
 
@@ -226,7 +312,11 @@ export function ShadowRootHost({ children, portalStrategy }: ShadowRootHostProps
                 </style>
               ) : null}
               {/* Host selectors cannot reach this reset boundary. */}
-              <div style={{ all: 'initial', display: 'contents' }}>
+              <div
+                ref={contentWrapperRef}
+                data-yv-shadow-content-wrapper
+                style={{ all: 'initial', display: 'contents' }}
+              >
                 {children}
               </div>
             </ShadowPortalContext.Provider>,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,6 +259,9 @@ importers:
       react-i18next:
         specifier: ^17.0.0
         version: 17.0.2(i18next@26.0.4(typescript@7.0.2))(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(typescript@7.0.2)
+      tabbable:
+        specifier: 6.5.0
+        version: 6.5.0
       tailwind-merge:
         specifier: 3.3.1
         version: 3.3.1
@@ -6071,6 +6074,9 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tabbable@6.5.0:
+    resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
 
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
@@ -12452,6 +12458,8 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   symbol-tree@3.2.4: {}
+
+  tabbable@6.5.0: {}
 
   tagged-tag@1.0.0: {}
 


### PR DESCRIPTION
## Summary

- add shadow-local top-layer portal support for Radix Dialog while preserving resolved ARIA relationships and clipping escape
- coordinate modal DOM presence, background inertness, focus containment, exit-phase overlay focus, and delayed focus restoration
- use tabbable for browser-like Tab ordering inside shadow-root dialogs and share controlled portal state with Popover
- document the prototype boundaries and add a patch changeset

## Verification

- pnpm build
- pnpm lint
- pnpm test (1,231 tests)
- focused Chromium Shadow DOM dialog journey
- pnpm analyze
- git diff --check

Ticket: YPE-5310

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the opt-in ShadowRootHost prototype so Radix dialogs can use a shadow-local portal while coordinating inertness, focus containment, animated exit presence, and delayed focus restoration.

- Adds shared controlled portal state for Dialog and Popover.
- Adds modal-presence and focus-restoration coordination to ShadowRootHost.
- Adds shadow-dialog keyboard traversal using tabbable.
- Adds unit and Chromium Storybook coverage, an ADR update, a pinned runtime dependency, and a patch changeset.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no concrete changed-code failure was established in the supported shadow-dialog scenarios.

The implementation keeps ordinary dialogs on Radix’s existing portal and focus path, while the opt-in shadow path coordinates portal presence, inertness, focus containment, animated teardown, and restoration with focused unit and browser coverage.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/ui/src/components/ui/dialog.tsx | Wraps Radix Dialog state and portal placement, then connects shadow-specific focus behavior without changing the non-shadow portal fallback. |
| packages/ui/src/components/ui/use-shadow-dialog-focus.ts | Implements shadow-root modal focus containment, Tab traversal, opener capture, and delayed restoration; no concrete current-caller defect was established. |
| packages/ui/src/components/ui/use-shadow-portal-state.ts | Centralizes controlled or uncontrolled open state and lazy shadow-portal targeting for Dialog and Popover. |
| packages/ui/src/lib/shadow-root-host.tsx | Tracks mounted modal instances to coordinate wrapper inertness and focus restoration after animated portal nodes leave the DOM. |
| packages/ui/src/components/ui/popover.tsx | Reuses the shared portal-state hook while preserving the existing Radix Popover state contract. |
| packages/ui/src/components/sign-in-dialog.shadow-isolation.stories.tsx | Adds a Chromium integration journey covering ARIA relationships, clipping escape, focus cycling, inertness, dismissal, exit phases, and opener restoration. |
| packages/ui/src/components/ui/dialog.test.tsx | Adds unit coverage for ordinary Radix behavior, shadow-local rendering, modal inertness, and programmatic focus redirection. |
| packages/ui/package.json | Adds tabbable 6.5.0 as an exactly pinned runtime dependency with a matching lockfile entry. |
| docs/adr/0005-prototype-shadow-dom-style-isolation.md | Documents the validated Dialog behavior and explicitly limits the prototype to non-nested, non-competing overlays. |
| .changeset/validate-shadow-dialog.md | Records the UI package behavior change as a patch release. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Trigger
  participant Dialog
  participant Portal as Shadow portal
  participant Host as ShadowRootHost
  Trigger->>Dialog: Open
  Dialog->>Portal: Mount overlay and content
  Portal->>Host: Modal present
  Host->>Host: Make shadow content inert
  Dialog->>Dialog: Contain focus and cycle Tab
  Trigger->>Dialog: Dismiss
  Dialog->>Portal: Keep exit nodes mounted
  Dialog->>Host: Queue opener restoration
  Portal->>Host: Overlay and content unmounted
  Host->>Host: Remove inertness
  Host->>Trigger: Restore focus
```

<sub>Reviews (1): Last reviewed commit: ["feat(ui): validate shadow DOM dialog top..."](https://github.com/youversion/platform-sdk-react/commit/a5841fffd9b225e884ea3b25068387ea2dcbba96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57093167)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [React UI component library](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/react-ui.md)
- Knowledge Base — [Authentication and profile UI](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/ui-auth-profile.md)
- Knowledge Base — [Package delivery workflows](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/delivery-workflows.md)
</details>


<!-- /greptile_comment -->