### PR TITLE
fix(ui): harden Shadow DOM CSS isolation (YPE-5352)

### DIFF
--- a/.changeset/tidy-shadows-reset.md
+++ b/.changeset/tidy-shadows-reset.md
@@ -1,0 +1,5 @@
+---
+'@youversion/platform-react-ui': patch
+---
+
+Harden Shadow DOM style isolation so only text direction crosses the boundary and host custom properties cannot alter known SDK spacing or radius values.

--- a/docs/adr/0006-prototype-shadow-dom-style-isolation.md
+++ b/docs/adr/0006-prototype-shadow-dom-style-isolation.md
@@ -17,6 +17,15 @@ The SDK's compiled Tailwind CSS is installed inside the root, the light-DOM host
 receives a protected box reset, and an internal wrapper resets inherited visual
 properties.
 
+Writing direction is the only intentional inherited visual input: both reset
+boundaries explicitly preserve `direction`, while `all: initial` restores
+horizontal writing, mixed text orientation, SDK typography, and other visual
+properties. Vertical host writing modes and host typography are unsupported.
+Known ambient custom-property dependencies are closed by using SDK-owned
+`--yv-spacing` and `--yv-radius` values and by defining a local `--spacing`
+compatibility alias for `tw-animate-css`. YPE-5400 owns the full custom-property
+inventory and a compiled-CSS prevention guard.
+
 Constructable stylesheets are cached per owning `Document`, because a sheet from
 the top-level document cannot be adopted into a same-origin iframe's shadow
 root. Environments without constructable stylesheets receive a `<style>` element
@@ -63,9 +72,10 @@ host, isolated content appears after hydration, and forwarded refs become
 available later. Automatic isolation is therefore a breaking change rather than
 an internal implementation detail.
 
-Shadow DOM does not isolate document-scoped `@font-face` names or protect a
-component host from constraints applied to its ancestors. Open roots are a CSS
-boundary, not a security boundary.
+Shadow DOM does not isolate document-scoped `@font-face` names; the prototype
+accepts that host registrations can collide with SDK family names. It also
+cannot protect a component host from constraints applied to its ancestors. Open
+roots are a CSS boundary, not a security boundary.
 
 Concurrent independent overlays in one shadow root and nested overlays launched
 from an open dialog are unsupported until the package defines stacking, focus

--- a/docs/shadow-dom-isolation-plan.md
+++ b/docs/shadow-dom-isolation-plan.md
@@ -26,7 +26,7 @@ This is a working plan, not approval for package-wide rollout.
 
 | Area | Evidence today | Status | Remaining work |
 | --- | --- | --- | --- |
-| Host CSS isolation | Hostile-CSS demo and focused Chromium coverage exercise element selectors, inherited properties, universal `!important` rules, host attacks, and generated pseudo-content. | Validated for the prototype | Repeat against each component selected for rollout. |
+| Host CSS isolation | Hostile-CSS demo and focused Chromium coverage exercise element selectors, direction inheritance, vertical writing and typography resets, hostile custom properties, universal `!important` rules, host attacks, and generated pseudo-content. | Validated for the prototype | Repeat against each component selected for rollout. |
 | Component behavior | Auth button interaction works through the React portal; Strict Mode does not attach the root twice. | Validated for the prototype | Audit component-specific refs, events, and consumer integrations during rollout. |
 | Owner-document handling | Focused coverage mounts into a same-origin iframe and verifies document-compatible stylesheet construction. | Validated for the prototype | Verify stylesheet failure recovery. |
 | Inline floating content | The picker negative control preserves tree-scope relationships but demonstrates clipping beyond a constrained ancestor. | Validated as a negative control | None; clipping is why inline placement is not the selected escaping strategy. |
@@ -45,10 +45,10 @@ This is a working plan, not approval for package-wide rollout.
   root renders an empty host on the server and delays content and forwarded refs.
 - Define stacking, focus ownership, and dismissal contracts for nested or
   competing modal and non-modal overlays.
-- Complete a package-wide custom-property audit. `all: initial` does not reset
-  custom properties, and existing bare references such as
-  `BibleVersionPicker`'s `var(--spacing)` must be classified rather than fixed as
-  isolated symptoms.
+- Complete the package-wide custom-property inventory and prevention guard in
+  YPE-5400. The known `BibleVersionPicker`, `InputGroup`, and `tw-animate-css`
+  dependencies now resolve through locally-defined SDK-owned spacing and radius
+  values, but `all: initial` does not reset unknown custom properties.
 - Audit components that use Radix primitives directly instead of the shared
   wrappers. `VerseActionPopover` is a known direct Popover consumer.
 
@@ -56,8 +56,9 @@ This is a working plan, not approval for package-wide rollout.
 
 - Verify native form participation and external `label`, `aria-labelledby`, and
   `aria-describedby` relationships when controls cross tree scopes.
-- Define which inherited inputs are intentional, including writing direction,
-  writing mode, and any future consumer-provided custom properties.
+- Preserve `direction` as the only intentional inherited visual input. Vertical
+  writing modes, text orientation, host typography, and undeclared host custom
+  properties are not supported customization inputs.
 - Document event retargeting, nested-root behavior, supported customization, and
   shadow-aware consumer test and automation queries.
 - Verify stylesheet construction and adoption failure recovery beyond the
@@ -68,8 +69,9 @@ This is a working plan, not approval for package-wide rollout.
 ## Accepted boundaries and unresolved environment coverage
 
 - Host `@font-face` registrations are document-scoped and can collide with the
-  public font family names used inside a shadow root. Avoiding that requires
-  private family names and controlled font declarations.
+  public font family names used inside a shadow root. This limitation is
+  accepted for the prototype; avoiding it requires private family names and
+  controlled font declarations.
 - Shadow DOM cannot prevent a host from hiding, clipping, transforming, or
   constraining the component host or its ancestors.
 - Open shadow roots prevent CSS selector crossover; they do not prevent
@@ -81,7 +83,8 @@ This is a working plan, not approval for package-wide rollout.
 
 ## Rollout sequence
 
-1. Complete the custom-property and direct-Radix-consumer audits.
+1. Complete YPE-5400's custom-property inventory and prevention guard, plus the
+   direct-Radix-consumer audit.
 2. Resolve SSR/hydration, rollout-control, and overlay-ownership decisions.
 3. Select the next public component and add component-specific compatibility,
    browser, and accessibility coverage before enabling isolation.

--- a/packages/ui/src/components/bible-version-picker.shadow-isolation.stories.tsx
+++ b/packages/ui/src/components/bible-version-picker.shadow-isolation.stories.tsx
@@ -3,7 +3,7 @@ import { YouVersionProvider as HooksYouVersionProvider } from '@youversion/platf
 import { http, HttpResponse } from 'msw';
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { expect, userEvent, waitFor } from 'storybook/test';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 import { ShadowRootHost } from '../lib/shadow-root-host';
 import { requireShadowRoot } from '../test/dom-stubs';
 import { globalHandlers } from '../test/mocks/handlers';
@@ -159,6 +159,25 @@ function styleSnapshot(element: HTMLElement) {
     fontFamily: styles.fontFamily,
     fontSize: styles.fontSize,
     padding: styles.padding,
+  };
+}
+
+function geometrySnapshot(element: HTMLElement) {
+  return {
+    blockSize: element.offsetHeight,
+    inlineSize: element.offsetWidth,
+  };
+}
+
+function typographySnapshot(element: HTMLElement, ownerWindow: Window) {
+  const style = ownerWindow.getComputedStyle(element);
+  return {
+    color: style.color,
+    fontFamily: style.fontFamily,
+    fontSize: style.fontSize,
+    letterSpacing: style.letterSpacing,
+    lineHeight: style.lineHeight,
+    wordSpacing: style.wordSpacing,
   };
 }
 
@@ -365,6 +384,123 @@ export const StylingFocusDismissalAndRapidReopen: Story = {
       void expect(topLayer.matches(':popover-open')).toBe(false);
       void expect(root.activeElement).toBe(trigger);
     });
+  },
+};
+
+export const DirectionOnlyInheritanceRejectsHostVisualValues: Story = {
+  render: () => (
+    <div
+      data-testid="hostile-inheritance-container"
+      dir="rtl"
+      style={{ display: 'flex', alignItems: 'center', gap: 24 }}
+    >
+      <span data-testid="hostile-inheritance-control">Host control</span>
+      <IsolatedBibleVersionPicker />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const ownerDocument = canvasElement.ownerDocument;
+    const ownerWindow = ownerDocument.defaultView;
+    if (!ownerWindow) throw new Error('story owner window not available');
+
+    const hostControl = canvasElement.querySelector<HTMLElement>(
+      '[data-testid="hostile-inheritance-control"]',
+    );
+    if (!hostControl) throw new Error('hostile inheritance control not rendered');
+
+    const { root, trigger, panel } = await openPicker(canvasElement);
+    const wrapper = root.querySelector<HTMLElement>('[data-yv-shadow-content-wrapper]');
+    const heading = panel.querySelector<HTMLElement>('h2');
+    const inputGroup = panel.querySelector<HTMLElement>('[data-slot="input-group"]');
+    if (!wrapper || !heading || !inputGroup) throw new Error('picker landmarks not rendered');
+
+    const triggerGeometry = geometrySnapshot(trigger);
+    const panelGeometry = geometrySnapshot(panel);
+    const inputGeometry = geometrySnapshot(inputGroup);
+    const headingTypography = typographySnapshot(heading, ownerWindow);
+    void expect(headingTypography.fontFamily).toContain('Inter');
+    void expect(ownerWindow.getComputedStyle(trigger).direction).toBe('rtl');
+    void expect(ownerWindow.getComputedStyle(wrapper).direction).toBe('rtl');
+
+    await userEvent.click(within(panel).getByRole('button', { name: /select language/i }));
+    const languageTabs = await waitForElement<HTMLElement>(
+      panel,
+      '[data-slot="tabs-list"]',
+      'language tabs did not render',
+    );
+    const languageTabsContainer = languageTabs.parentElement;
+    const languageContent = languageTabs.closest<HTMLElement>('[data-yv-sdk]');
+    const languageInputGroup = languageContent?.querySelector<HTMLElement>(
+      '[data-slot="input-group"]',
+    );
+    if (!languageTabsContainer || !languageInputGroup) {
+      throw new Error('language panel geometry landmarks not rendered');
+    }
+    const languageTabsInlineSize = languageTabs.offsetWidth;
+    const languageInputRadius = ownerWindow.getComputedStyle(languageInputGroup).borderRadius;
+    void expect(languageTabsInlineSize).toBe(languageTabsContainer.clientWidth - 32);
+    void expect(languageInputRadius).toBe('30px');
+
+    const hostileStyle = ownerDocument.createElement('style');
+    hostileStyle.textContent = `
+      [data-testid='hostile-inheritance-container'] {
+        --spacing: 6rem;
+        --yv-spacing: 6rem;
+        --radius: 0;
+        --yv-radius: 0;
+        writing-mode: vertical-rl;
+        text-orientation: upright;
+        color: rgb(185, 28, 28);
+        font-family: fantasy;
+        font-size: 32px;
+        letter-spacing: 0.5em;
+        line-height: 3;
+        word-spacing: 1em;
+      }
+
+      [data-testid='hostile-inheritance-control'] {
+        border-radius: var(--radius);
+      }
+    `;
+
+    try {
+      ownerDocument.head.append(hostileStyle);
+      await waitFor(() => {
+        const controlStyle = ownerWindow.getComputedStyle(hostControl);
+        void expect(controlStyle.writingMode).toBe('vertical-rl');
+        void expect(controlStyle.textOrientation).toBe('upright');
+        void expect(controlStyle.color).toBe('rgb(185, 28, 28)');
+        void expect(controlStyle.fontFamily).toContain('fantasy');
+        void expect(controlStyle.fontSize).toBe('32px');
+        void expect(controlStyle.letterSpacing).toBe('16px');
+        void expect(controlStyle.lineHeight).toBe('96px');
+        void expect(controlStyle.wordSpacing).toBe('32px');
+        void expect(controlStyle.borderRadius).toBe('0px');
+      });
+
+      const wrapperStyle = ownerWindow.getComputedStyle(wrapper);
+      const headingStyle = ownerWindow.getComputedStyle(heading);
+      const panelStyle = ownerWindow.getComputedStyle(panel);
+      void expect(wrapperStyle.direction).toBe('rtl');
+      void expect(wrapperStyle.writingMode).toBe('horizontal-tb');
+      void expect(wrapperStyle.textOrientation).toBe('mixed');
+      void expect(headingStyle.direction).toBe('rtl');
+      void expect(headingStyle.writingMode).toBe('horizontal-tb');
+      void expect(headingStyle.textOrientation).toBe('mixed');
+      void expect(typographySnapshot(heading, ownerWindow)).toEqual(headingTypography);
+      void expect(panelStyle.getPropertyValue('--yv-spacing').trim()).toBe('.25rem');
+      void expect(panelStyle.getPropertyValue('--spacing').trim()).toBe('.25rem');
+      void expect(panelStyle.getPropertyValue('--yv-radius').trim()).toBe('2rem');
+      void expect(languageTabs.offsetWidth).toBe(languageTabsInlineSize);
+      void expect(ownerWindow.getComputedStyle(languageInputGroup).borderRadius).toBe(
+        languageInputRadius,
+      );
+      void expect(geometrySnapshot(trigger)).toEqual(triggerGeometry);
+      void expect(geometrySnapshot(panel)).toEqual(panelGeometry);
+      void expect(geometrySnapshot(inputGroup)).toEqual(inputGeometry);
+    } finally {
+      hostileStyle.remove();
+    }
   },
 };
 

--- a/packages/ui/src/components/bible-version-picker.tsx
+++ b/packages/ui/src/components/bible-version-picker.tsx
@@ -986,7 +986,7 @@ export function BibleLanguagePickerContent({
           value={languageTab}
           onValueChange={setLanguageTab}
         >
-          <TabsList className="yv:mx-4 yv:w-[calc(100%-4*var(--spacing)*2)]">
+          <TabsList className="yv:mx-4 yv:w-[calc(100%-4*var(--yv-spacing)*2)]">
             <TabsTrigger className="yv:p-0" value="suggested">
               {t('suggestedTab')}
             </TabsTrigger>

--- a/packages/ui/src/components/ui/input-group.test.tsx
+++ b/packages/ui/src/components/ui/input-group.test.tsx
@@ -3,15 +3,12 @@
  */
 import { render } from '@testing-library/react';
 import { expect, it } from 'vitest';
-import { InputGroup, InputGroupAddon, InputGroupInput } from './input-group';
+import { InputGroup, InputGroupAddon } from './input-group';
 
-it('keeps keyboard-hint radius independent of host custom properties', () => {
+it('uses --yv-radius for kbd rounding, not --radius', () => {
   const { container } = render(
     <InputGroup>
-      <InputGroupInput aria-label="Search" />
-      <InputGroupAddon>
-        <kbd>⌘K</kbd>
-      </InputGroupAddon>
+      <InputGroupAddon />
     </InputGroup>,
   );
   const addon = container.querySelector('[data-slot="input-group-addon"]');

--- a/packages/ui/src/components/ui/input-group.test.tsx
+++ b/packages/ui/src/components/ui/input-group.test.tsx
@@ -1,0 +1,21 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render } from '@testing-library/react';
+import { expect, it } from 'vitest';
+import { InputGroup, InputGroupAddon, InputGroupInput } from './input-group';
+
+it('keeps keyboard-hint radius independent of host custom properties', () => {
+  const { container } = render(
+    <InputGroup>
+      <InputGroupInput aria-label="Search" />
+      <InputGroupAddon>
+        <kbd>⌘K</kbd>
+      </InputGroupAddon>
+    </InputGroup>,
+  );
+  const addon = container.querySelector('[data-slot="input-group-addon"]');
+
+  expect(addon).toHaveClass('yv:[&>kbd]:rounded-[calc(var(--yv-radius)-5px)]');
+  expect(addon).not.toHaveClass('yv:[&>kbd]:rounded-[calc(var(--radius)-5px)]');
+});

--- a/packages/ui/src/components/ui/input-group.tsx
+++ b/packages/ui/src/components/ui/input-group.tsx
@@ -33,7 +33,7 @@ function InputGroup({ className, ...props }: React.ComponentProps<'div'>): React
 }
 
 const inputGroupAddonVariants = cva(
-  'yv:text-muted-foreground yv:flex yv:h-auto yv:cursor-text yv:items-center yv:justify-center yv:gap-2 yv:py-1.5 yv:text-sm yv:font-medium yv:select-none yv:[&>svg:not([class*=size-])]:size-4 yv:[&>kbd]:rounded-[calc(var(--radius)-5px)] yv:group-data-[disabled=true]/input-group:opacity-50',
+  'yv:text-muted-foreground yv:flex yv:h-auto yv:cursor-text yv:items-center yv:justify-center yv:gap-2 yv:py-1.5 yv:text-sm yv:font-medium yv:select-none yv:[&>svg:not([class*=size-])]:size-4 yv:[&>kbd]:rounded-[calc(var(--yv-radius)-5px)] yv:group-data-[disabled=true]/input-group:opacity-50',
   {
     variants: {
       align: {

--- a/packages/ui/src/lib/shadow-root-host.test.tsx
+++ b/packages/ui/src/lib/shadow-root-host.test.tsx
@@ -32,7 +32,7 @@ describe('ShadowRootHost', () => {
     expect(host?.shadowRoot?.textContent).toContain('content');
   });
 
-  it('applies important inline declarations to stabilize the host box', () => {
+  it('stabilizes the host box while preserving only writing direction', () => {
     const { container } = render(
       <ShadowRootHost>
         <span>content</span>
@@ -40,16 +40,26 @@ describe('ShadowRootHost', () => {
     );
 
     const host = container.querySelector<HTMLElement>('[data-yv-shadow-host]');
+    const wrapper = host?.shadowRoot?.querySelector<HTMLElement>(
+      '[data-yv-shadow-content-wrapper]',
+    );
     expect(host).not.toBeNull();
+    expect(wrapper).not.toBeNull();
     expect(host?.style.getPropertyValue('all')).toBe('initial');
     expect(host?.style.getPropertyValue('display')).toBe('contents');
-    expect(host?.style.getPropertyValue('writing-mode')).toBe('inherit');
-    expect(host?.style.getPropertyValue('text-orientation')).toBe('inherit');
+    expect(host?.style.getPropertyValue('direction')).toBe('inherit');
+    expect(host?.style.getPropertyValue('writing-mode')).toBe('');
+    expect(host?.style.getPropertyValue('text-orientation')).toBe('');
+    expect(wrapper?.style.getPropertyValue('all')).toBe('initial');
+    expect(wrapper?.style.getPropertyValue('display')).toBe('contents');
+    expect(wrapper?.style.getPropertyValue('direction')).toBe('inherit');
+    expect(wrapper?.style.getPropertyValue('writing-mode')).toBe('');
+    expect(wrapper?.style.getPropertyValue('text-orientation')).toBe('');
 
     // jsdom's cssstyle backing does not track priority for `all`,
-    // `writing-mode`, or `text-orientation` (real browsers do), so only
-    // `display` can assert getPropertyPriority here. The value-only checks
-    // above still prove the other properties were set.
+    // or `direction` (real browsers do), so only `display` can assert
+    // getPropertyPriority here. The value-only checks above still prove
+    // direction was set.
     expect(host?.style.getPropertyPriority('display')).toBe('important');
   });
 

--- a/packages/ui/src/lib/shadow-root-host.test.tsx
+++ b/packages/ui/src/lib/shadow-root-host.test.tsx
@@ -56,7 +56,7 @@ describe('ShadowRootHost', () => {
     expect(wrapper?.style.getPropertyValue('writing-mode')).toBe('');
     expect(wrapper?.style.getPropertyValue('text-orientation')).toBe('');
 
-    // jsdom's cssstyle backing does not track priority for `all`,
+    // jsdom's cssstyle backing does not track priority for `all`
     // or `direction` (real browsers do), so only `display` can assert
     // getPropertyPriority here. The value-only checks above still prove
     // direction was set.

--- a/packages/ui/src/lib/shadow-root-host.tsx
+++ b/packages/ui/src/lib/shadow-root-host.tsx
@@ -116,8 +116,7 @@ function resetHost(host: HTMLDivElement): void {
   // Inline author-important declarations establish the smallest stable box.
   host.style.setProperty('all', 'initial', 'important');
   host.style.setProperty('display', 'contents', 'important');
-  host.style.setProperty('writing-mode', 'inherit', 'important');
-  host.style.setProperty('text-orientation', 'inherit', 'important');
+  host.style.setProperty('direction', 'inherit', 'important');
 }
 
 function hidePopoverIfOpen(container: HTMLElement | null): void {
@@ -315,7 +314,7 @@ export function ShadowRootHost({ children, portalStrategy }: ShadowRootHostProps
               <div
                 ref={contentWrapperRef}
                 data-yv-shadow-content-wrapper
-                style={{ all: 'initial', display: 'contents' }}
+                style={{ all: 'initial', direction: 'inherit', display: 'contents' }}
               >
                 {children}
               </div>

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -89,6 +89,10 @@ layer(yv-sdk-fonts);
 
 @layer yv-sdk-theme {
   [data-yv-sdk] {
+    /* Keep Tailwind and tw-animate-css spacing independent of host custom properties. */
+    --yv-spacing: 0.25rem;
+    --spacing: var(--yv-spacing);
+
     @theme inline {
       /* Untitled Serif is the brand serif, loaded from the gated Fonts API stylesheet
          endpoint by <YvFonts /> — see docs/adr/0004-adopt-untitled-serif-via-fonts-api.md.


### PR DESCRIPTION
## Summary

- Preserve only LTR/RTL direction across the Shadow DOM seam while resetting vertical writing and host typography.
- Close the known ambient spacing and radius dependencies with SDK-owned tokens and a local tw-animate-css compatibility alias.
- Document the direction-only contract, accepted font-face limitation, and YPE-5400 follow-up scope.
- Add focused Chromium coverage for hostile inherited styles, language-panel spacing, and representative picker radius.
- Add a focused rendered-class regression for the dormant InputGroup keyboard-hint radius selector.

## Verification

- UI unit tests: passed, 509/509.
- InputGroup keyboard-hint token regression: passed; restoring bare --radius fails the focused test.
- Focused Chromium Shadow DOM story: passed, 8/8.
- UI build: passed.
- Root lint: passed.
- Root typecheck: passed.
- Prettier and git diff check: passed.

## Known unrelated suite failures

- UI integration reached 562 passing tests, then failed on an existing ProfileAvatar story rendering issue and a BibleReader timeout.
- Root tests failed on two existing BibleReader five-second timeouts under workspace concurrency.

YPE-5352



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR narrows Shadow DOM visual inheritance to text direction and replaces known ambient spacing and radius dependencies with SDK-owned tokens.

- Resets host typography, writing mode, and text orientation while retaining LTR/RTL direction.
- Defines scoped spacing compatibility tokens and updates picker and keyboard-hint calculations.
- Adds focused unit and Chromium story coverage and documents the supported isolation contract.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/ui/src/lib/shadow-root-host.tsx | Replaces writing-mode and text-orientation inheritance with explicit direction preservation at the host and internal reset boundary. |
| packages/ui/src/styles/global.css | Adds SDK-scoped spacing and radius ownership needed to prevent known host custom-property interference. |
| packages/ui/src/components/bible-version-picker.tsx | Moves the language-tabs width calculation from the ambient spacing token to the SDK-owned token. |
| packages/ui/src/components/ui/input-group.tsx | Moves keyboard-hint rounding from the ambient radius token to the SDK-owned radius token. |
| packages/ui/src/components/bible-version-picker.shadow-isolation.stories.tsx | Adds browser coverage for direction-only inheritance, hostile typography and custom properties, stable geometry, spacing, and radius. |
| packages/ui/src/lib/shadow-root-host.test.tsx | Updates unit assertions to cover direction preservation and reset behavior on both isolation boundaries. |
| packages/ui/src/components/ui/input-group.test.tsx | Adds a rendered-class regression test for the keyboard-hint radius token. |
| .changeset/tidy-shadows-reset.md | Records the user-facing Shadow DOM isolation hardening as a UI patch release. |
| docs/adr/0006-prototype-shadow-dom-style-isolation.md | Documents the direction-only inheritance contract, token ownership, and accepted font-face limitation. |
| docs/shadow-dom-isolation-plan.md | Updates validation evidence and assigns the remaining custom-property inventory and prevention work to YPE-5400. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Host[Host document styles] --> Seam[Shadow host reset]
  Seam -->|direction only| Root[Shadow root]
  Root --> Wrapper[Reset content wrapper]
  Root --> Portal[Shadow-local portal]
  Tokens[SDK-owned spacing and radius tokens] --> Wrapper
  Tokens --> Portal
  Wrapper --> Content[SDK component content]
  Portal --> Overlay[Picker and dialog overlays]
```

<sub>Reviews (2): Last reviewed commit: ["test(ui): align input group radius asser..."](https://github.com/youversion/platform-sdk-react/commit/b294b1948e37a30417527efb7c19da2747e77433) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57686073)</sub>

**Context used:**

- Knowledge Base — [UI provider and styling system](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/ui-provider-styling.md)
- Knowledge Base — [Package delivery workflows](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/delivery-workflows.md)

<!-- /greptile_comment -->