### PR TITLE
fix(core): accept string expires_in from the token endpoint

### DIFF
--- a/.changeset/auth-expires-in-string.md
+++ b/.changeset/auth-expires-in-string.md
@@ -3,4 +3,4 @@
 '@youversion/platform-react-hooks': patch
 ---
 
-Sign-in no longer fails when the token endpoint returns `expires_in` as a string. Callback failures are also logged so a failed exchange is visible in the console.
+Sign-in no longer fails when the token endpoint returns `expires_in` as a string. Callback failures are logged in development so a failed exchange is visible in the console.

--- a/.changeset/auth-expires-in-string.md
+++ b/.changeset/auth-expires-in-string.md
@@ -1,0 +1,6 @@
+---
+'@youversion/platform-core': patch
+'@youversion/platform-react-hooks': patch
+---
+
+Sign-in no longer fails when the token endpoint returns `expires_in` as a string. Callback failures are also logged so a failed exchange is visible in the console.

--- a/examples/vite-react/src/components/navbar.tsx
+++ b/examples/vite-react/src/components/navbar.tsx
@@ -84,21 +84,11 @@ export function Navbar({ currentPage, onNavigate }: NavbarProps) {
               </Button>
             </div>
           ) : (
-            <div className="flex items-center gap-2">
-              {auth.error ? (
-                <span
-                  className="max-w-xs truncate text-sm text-destructive"
-                  title={auth.error.message}
-                >
-                  {auth.error.message}
-                </span>
-              ) : null}
-              <YouVersionAuthButton
-                size="short"
-                onAuthError={(err) => console.error('Auth error:', err)}
-                scopes={['profile', 'email']}
-              />
-            </div>
+            <YouVersionAuthButton
+              size="short"
+              onAuthError={(err) => console.error('Auth error:', err)}
+              scopes={['profile', 'email']}
+            />
           )}
 
           <ModeToggle />

--- a/examples/vite-react/src/components/navbar.tsx
+++ b/examples/vite-react/src/components/navbar.tsx
@@ -84,11 +84,21 @@ export function Navbar({ currentPage, onNavigate }: NavbarProps) {
               </Button>
             </div>
           ) : (
-            <YouVersionAuthButton
-              size="short"
-              onAuthError={(err) => console.error('Auth error:', err)}
-              scopes={['profile', 'email']}
-            />
+            <div className="flex items-center gap-2">
+              {auth.error ? (
+                <span
+                  className="max-w-xs truncate text-sm text-destructive"
+                  title={auth.error.message}
+                >
+                  {auth.error.message}
+                </span>
+              ) : null}
+              <YouVersionAuthButton
+                size="short"
+                onAuthError={(err) => console.error('Auth error:', err)}
+                scopes={['profile', 'email']}
+              />
+            </div>
           )}
 
           <ModeToggle />

--- a/packages/core/src/Users.ts
+++ b/packages/core/src/Users.ts
@@ -384,7 +384,11 @@ export class YouVersionAPIUsers {
 
       const responseText = await response.text();
 
-      const tokens = TokenExchangeResponseSchema.parse(JSON.parse(responseText));
+      const parsed = TokenExchangeResponseSchema.safeParse(JSON.parse(responseText));
+      if (!parsed.success) {
+        throw new Error(`Token exchange response was invalid: ${parsed.error.message}`);
+      }
+      const tokens = parsed.data;
 
       // Match Swift: union grants from (1) this URL, (2) stashed pre-code hop,
       // (3) token scope — then drop OIDC scopes before seeding the data-exchange

--- a/packages/core/src/__tests__/Users.test.ts
+++ b/packages/core/src/__tests__/Users.test.ts
@@ -13,7 +13,7 @@ const mockFetch = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promis
 
 type TokenJson = {
   access_token?: string;
-  expires_in?: number;
+  expires_in?: number | string;
   id_token?: string;
   refresh_token?: string;
   scope?: string;
@@ -37,11 +37,11 @@ function emptyResponse(status: number, statusText: string): Response {
 const MOCK_ID_TOKEN =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJlbWFpbCI6ImpvaG5AZXhhbXBsZS5jb20iLCJwcm9maWxlX3BpY3R1cmUiOiJodHRwczovL2V4YW1wbGUuY29tL2F2YXRhci5qcGcifQ.invalid-signature';
 
-/** Builds the token payload the /auth/token exchange returns; only `scope` varies per test. */
+/** Token body from `/auth/token`. `expires_in` is a string, matching the live endpoint. */
 function makeTokens(scope: string) {
   return {
     access_token: 'access-token-123',
-    expires_in: 3600,
+    expires_in: '3599',
     id_token: MOCK_ID_TOKEN,
     refresh_token: 'refresh-token-456',
     scope,

--- a/packages/core/src/schemas/auth.test.ts
+++ b/packages/core/src/schemas/auth.test.ts
@@ -38,4 +38,13 @@ it('accepts expires_in as a number or digit string and rejects other JSON values
   expect(
     TokenExchangeResponseSchema.safeParse({ ...exchangeFields, expires_in: ' ' }).success,
   ).toBe(false);
+  expect(TokenExchangeResponseSchema.safeParse({ ...exchangeFields, expires_in: 0 }).success).toBe(
+    false,
+  );
+  expect(
+    TokenExchangeResponseSchema.safeParse({ ...exchangeFields, expires_in: '0' }).success,
+  ).toBe(false);
+  expect(TokenExchangeResponseSchema.safeParse({ ...exchangeFields, expires_in: -1 }).success).toBe(
+    false,
+  );
 });

--- a/packages/core/src/schemas/auth.test.ts
+++ b/packages/core/src/schemas/auth.test.ts
@@ -1,0 +1,41 @@
+import { expect, it } from 'vitest';
+import { TokenExchangeResponseSchema, TokenRefreshResponseSchema } from './auth';
+
+const exchangeFields = {
+  access_token: 'access-token',
+  id_token: 'id-token',
+  refresh_token: 'refresh-token',
+  scope: 'openid',
+  token_type: 'Bearer',
+};
+
+it('accepts expires_in as a number or digit string and rejects other JSON values', () => {
+  expect(
+    TokenExchangeResponseSchema.parse({ ...exchangeFields, expires_in: 3600 }).expires_in,
+  ).toBe(3600);
+  expect(
+    TokenExchangeResponseSchema.parse({ ...exchangeFields, expires_in: '3599' }).expires_in,
+  ).toBe(3599);
+  expect(
+    TokenRefreshResponseSchema.parse({
+      access_token: 'access-token',
+      expires_in: '3599',
+      refresh_token: 'refresh-token',
+      scope: 'openid',
+      token_type: 'Bearer',
+    }).expires_in,
+  ).toBe(3599);
+
+  expect(
+    TokenExchangeResponseSchema.safeParse({ ...exchangeFields, expires_in: null }).success,
+  ).toBe(false);
+  expect(
+    TokenExchangeResponseSchema.safeParse({ ...exchangeFields, expires_in: false }).success,
+  ).toBe(false);
+  expect(TokenExchangeResponseSchema.safeParse({ ...exchangeFields, expires_in: '' }).success).toBe(
+    false,
+  );
+  expect(
+    TokenExchangeResponseSchema.safeParse({ ...exchangeFields, expires_in: ' ' }).success,
+  ).toBe(false);
+});

--- a/packages/core/src/schemas/auth.test.ts
+++ b/packages/core/src/schemas/auth.test.ts
@@ -47,4 +47,7 @@ it('accepts expires_in as a number or digit string and rejects other JSON values
   expect(TokenExchangeResponseSchema.safeParse({ ...exchangeFields, expires_in: -1 }).success).toBe(
     false,
   );
+  expect(
+    TokenExchangeResponseSchema.safeParse({ ...exchangeFields, expires_in: 1.5 }).success,
+  ).toBe(false);
 });

--- a/packages/core/src/schemas/auth.ts
+++ b/packages/core/src/schemas/auth.ts
@@ -23,10 +23,14 @@ export const IdTokenClaimsSchema = z.object({
 });
 export type IdTokenClaims = z.infer<typeof IdTokenClaimsSchema>;
 
+/** Seconds until expiry. Live `/auth/token` sends a digit string; mocks may send a number. */
+const TokenExpiresInSchema = z
+  .union([z.number(), z.string().regex(/^\d+$/).transform(Number)])
+  .pipe(z.number().finite());
+
 export const TokenExchangeResponseSchema = z.object({
   access_token: z.string(),
-  // Live `/auth/token` (and the platform docs) send this as a string.
-  expires_in: z.coerce.number(),
+  expires_in: TokenExpiresInSchema,
   id_token: z.string(),
   refresh_token: z.string(),
   scope: z.string(),
@@ -36,7 +40,7 @@ export type TokenExchangeResponse = z.infer<typeof TokenExchangeResponseSchema>;
 
 export const TokenRefreshResponseSchema = z.object({
   access_token: z.string(),
-  expires_in: z.coerce.number(),
+  expires_in: TokenExpiresInSchema,
   refresh_token: z.string(),
   scope: z.string(),
   token_type: z.string(),

--- a/packages/core/src/schemas/auth.ts
+++ b/packages/core/src/schemas/auth.ts
@@ -26,7 +26,7 @@ export type IdTokenClaims = z.infer<typeof IdTokenClaimsSchema>;
 /** Seconds until expiry. Live `/auth/token` sends a digit string; mocks may send a number. */
 const TokenExpiresInSchema = z
   .union([z.number(), z.string().regex(/^\d+$/).transform(Number)])
-  .pipe(z.number().finite().positive());
+  .pipe(z.number().int().positive());
 
 export const TokenExchangeResponseSchema = z.object({
   access_token: z.string(),

--- a/packages/core/src/schemas/auth.ts
+++ b/packages/core/src/schemas/auth.ts
@@ -26,7 +26,7 @@ export type IdTokenClaims = z.infer<typeof IdTokenClaimsSchema>;
 /** Seconds until expiry. Live `/auth/token` sends a digit string; mocks may send a number. */
 const TokenExpiresInSchema = z
   .union([z.number(), z.string().regex(/^\d+$/).transform(Number)])
-  .pipe(z.number().finite());
+  .pipe(z.number().finite().positive());
 
 export const TokenExchangeResponseSchema = z.object({
   access_token: z.string(),

--- a/packages/core/src/schemas/auth.ts
+++ b/packages/core/src/schemas/auth.ts
@@ -25,7 +25,8 @@ export type IdTokenClaims = z.infer<typeof IdTokenClaimsSchema>;
 
 export const TokenExchangeResponseSchema = z.object({
   access_token: z.string(),
-  expires_in: z.number(),
+  // Live `/auth/token` (and the platform docs) send this as a string.
+  expires_in: z.coerce.number(),
   id_token: z.string(),
   refresh_token: z.string(),
   scope: z.string(),
@@ -35,7 +36,7 @@ export type TokenExchangeResponse = z.infer<typeof TokenExchangeResponseSchema>;
 
 export const TokenRefreshResponseSchema = z.object({
   access_token: z.string(),
-  expires_in: z.number(),
+  expires_in: z.coerce.number(),
   refresh_token: z.string(),
   scope: z.string(),
   token_type: z.string(),

--- a/packages/hooks/src/context/YouVersionAuthProvider.test.tsx
+++ b/packages/hooks/src/context/YouVersionAuthProvider.test.tsx
@@ -158,6 +158,7 @@ describe('YouVersionAuthProvider', () => {
       mockWindow.location.search = '?state=test-state&code=auth-code';
       const callbackError = new Error('Callback processing failed');
       vi.spyOn(YouVersionAPIUsers, 'handleAuthCallback').mockRejectedValue(callbackError);
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
       const { getByTestId } = render(
         <YouVersionAuthProvider config={mockConfig}>
@@ -170,6 +171,7 @@ describe('YouVersionAuthProvider', () => {
         expect(getByTestId('is-loading')).toHaveTextContent('false');
         expect(getByTestId('user-info')).toHaveTextContent('null');
       });
+      expect(errorSpy).toHaveBeenCalledWith('Auth callback failed:', callbackError);
     });
 
     it('tolerates the StrictMode double-invocation without a spurious error', async () => {

--- a/packages/hooks/src/context/YouVersionAuthProvider.test.tsx
+++ b/packages/hooks/src/context/YouVersionAuthProvider.test.tsx
@@ -171,7 +171,7 @@ describe('YouVersionAuthProvider', () => {
         expect(getByTestId('is-loading')).toHaveTextContent('false');
         expect(getByTestId('user-info')).toHaveTextContent('null');
       });
-      expect(errorSpy).toHaveBeenCalledWith('Auth callback failed:', callbackError);
+      expect(errorSpy).not.toHaveBeenCalledWith('Auth callback failed:', callbackError);
     });
 
     it('tolerates the StrictMode double-invocation without a spurious error', async () => {

--- a/packages/hooks/src/context/YouVersionAuthProvider.tsx
+++ b/packages/hooks/src/context/YouVersionAuthProvider.tsx
@@ -62,7 +62,9 @@ export default function YouVersionAuthProvider({
             }
           } catch (err) {
             if (!mounted) return;
-            setError(err instanceof Error ? err : new Error('Auth callback failed'));
+            const error = err instanceof Error ? err : new Error('Auth callback failed');
+            console.error('Auth callback failed:', error);
+            setError(error);
           }
         } else {
           // Check for existing token

--- a/packages/hooks/src/context/YouVersionAuthProvider.tsx
+++ b/packages/hooks/src/context/YouVersionAuthProvider.tsx
@@ -63,7 +63,9 @@ export default function YouVersionAuthProvider({
           } catch (err) {
             if (!mounted) return;
             const error = err instanceof Error ? err : new Error('Auth callback failed');
-            console.error('Auth callback failed:', error);
+            if (process.env.NODE_ENV === 'development') {
+              console.error('Auth callback failed:', error);
+            }
             setError(error);
           }
         } else {


### PR DESCRIPTION
## Summary
- Sign-in after the YouVersion portal was completing the code redirect, then dropping the session so the user stayed signed out with `?code=` still in the URL.

## Root cause
[#341](https://github.com/youversion/platform-sdk-react/pull/341) (`e9840fc5`) started validating `/auth/token` JSON with Zod and required `expires_in` to be a **number**.

Before that PR, the SDK `JSON.parse`’d the body and type-asserted it. A string like `"3599"` still worked at runtime (`"3599" * 1000`). After #341, Zod rejected the live payload, the exchange catch path cleared tokens, and the failure was easy to miss.

The live token endpoint (and the [platform docs](https://developers.youversion.com/sign-in-apis)) still send `expires_in` as a string. Tests only used a numeric fixture, so CI did not catch it.

## Solution
- Coerce `expires_in` to a number on both the token-exchange and token-refresh schemas.
- Surface a clear parse error instead of a raw Zod throw.
- Point the token-exchange test fixture at the live string shape.
- Log callback failures to the console so a failed exchange is visible.

## Test plan
- [ ] Sign in on `http://localhost:5173` (not `127.0.0.1`)
- [ ] After clicking your name on the YouVersion portal, land signed in (name + Sign out, no `?code=` in the URL)







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates token exchange and refresh validation to accept the live endpoint’s string-shaped `expires_in` while retaining strict validation.
- Adds a shared positive-integer expiry schema for numeric and digit-string values.
- Improves token-exchange validation errors and development callback diagnostics.
- Adds schema coverage and updates exchange fixtures to match the live response shape.
- Adds coordinated patch changesets for core and React hooks.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/core/src/schemas/auth.ts | Introduces a narrowly constrained positive-integer expiry schema shared by token exchange and refresh responses, resolving both prior findings. |
| packages/core/src/schemas/auth.test.ts | Covers numeric and digit-string expiry values and rejects malformed, non-positive, and fractional inputs. |
| packages/core/src/Users.ts | Uses safe parsing to provide a clearer token-exchange contract error while preserving validated token handling. |
| packages/hooks/src/context/YouVersionAuthProvider.tsx | Adds development-only callback error logging without changing the provider’s existing error state behavior. |
| packages/core/src/__tests__/Users.test.ts | Aligns token exchange fixtures and test typing with the live endpoint’s string expiry representation. |
| packages/hooks/src/context/YouVersionAuthProvider.test.tsx | Updates callback failure coverage for the development-only logging behavior. |
| .changeset/auth-expires-in-string.md | Records coordinated patch releases for the affected core and hooks packages. |

<sub>Reviews (4): Last reviewed commit: ["fix: require positive integer expires\_in..."](https://github.com/youversion/platform-sdk-react/commit/d2fd328822893394a26c7fa841c33b468a15a6b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57571161)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Core API clients and data contracts](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/core-api-data.md)
- Knowledge Base — [Authentication and storage](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/core-auth-storage.md)
- Knowledge Base — [Hook providers and authentication state](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/hooks-providers-auth.md)
- Knowledge Base — [Package delivery workflows](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/delivery-workflows.md)
</details>


<!-- /greptile_comment -->