### PR TITLE
Codex/app scoped permission cache

### DIFF
--- a/.changeset/scope-permissions-by-app-key.md
+++ b/.changeset/scope-permissions-by-app-key.md
@@ -4,4 +4,4 @@
 '@youversion/platform-react-ui': patch
 ---
 
-Scope cached grants and pending data-exchange state by app key as well as user, and keep the auth hook's access token current after callbacks and refreshes.
+Scope cached grants and pending data-exchange state by app key as well as user, keep the auth hook's access token current after callbacks and refreshes, and preserve server-accepted highlight overlays across provider remounts while read replicas converge.

--- a/.changeset/scope-permissions-by-app-key.md
+++ b/.changeset/scope-permissions-by-app-key.md
@@ -1,0 +1,7 @@
+---
+'@youversion/platform-core': patch
+'@youversion/platform-react-hooks': patch
+'@youversion/platform-react-ui': patch
+---
+
+Scope cached grants and pending data-exchange state by app key as well as user, and keep the auth hook's access token current after callbacks and refreshes.

--- a/packages/core/src/YouVersionPlatformConfiguration.ts
+++ b/packages/core/src/YouVersionPlatformConfiguration.ts
@@ -116,12 +116,22 @@ export class YouVersionPlatformConfiguration {
    * 401/403 on a permissioned request invalidates the relevant entry via
    * {@link removeGrantedPermission}.
    *
-   * The cache is scoped to the signed-in user: it is persisted as
-   * `{ userId, permissions }` and only read back when `userId` matches the
-   * current {@link storedUserInfo}. This prevents one user's grants from leaking
-   * to a later user who signs in without a {@link clearAuthTokens} in between.
+   * The cache is scoped to both the configured app key and signed-in user. Each
+   * app key gets a separate storage entry containing `{ userId, permissions }`,
+   * and that entry is only read back when `userId` matches the current
+   * {@link storedUserInfo}. This prevents one app or user from inheriting grants
+   * that belong to another session sharing the same origin.
    */
-  private static readonly grantedPermissionsKey = 'youversion-platform:granted-permissions';
+  private static readonly grantedPermissionsKeyPrefix = 'youversion-platform:granted-permissions';
+
+  private static scopedStorageKey(prefix: string): string | null {
+    const appKey = this.appKey?.trim();
+    return appKey ? `${prefix}:${encodeURIComponent(appKey)}` : null;
+  }
+
+  private static get grantedPermissionsKey(): string | null {
+    return this.scopedStorageKey(this.grantedPermissionsKeyPrefix);
+  }
 
   /** The id of the user the cache is scoped to, or `null` when signed out. */
   private static get currentUserId(): string | null {
@@ -133,7 +143,9 @@ export class YouVersionPlatformConfiguration {
    * malformed, or in the legacy bare-array format (which is treated as absent).
    */
   private static readStoredGrants(): { userId: string; permissions: string[] } | null {
-    const raw = getLocalStorage()?.getItem(this.grantedPermissionsKey);
+    const key = this.grantedPermissionsKey;
+    if (!key) return null;
+    const raw = getLocalStorage()?.getItem(key);
     if (!raw) return null;
     try {
       const parsed = StoredGrantsSchema.safeParse(JSON.parse(raw));
@@ -144,11 +156,9 @@ export class YouVersionPlatformConfiguration {
   }
 
   private static writeStoredGrants(userId: string, permissions: string[]): void {
-    setStorageItem(
-      getLocalStorage(),
-      this.grantedPermissionsKey,
-      JSON.stringify({ userId, permissions }),
-    );
+    const key = this.grantedPermissionsKey;
+    if (!key) return;
+    setStorageItem(getLocalStorage(), key, JSON.stringify({ userId, permissions }));
   }
 
   public static get grantedPermissions(): string[] {
@@ -180,7 +190,9 @@ export class YouVersionPlatformConfiguration {
   }
 
   public static clearGrantedPermissions(): void {
-    removeStorageItem(getLocalStorage(), this.grantedPermissionsKey);
+    const key = this.grantedPermissionsKey;
+    if (!key) return;
+    removeStorageItem(getLocalStorage(), key);
   }
 
   /**
@@ -193,7 +205,12 @@ export class YouVersionPlatformConfiguration {
    * the callback loads. Recording the initiating user here lets the callback
    * verify the same user is still signed in before honoring the grant.
    */
-  private static readonly dataExchangeInitiatorKey = 'youversion-platform:data-exchange-initiator';
+  private static readonly dataExchangeInitiatorKeyPrefix =
+    'youversion-platform:data-exchange-initiator';
+
+  private static get dataExchangeInitiatorKey(): string | null {
+    return this.scopedStorageKey(this.dataExchangeInitiatorKeyPrefix);
+  }
 
   /**
    * Records the current user as the initiator of a data-exchange redirect.
@@ -203,17 +220,21 @@ export class YouVersionPlatformConfiguration {
    */
   public static saveDataExchangeInitiator(): void {
     const userId = this.currentUserId;
-    if (!userId) return;
-    setStorageItem(getLocalStorage(), this.dataExchangeInitiatorKey, userId);
+    const key = this.dataExchangeInitiatorKey;
+    if (!userId || !key) return;
+    setStorageItem(getLocalStorage(), key, userId);
   }
 
   /** The initiating user's id for the pending data exchange, or `null`. */
   public static get dataExchangeInitiator(): string | null {
-    return getLocalStorage()?.getItem(this.dataExchangeInitiatorKey) ?? null;
+    const key = this.dataExchangeInitiatorKey;
+    return key ? (getLocalStorage()?.getItem(key) ?? null) : null;
   }
 
   public static clearDataExchangeInitiator(): void {
-    removeStorageItem(getLocalStorage(), this.dataExchangeInitiatorKey);
+    const key = this.dataExchangeInitiatorKey;
+    if (!key) return;
+    removeStorageItem(getLocalStorage(), key);
   }
 
   /** Optimistic check against the permission cache. Server 401/403 still wins. */

--- a/packages/core/src/__tests__/data-exchange.test.ts
+++ b/packages/core/src/__tests__/data-exchange.test.ts
@@ -132,6 +132,7 @@ describe('handleDataExchangeCallback URL cleanup', () => {
   beforeEach(() => {
     // A signed-in user who is also the flow initiator, so a `granted` return is
     // honored and these tests can focus on URL cleanup.
+    YouVersionPlatformConfiguration.appKey = 'test-app';
     YouVersionPlatformConfiguration.clearAuthTokens();
     YouVersionPlatformConfiguration.saveUserInfo({ id: 'user-a', name: 'A' });
     YouVersionPlatformConfiguration.saveDataExchangeInitiator();
@@ -139,6 +140,7 @@ describe('handleDataExchangeCallback URL cleanup', () => {
 
   afterEach(() => {
     YouVersionPlatformConfiguration.clearAuthTokens();
+    YouVersionPlatformConfiguration.appKey = null;
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
@@ -184,11 +186,13 @@ describe('handleDataExchangeCallback grant safety (initiating user)', () => {
     'https://app.example.com/read?data_exchange_status=granted&granted_permissions=highlights';
 
   beforeEach(() => {
+    YouVersionPlatformConfiguration.appKey = 'test-app';
     YouVersionPlatformConfiguration.clearAuthTokens();
   });
 
   afterEach(() => {
     YouVersionPlatformConfiguration.clearAuthTokens();
+    YouVersionPlatformConfiguration.appKey = null;
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });

--- a/packages/core/src/__tests__/permissions.test.ts
+++ b/packages/core/src/__tests__/permissions.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { parseGrantedPermissions } from '../permissions';
 import { YouVersionPlatformConfiguration } from '../YouVersionPlatformConfiguration';
 
@@ -65,13 +65,19 @@ describe('parseGrantedPermissions', () => {
 });
 
 describe('YouVersionPlatformConfiguration permission cache', () => {
-  const storageKey = 'youversion-platform:granted-permissions';
+  const legacyStorageKey = 'youversion-platform:granted-permissions';
+  const storageKey = `${legacyStorageKey}:app-a`;
 
   beforeEach(() => {
     localStorage.clear();
+    YouVersionPlatformConfiguration.appKey = 'app-a';
     // The cache is scoped to the signed-in user; establish one for the cases
     // that exercise reads/writes for a single user.
     YouVersionPlatformConfiguration.saveUserInfo({ id: 'user-a' });
+  });
+
+  afterEach(() => {
+    YouVersionPlatformConfiguration.appKey = null;
   });
 
   it('starts empty and merges granted permissions without duplicates', () => {
@@ -110,6 +116,40 @@ describe('YouVersionPlatformConfiguration permission cache', () => {
     localStorage.setItem(storageKey, JSON.stringify(['highlights']));
     expect(YouVersionPlatformConfiguration.grantedPermissions).toEqual([]);
     expect(YouVersionPlatformConfiguration.hasPermission('highlights')).toBe(false);
+  });
+
+  it('ignores an unscoped legacy entry instead of assigning it to the current app', () => {
+    localStorage.setItem(
+      legacyStorageKey,
+      JSON.stringify({ userId: 'user-a', permissions: ['highlights'] }),
+    );
+
+    expect(YouVersionPlatformConfiguration.grantedPermissions).toEqual([]);
+  });
+
+  it('keeps grants separate for two app keys used by the same user and origin', () => {
+    YouVersionPlatformConfiguration.saveGrantedPermissions(['highlights']);
+
+    YouVersionPlatformConfiguration.appKey = 'app-b';
+    expect(YouVersionPlatformConfiguration.grantedPermissions).toEqual([]);
+    YouVersionPlatformConfiguration.saveGrantedPermissions(['votd']);
+
+    YouVersionPlatformConfiguration.appKey = 'app-a';
+    expect(YouVersionPlatformConfiguration.grantedPermissions).toEqual(['highlights']);
+
+    YouVersionPlatformConfiguration.appKey = 'app-b';
+    expect(YouVersionPlatformConfiguration.grantedPermissions).toEqual(['votd']);
+  });
+
+  it('keeps pending data-exchange state separate for each app key', () => {
+    YouVersionPlatformConfiguration.saveDataExchangeInitiator();
+    expect(YouVersionPlatformConfiguration.dataExchangeInitiator).toBe('user-a');
+
+    YouVersionPlatformConfiguration.appKey = 'app-b';
+    expect(YouVersionPlatformConfiguration.dataExchangeInitiator).toBeNull();
+
+    YouVersionPlatformConfiguration.appKey = 'app-a';
+    expect(YouVersionPlatformConfiguration.dataExchangeInitiator).toBe('user-a');
   });
 
   it('returns [] when signed out even if an entry is stored', () => {

--- a/packages/hooks/src/useHighlightAuthActions.test.tsx
+++ b/packages/hooks/src/useHighlightAuthActions.test.tsx
@@ -31,6 +31,7 @@ function wrapper({ children }: { children: ReactNode }) {
 describe('useHighlightAuthActions', () => {
   beforeEach(() => {
     localStorage.clear();
+    YouVersionPlatformConfiguration.appKey = 'app-1';
     // A writable location stub so href assignment doesn't hit jsdom navigation.
     Object.defineProperty(window, 'location', {
       value: { href: 'https://host.example/read' },
@@ -40,6 +41,7 @@ describe('useHighlightAuthActions', () => {
   });
 
   afterEach(() => {
+    YouVersionPlatformConfiguration.appKey = null;
     vi.restoreAllMocks();
   });
 

--- a/packages/hooks/src/useYVAuth.test.tsx
+++ b/packages/hooks/src/useYVAuth.test.tsx
@@ -237,6 +237,16 @@ describe('useYVAuth', () => {
 
       expect(result.current.auth.accessToken).toBe('access-token');
     });
+
+    it('reads a newly persisted access token after the provider rerenders', async () => {
+      const { result, rerender } = await renderAuthHook();
+      expect(result.current.auth.accessToken).toBeNull();
+
+      YouVersionPlatformConfiguration.saveAuthData('fresh-access-token', null, null);
+      rerender();
+
+      expect(result.current.auth.accessToken).toBe('fresh-access-token');
+    });
   });
 
   describe('memoization', () => {

--- a/packages/hooks/src/useYVAuth.ts
+++ b/packages/hooks/src/useYVAuth.ts
@@ -122,13 +122,9 @@ export function useYVAuth(): UseYVAuthReturn {
   // Derive authentication state
   const isAuthenticated = !!userInfo;
 
-  // Get current tokens for actions
-  const authTokens = useMemo(
-    () => ({
-      accessToken: YouVersionPlatformConfiguration.accessToken,
-    }),
-    [],
-  );
+  // Read persisted auth data on every render so callbacks and refreshes are
+  // reflected in consumers instead of being frozen at the hook's first mount.
+  const accessToken = YouVersionPlatformConfiguration.accessToken;
 
   // Sign in function
   const signIn = useCallback(
@@ -160,11 +156,11 @@ export function useYVAuth(): UseYVAuthReturn {
     () => ({
       isAuthenticated,
       isLoading,
-      accessToken: authTokens.accessToken,
+      accessToken,
       result: null,
       error,
     }),
-    [isAuthenticated, isLoading, authTokens.accessToken, error],
+    [isAuthenticated, isLoading, accessToken, error],
   );
 
   // Sign out function

--- a/packages/ui/src/components/bible-reader-highlights-machine.test.ts
+++ b/packages/ui/src/components/bible-reader-highlights-machine.test.ts
@@ -51,6 +51,7 @@ function makeServices(overrides: Partial<HighlightServices> = {}): MachineTestSe
     consumeDataExchangeReturn: () => null,
     startSignInForHighlights: vi.fn().mockResolvedValue(undefined),
     startDataExchangeForHighlights: vi.fn().mockResolvedValue(undefined),
+    persistSettledWrite: vi.fn(),
     ...overrides,
   };
   return { ref: { current: services }, refetch };
@@ -81,6 +82,28 @@ afterEach(() => {
 });
 
 describe('bibleReaderHighlightsMachine — writeIntent lifecycle', () => {
+  it('persists a successful write even when navigation stops the machine before settlement', async () => {
+    const pending = deferred();
+    const createHighlight = vi.fn().mockReturnValue(pending.promise);
+    const persistSettledWrite = vi.fn();
+    const { ref } = makeServices({ createHighlight, persistSettledWrite });
+    const actor = startMachine(ref);
+
+    actor.send({ type: 'TAP_COLOR', color: 'FFEC5B', verses: [16] });
+    await vi.waitFor(() => expect(createHighlight).toHaveBeenCalledTimes(1));
+    actor.stop();
+
+    pending.resolve();
+    await vi.waitFor(() => {
+      expect(persistSettledWrite).toHaveBeenCalledWith({
+        kind: 'apply',
+        color: 'ffec5b',
+        verses: [16],
+        scope: scopeJHN3,
+      });
+    });
+  });
+
   it('releases a verse writeIntent entry once its write settles', async () => {
     const { ref, refetch } = makeServices();
     const actor = startMachine(ref);

--- a/packages/ui/src/components/bible-reader-highlights-machine.ts
+++ b/packages/ui/src/components/bible-reader-highlights-machine.ts
@@ -53,6 +53,7 @@ import {
   stashPendingHighlight,
   type PendingHighlight,
 } from '@/lib/pending-highlight';
+import type { SettledHighlightWrite } from '@/lib/settled-highlight-overlay';
 import { getHttpStatus, type Highlight } from '@youversion/platform-core';
 import { Result } from 'better-result';
 import { assign, enqueueActions, fromPromise, setup, type DoneActorEvent } from 'xstate';
@@ -114,6 +115,8 @@ export type HighlightServices = {
   consumeDataExchangeReturn: () => { status: DataExchangeStatus } | null;
   startSignInForHighlights: () => Promise<void>;
   startDataExchangeForHighlights: () => Promise<void>;
+  /** Persist server-accepted writes across a provider unmount/remount. */
+  persistSettledWrite: (write: SettledHighlightWrite) => void;
 };
 
 export type HighlightServicesRef = { current: HighlightServices };
@@ -357,6 +360,19 @@ const processWrite = fromPromise<WriteResult, { services: HighlightServicesRef; 
         } else {
           succeededVerses.push(verse);
         }
+      });
+    }
+
+    // Persist only server-accepted verses. This runs inside the promise actor,
+    // before its completion event is delivered to the parent machine, so it
+    // still executes if route navigation stops the machine while the request is
+    // in flight. The adapter binds the write to the originating app key + user.
+    if (succeededVerses.length > 0) {
+      svc.persistSettledWrite({
+        kind: op.kind,
+        color: op.color,
+        verses: succeededVerses,
+        scope: op.scope,
       });
     }
 

--- a/packages/ui/src/components/use-bible-reader-highlights.test.tsx
+++ b/packages/ui/src/components/use-bible-reader-highlights.test.tsx
@@ -511,6 +511,48 @@ describe('useBibleReaderHighlights — apply', () => {
 });
 
 describe('useBibleReaderHighlights — overlay reconciliation (Fix 2)', () => {
+  it('keeps a server-accepted highlight across provider unmount/remount while the GET is stale', async () => {
+    const mocked = mockUseHighlights();
+
+    const firstMount = renderHook(() => useBibleReaderHighlights(defaultOptions), {
+      wrapper: AuthWrapper,
+    });
+
+    act(() => {
+      firstMount.result.current.apply('ffec5b', [16]);
+    });
+    await waitFor(() => {
+      expect(mocked.refetch).toHaveBeenCalledTimes(1);
+    });
+    firstMount.unmount();
+
+    // Leaving /demos destroys its private provider and query client. A fresh
+    // provider can therefore receive an empty read-replica response even though
+    // the POST above succeeded. The app+user-scoped settled overlay bridges it.
+    mockUseHighlights({ highlights: makeCollection([]) });
+    const secondMount = renderHook(() => useBibleReaderHighlights(defaultOptions), {
+      wrapper: AuthWrapper,
+    });
+    expect(secondMount.result.current.highlightedVerses).toEqual({ 16: 'ffec5b' });
+
+    // Once server truth reflects the write, the session overlay is retired.
+    mockUseHighlights({
+      highlights: makeCollection([{ version_id: 111, passage_id: 'JHN.3.16', color: 'ffec5b' }]),
+    });
+    secondMount.rerender();
+    await waitFor(() => {
+      expect(secondMount.result.current.highlightedVerses).toEqual({ 16: 'ffec5b' });
+    });
+    secondMount.unmount();
+
+    // It is only a read-lag bridge, not a second durable highlight database.
+    mockUseHighlights({ highlights: makeCollection([]) });
+    const thirdMount = renderHook(() => useBibleReaderHighlights(defaultOptions), {
+      wrapper: AuthWrapper,
+    });
+    expect(thirdMount.result.current.highlightedVerses).toEqual({});
+  });
+
   it('holds the overlay until a fetch REFLECTS the write, then retires it to server truth', async () => {
     const mocked = mockUseHighlights();
 

--- a/packages/ui/src/components/use-bible-reader-highlights.ts
+++ b/packages/ui/src/components/use-bible-reader-highlights.ts
@@ -3,6 +3,12 @@
 import { isHighlightsLive } from '@/lib/feature-flags';
 import { deriveHighlightedVerses } from '@/lib/highlight-projection';
 import { isPaletteHighlightColor, normalizeHighlightHex } from '@/lib/highlight-colors';
+import {
+  persistSettledHighlightWrite,
+  readSettledHighlightOverlay,
+  reconcileSettledHighlightOverlay,
+  type SettledHighlightOverlay,
+} from '@/lib/settled-highlight-overlay';
 import type { Highlight } from '@youversion/platform-core';
 import {
   bibleReaderHighlightsMachine,
@@ -16,9 +22,10 @@ import {
   useHighlightAuthActions,
   useHighlights,
   YouVersionAuthContext,
+  YouVersionContext,
 } from '@youversion/platform-react-hooks';
 import { useActorRef, useSelector } from '@xstate/react';
-import { useContext, useEffect, useMemo, useRef } from 'react';
+import { useContext, useEffect, useMemo, useReducer, useRef } from 'react';
 
 /**
  * Bridge-safe highlight intent emitted in controlled mode. Structurally
@@ -128,6 +135,15 @@ function serverColorsEqual(a: ServerColors, b: ServerColors): boolean {
   return true;
 }
 
+function overlaysEqual(a: SettledHighlightOverlay, b: SettledHighlightOverlay): boolean {
+  const aKeys = Object.keys(a);
+  if (aKeys.length !== Object.keys(b).length) return false;
+  for (const key of aKeys) {
+    if (a[Number(key)] !== b[Number(key)]) return false;
+  }
+  return true;
+}
+
 function buildHighlightIntent(
   versionId: number,
   book: string,
@@ -179,6 +195,7 @@ export function useBibleReaderHighlights({
   // auth provider is mounted. No provider and signed out are the same state
   // here for the self-contained path: no fetch, no writes, nothing rendered.
   const authContext = useContext(YouVersionAuthContext);
+  const platformContext = useContext(YouVersionContext);
   const hasAuthProvider = authContext !== null;
   // A profile with no `userId` is not enough. `useHighlights` keys its cache by
   // account and does not fetch for an unidentified one, so treating this state
@@ -192,6 +209,7 @@ export function useBibleReaderHighlights({
   // still carries a `userId` in that window would otherwise let a POST through
   // that the withheld GET cannot show.
   const userId = authContext?.userInfo?.userId ?? null;
+  const appKey = platformContext?.appKey ?? null;
   const isAuthenticated = Boolean(authContext && !authContext.isLoading && userId);
   // Controlled mode keeps the machine disabled (provably inert) and never hits
   // the network — the dark-launch flag only gates the self-contained server path.
@@ -217,6 +235,22 @@ export function useBibleReaderHighlights({
   const controlledRef = useRef(controlled);
   controlledRef.current = controlled;
 
+  // Successful writes are persisted by app + account so a demos provider can
+  // unmount during route navigation without losing the read-lag overlay. The
+  // revision makes this mount observe a settlement immediately; a future mount
+  // reads the same short-lived session entry during render.
+  const [settledOverlayRevision, bumpSettledOverlayRevision] = useReducer(
+    (revision: number) => revision + 1,
+    0,
+  );
+  const mountedRef = useRef(false);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
   // A stable ref bag of the live SDK service closures. Passed once to the machine
   // via `input`; the machine reads `.current` at call time so it always sees the
   // latest closures without re-spawning. The ref is initialized with the first
@@ -231,6 +265,11 @@ export function useBibleReaderHighlights({
     consumeDataExchangeReturn,
     startSignInForHighlights,
     startDataExchangeForHighlights,
+    persistSettledWrite: (write) => {
+      if (!appKey || !userId) return;
+      persistSettledHighlightWrite(appKey, userId, write);
+      if (mountedRef.current) bumpSettledOverlayRevision();
+    },
   };
   const servicesRef = useRef(services);
   servicesRef.current = services;
@@ -276,6 +315,17 @@ export function useBibleReaderHighlights({
     [highlights, versionId, chapterUsfm],
   );
 
+  const settledOverlay = useMemo(() => {
+    if (!live || !appKey || !userId) return {};
+    return readSettledHighlightOverlay(appKey, userId, scope);
+  }, [live, appKey, userId, scope, settledOverlayRevision]);
+
+  useEffect(() => {
+    if (!live || !appKey || !userId) return;
+    const reconciled = reconcileSettledHighlightOverlay(appKey, userId, scope, serverColors);
+    if (!overlaysEqual(reconciled, settledOverlay)) bumpSettledOverlayRevision();
+  }, [live, appKey, userId, scope, serverColors, settledOverlay]);
+
   const lastSentServerColorsRef = useRef<ServerColors | null>(null);
   useEffect(() => {
     if (
@@ -311,12 +361,15 @@ export function useBibleReaderHighlights({
     // machine still holds the previous account's overlay. Skip it, so the new
     // account never sees those entries, not even for one paint.
     if (machineUserId !== userId) return { ...serverColors };
-    return selectHighlightedVerses(serverColors, overlay);
+    // Fresh in-memory intent wins over the settled cross-remount overlay; both
+    // win over a stale read replica.
+    return selectHighlightedVerses(serverColors, { ...settledOverlay, ...overlay });
   }, [
     isControlled,
     controlled?.highlights,
     live,
     serverColors,
+    settledOverlay,
     overlay,
     machineScope,
     scope,

--- a/packages/ui/src/lib/settled-highlight-overlay.test.ts
+++ b/packages/ui/src/lib/settled-highlight-overlay.test.ts
@@ -1,0 +1,143 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  persistSettledHighlightWrite,
+  reconcileSettledHighlightOverlay,
+  SETTLED_HIGHLIGHT_OVERLAY_TTL_MS,
+  type SettledHighlightScope,
+} from './settled-highlight-overlay';
+
+const scope: SettledHighlightScope = { versionId: 111, book: 'JHN', chapter: '3' };
+
+describe('settled-highlight-overlay', () => {
+  beforeEach(() => sessionStorage.clear());
+
+  it('round-trips a successful apply for the same app, user, and scope', () => {
+    persistSettledHighlightWrite(
+      'demos-key',
+      'user-1',
+      { kind: 'apply', color: 'FFEC5B', verses: [16, 17], scope },
+      1_000,
+    );
+
+    expect(
+      reconcileSettledHighlightOverlay('demos-key', 'user-1', scope, {}, 1_001),
+    ).toEqual({ 16: 'ffec5b', 17: 'ffec5b' });
+  });
+
+  it('isolates overlays by app key and user', () => {
+    persistSettledHighlightWrite(
+      'demos-key',
+      'user-1',
+      { kind: 'apply', color: 'ffec5b', verses: [16], scope },
+      1_000,
+    );
+
+    expect(reconcileSettledHighlightOverlay('portal-key', 'user-1', scope, {}, 1_001)).toEqual({});
+    expect(reconcileSettledHighlightOverlay('demos-key', 'user-2', scope, {}, 1_001)).toEqual({});
+    expect(reconcileSettledHighlightOverlay('demos-key', 'user-1', scope, {}, 1_001)).toEqual({
+      16: 'ffec5b',
+    });
+  });
+
+  it('isolates overlays by Bible scope', () => {
+    persistSettledHighlightWrite(
+      'demos-key',
+      'user-1',
+      { kind: 'apply', color: 'ffec5b', verses: [16], scope },
+      1_000,
+    );
+
+    expect(
+      reconcileSettledHighlightOverlay(
+        'demos-key',
+        'user-1',
+        { ...scope, chapter: '4' },
+        {},
+        1_001,
+      ),
+    ).toEqual({});
+  });
+
+  it('retires an apply once server truth reflects it', () => {
+    persistSettledHighlightWrite(
+      'demos-key',
+      'user-1',
+      { kind: 'apply', color: 'ffec5b', verses: [16], scope },
+      1_000,
+    );
+
+    expect(
+      reconcileSettledHighlightOverlay(
+        'demos-key',
+        'user-1',
+        scope,
+        { 16: 'ffec5b' },
+        1_001,
+      ),
+    ).toEqual({});
+    expect(reconcileSettledHighlightOverlay('demos-key', 'user-1', scope, {}, 1_002)).toEqual({});
+  });
+
+  it('holds a successful remove tombstone until TTL', () => {
+    persistSettledHighlightWrite(
+      'demos-key',
+      'user-1',
+      { kind: 'remove', color: 'ffec5b', verses: [16], scope },
+      1_000,
+    );
+
+    expect(
+      reconcileSettledHighlightOverlay(
+        'demos-key',
+        'user-1',
+        scope,
+        { 16: 'ffec5b' },
+        1_001,
+      ),
+    ).toEqual({ 16: null });
+    expect(reconcileSettledHighlightOverlay('demos-key', 'user-1', scope, {}, 1_002)).toEqual({
+      16: null,
+    });
+  });
+
+  it('expires the overlay instead of becoming a durable highlight store', () => {
+    persistSettledHighlightWrite(
+      'demos-key',
+      'user-1',
+      { kind: 'apply', color: 'ffec5b', verses: [16], scope },
+      1_000,
+    );
+
+    expect(
+      reconcileSettledHighlightOverlay(
+        'demos-key',
+        'user-1',
+        scope,
+        {},
+        1_000 + SETTLED_HIGHLIGHT_OVERLAY_TTL_MS + 1,
+      ),
+    ).toEqual({});
+  });
+
+  it('uses the newest settled write for the same verse', () => {
+    persistSettledHighlightWrite(
+      'demos-key',
+      'user-1',
+      { kind: 'apply', color: 'ffec5b', verses: [16], scope },
+      1_000,
+    );
+    persistSettledHighlightWrite(
+      'demos-key',
+      'user-1',
+      { kind: 'remove', color: 'ffec5b', verses: [16], scope },
+      1_001,
+    );
+
+    expect(reconcileSettledHighlightOverlay('demos-key', 'user-1', scope, {}, 1_002)).toEqual({
+      16: null,
+    });
+  });
+});

--- a/packages/ui/src/lib/settled-highlight-overlay.ts
+++ b/packages/ui/src/lib/settled-highlight-overlay.ts
@@ -1,0 +1,196 @@
+/**
+ * A short-lived record of highlight writes the API has accepted but a read
+ * replica may not reflect yet.
+ *
+ * This is not the canonical highlight store: account highlights remain
+ * server-owned. The overlay only bridges read-after-write lag across a provider
+ * unmount/remount (for example, leaving a demos route and coming back). Entries
+ * live in sessionStorage, expire quickly, and are isolated by app key + user.
+ */
+import {
+  getSessionStorage,
+  removeStorageItem,
+  setStorageItem,
+} from '@youversion/platform-core';
+
+export type SettledHighlightScope = {
+  versionId: number;
+  book: string;
+  chapter: string;
+};
+
+export type SettledHighlightWrite = {
+  kind: 'apply' | 'remove';
+  color: string;
+  verses: number[];
+  scope: SettledHighlightScope;
+};
+
+export type SettledHighlightOverlay = Record<number, string | null>;
+
+type SettledHighlightEntry = SettledHighlightScope & {
+  verse: number;
+  color: string | null;
+  timestamp: number;
+};
+
+const STORAGE_PREFIX = 'youversion-platform:settled-highlight-overlay:v1';
+
+/** Long enough to cover replica lag without becoming a second highlight store. */
+export const SETTLED_HIGHLIGHT_OVERLAY_TTL_MS = 5 * 60 * 1000;
+
+/** Bounds storage even if a user highlights many passages inside the TTL. */
+const MAX_ENTRIES = 500;
+
+type StoredRead = {
+  entries: SettledHighlightEntry[];
+  stale: boolean;
+};
+
+type JsonPrimitive = string | number | boolean | null;
+type JsonObject = { [key: string]: JsonValue };
+type JsonValue = JsonPrimitive | JsonValue[] | JsonObject;
+
+function storageKey(appKey: string, userId: string): string {
+  return `${STORAGE_PREFIX}:${encodeURIComponent(appKey)}:${encodeURIComponent(userId)}`;
+}
+
+function scopesEqual(a: SettledHighlightScope, b: SettledHighlightScope): boolean {
+  return a.versionId === b.versionId && a.book === b.book && a.chapter === b.chapter;
+}
+
+function isText(value: JsonValue | undefined): value is string {
+  return Object.prototype.toString.call(value) === '[object String]';
+}
+
+function isFiniteNumber(value: JsonValue | undefined): value is number {
+  return Object.prototype.toString.call(value) === '[object Number]' && Number.isFinite(value);
+}
+
+function isJsonObject(value: JsonValue): value is JsonObject {
+  return value !== null && Object.prototype.toString.call(value) === '[object Object]';
+}
+
+function parseEntry(entry: JsonObject): SettledHighlightEntry | undefined {
+  const versionId = entry.versionId;
+  const book = entry.book;
+  const chapter = entry.chapter;
+  const verse = entry.verse;
+  const color = entry.color;
+  const timestamp = entry.timestamp;
+  if (!isFiniteNumber(versionId) || !isText(book) || !isText(chapter)) return undefined;
+  if (!isFiniteNumber(verse) || !Number.isInteger(verse) || verse <= 0) return undefined;
+  if (color !== null && (!isText(color) || !/^[0-9a-f]{6}$/u.test(color))) return undefined;
+  if (!isFiniteNumber(timestamp)) return undefined;
+  return { versionId, book, chapter, verse, color, timestamp };
+}
+
+function readStored(appKey: string, userId: string, now: number): StoredRead {
+  const raw = getSessionStorage()?.getItem(storageKey(appKey, userId));
+  if (!raw) return { entries: [], stale: false };
+
+  let parsed: JsonValue;
+  try {
+    // SAFETY: JSON.parse returns untyped input. The loop below validates every
+    // collection member and field before constructing a domain entry.
+    parsed = JSON.parse(raw) as JsonValue;
+  } catch {
+    return { entries: [], stale: true };
+  }
+  if (!Array.isArray(parsed)) return { entries: [], stale: true };
+  const parsedEntries: SettledHighlightEntry[] = [];
+  for (const item of parsed) {
+    if (!isJsonObject(item)) return { entries: [], stale: true };
+    const entry = parseEntry(item);
+    if (entry === undefined) return { entries: [], stale: true };
+    parsedEntries.push(entry);
+  }
+
+  const entries = parsedEntries.filter(
+    (entry) => now - entry.timestamp <= SETTLED_HIGHLIGHT_OVERLAY_TTL_MS,
+  );
+  return { entries, stale: entries.length !== parsedEntries.length };
+}
+
+function writeStored(appKey: string, userId: string, entries: SettledHighlightEntry[]): void {
+  const key = storageKey(appKey, userId);
+  if (entries.length === 0) {
+    removeStorageItem(getSessionStorage(), key);
+    return;
+  }
+  setStorageItem(getSessionStorage(), key, JSON.stringify(entries.slice(-MAX_ENTRIES)));
+}
+
+function overlayForScope(
+  entries: SettledHighlightEntry[],
+  scope: SettledHighlightScope,
+) {
+  const overlay: SettledHighlightOverlay = {};
+  for (const entry of entries) {
+    if (scopesEqual(entry, scope)) overlay[entry.verse] = entry.color;
+  }
+  return overlay;
+}
+
+/** Pure read used during render; cleanup/reconciliation stays in an effect. */
+export function readSettledHighlightOverlay(
+  appKey: string,
+  userId: string,
+  scope: SettledHighlightScope,
+  now: number = Date.now(),
+): SettledHighlightOverlay {
+  if (!appKey || !userId) return {};
+  return overlayForScope(readStored(appKey, userId, now).entries, scope);
+}
+
+/**
+ * Records only verses whose write request succeeded. A later write to the same
+ * verse wins, matching the in-memory optimistic overlay.
+ */
+export function persistSettledHighlightWrite(
+  appKey: string,
+  userId: string,
+  write: SettledHighlightWrite,
+  now: number = Date.now(),
+): void {
+  if (!appKey || !userId || write.verses.length === 0) return;
+
+  const existing = readStored(appKey, userId, now).entries;
+  const changedVerses = new Set(write.verses);
+  const entries = existing.filter(
+    (entry) => !(scopesEqual(entry, write.scope) && changedVerses.has(entry.verse)),
+  );
+  const color = write.kind === 'apply' ? write.color.toLowerCase() : null;
+  for (const verse of changedVerses) {
+    if (!Number.isInteger(verse) || verse <= 0) continue;
+    entries.push({ ...write.scope, verse, color, timestamp: now });
+  }
+  writeStored(appKey, userId, entries);
+}
+
+/**
+ * Reads the current scope's overlay and prunes entries that have expired or
+ * whose successful apply is now reflected by server truth. Remove tombstones
+ * intentionally live until TTL so a later stale replica cannot resurrect a
+ * deleted highlight.
+ */
+export function reconcileSettledHighlightOverlay(
+  appKey: string,
+  userId: string,
+  scope: SettledHighlightScope,
+  serverColors: Record<number, string>,
+  now: number = Date.now(),
+): SettledHighlightOverlay {
+  if (!appKey || !userId) return {};
+
+  const stored = readStored(appKey, userId, now);
+  const entries = stored.entries.filter((entry) => {
+    if (!scopesEqual(entry, scope)) return true;
+    if (entry.color === null) return true;
+    return serverColors[entry.verse] !== entry.color;
+  });
+  if (stored.stale || entries.length !== stored.entries.length) {
+    writeStored(appKey, userId, entries);
+  }
+  return overlayForScope(entries, scope);
+}

--- a/packages/ui/src/test/setup.ts
+++ b/packages/ui/src/test/setup.ts
@@ -1,6 +1,7 @@
 // Vitest setup file
-import { afterEach } from 'vitest';
+import { afterEach, beforeEach } from 'vitest';
 import { cleanup } from '@testing-library/react';
+import { YouVersionPlatformConfiguration } from '@youversion/platform-core';
 import { graftTestWebStorage } from '@youversion/platform-react-hooks/test-utils';
 import '@testing-library/jest-dom/vitest';
 
@@ -12,7 +13,15 @@ await graftTestWebStorage();
 // jsdom does not implement scrollIntoView. Chapter picker calls it on open.
 Element.prototype.scrollIntoView = function scrollIntoView(): void {};
 
+beforeEach(() => {
+  // Permission state is app-scoped in production. Unit-test wrappers that use
+  // the raw contexts (instead of mounting YouVersionProvider) still need an
+  // app identity for permission reads and writes.
+  YouVersionPlatformConfiguration.appKey = 'test-app-key';
+});
+
 // Clean up after each test
 afterEach(() => {
   cleanup();
+  YouVersionPlatformConfiguration.appKey = null;
 });


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR scopes permission and data-exchange state by app key, keeps auth tokens current across renders, and adds a session-backed overlay for accepted highlight writes across provider remounts.
- Separates permission and consent-flow storage by application and user.
- Reads the current persisted access token on every auth-hook render.
- Persists accepted highlight applies and removals while replicas converge, with app, user, and passage isolation.
- Adds unit coverage for storage isolation, token refresh visibility, remount persistence, expiry, and reconciliation.

<h3>Confidence Score: 4/5</h3>

The highlight reconciliation defect should be fixed before merging because updated account state from another client can remain hidden behind the session overlay.

Remove tombstones and mismatched apply entries always override subsequent server reads until expiry, so the reader can display obsolete highlight state even after receiving a newer account value.

**Files Needing Attention:** packages/ui/src/lib/settled-highlight-overlay.ts, packages/ui/src/components/use-bible-reader-highlights.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/core/src/YouVersionPlatformConfiguration.ts | Scopes cached permissions and pending consent initiators by encoded app key while retaining user ownership checks. |
| packages/hooks/src/useYVAuth.ts | Reads the persisted access token on each render so provider updates are reflected without remounting. |
| packages/ui/src/components/bible-reader-highlights-machine.ts | Persists successfully settled verses from the originating write even when the parent machine has stopped. |
| packages/ui/src/components/use-bible-reader-highlights.ts | Integrates app- and user-scoped settled overlays into rendering and reconciliation, but lets retained entries override independently updated server state. |
| packages/ui/src/lib/settled-highlight-overlay.ts | Implements validated, bounded, expiring session persistence, but cannot distinguish replica lag from newer server changes and therefore retains stale overrides. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Reader
  participant API
  participant Session as Session Overlay
  participant Replica
  Reader->>API: Apply or remove highlight
  API-->>Reader: Write accepted
  Reader->>Session: Persist app + user + passage overlay
  Reader->>Replica: Refetch highlights
  Replica-->>Reader: Possibly stale server state
  Session-->>Reader: Overlay accepted write
  Note over Reader,Session: Overlay expires after five minutes
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20youversion%2Fplatform-sdk-react%20PR%20%23368%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=youversion%2Fplatform-sdk-react&pr=368&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fui%2Fsrc%2Flib%2Fsettled-highlight-overlay.ts%3A189-190%0A**Overlay%20masks%20newer%20server%20state**%0A%0AWhen%20another%20client%20reapplies%20a%20removed%20highlight%20or%20changes%20its%20color%20within%20the%20five-minute%20TTL%2C%20reconciliation%20retains%20the%20local%20tombstone%20or%20mismatched%20apply%20entry%20and%20renders%20it%20over%20the%20newer%20server%20value%2C%20causing%20the%20reader%20to%20hide%20the%20highlight%20or%20display%20an%20obsolete%20color.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=youversion%2Fplatform-sdk-react&pr=368&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Fui%2Fsrc%2Flib%2Fsettled-highlight-overlay.ts%3A189-190%0A**Overlay%20masks%20newer%20server%20state**%0A%0AWhen%20another%20client%20reapplies%20a%20removed%20highlight%20or%20changes%20its%20color%20within%20the%20five-minute%20TTL%2C%20reconciliation%20retains%20the%20local%20tombstone%20or%20mismatched%20apply%20entry%20and%20renders%20it%20over%20the%20newer%20server%20value%2C%20causing%20the%20reader%20to%20hide%20the%20highlight%20or%20display%20an%20obsolete%20color.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=368&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-react%22%20on%20the%20existing%20branch%20%22codex%2Fapp-scoped-permission-cache%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fapp-scoped-permission-cache%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Fui%2Fsrc%2Flib%2Fsettled-highlight-overlay.ts%3A189-190%0A**Overlay%20masks%20newer%20server%20state**%0A%0AWhen%20another%20client%20reapplies%20a%20removed%20highlight%20or%20changes%20its%20color%20within%20the%20five-minute%20TTL%2C%20reconciliation%20retains%20the%20local%20tombstone%20or%20mismatched%20apply%20entry%20and%20renders%20it%20over%20the%20newer%20server%20value%2C%20causing%20the%20reader%20to%20hide%20the%20highlight%20or%20display%20an%20obsolete%20color.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=youversion%2Fplatform-sdk-react&pr=368&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/ui/src/lib/settled-highlight-overlay.ts:189-190
**Overlay masks newer server state**

When another client reapplies a removed highlight or changes its color within the five-minute TTL, reconciliation retains the local tombstone or mismatched apply entry and renders it over the newer server value, causing the reader to hide the highlight or display an obsolete color.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): preserve highlights across prov..."](https://github.com/youversion/platform-sdk-react/commit/bc5f1e38d23b2b53f8317a8fd606a8a50c13f53f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57968302)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Authentication and storage](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/core-auth-storage.md)
- Knowledge Base — [Hook providers and authentication state](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/hooks-providers-auth.md)
- Knowledge Base — [Scripture highlighting interactions](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/ui-highlights.md)
- Knowledge Base — [Package delivery workflows](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/delivery-workflows.md)
</details>


<!-- /greptile_comment -->