### PR TITLE
fix(ui): route verse actions through shadow portals

### DIFF
--- a/.changeset/shadow-aware-verse-actions.md
+++ b/.changeset/shadow-aware-verse-actions.md
@@ -1,0 +1,5 @@
+---
+'@youversion/platform-react-ui': patch
+---
+
+Keep verse action popovers in their component's shadow-local portal and restore focus after dismissal.

--- a/docs/shadow-dom-isolation-plan.md
+++ b/docs/shadow-dom-isolation-plan.md
@@ -15,6 +15,8 @@ This is a working plan, not approval for package-wide rollout.
 - `BibleVersionPicker` validates shadow-local inline and native top-layer
   floating content through opt-in stories.
 - The shared Dialog and Popover primitives support opt-in shadow-local portals.
+- `VerseActionPopover` uses the shared portal-state infrastructure while
+  retaining its specialized direct Radix composition.
 - `BibleVersionPicker` and other public exports do not automatically create
   Shadow DOM boundaries.
 - The internal `SignInDialog` is validated only through an opt-in
@@ -31,11 +33,25 @@ This is a working plan, not approval for package-wide rollout.
 | Owner-document handling | Focused coverage mounts into a same-origin iframe and verifies document-compatible stylesheet construction. | Validated for the prototype | Verify stylesheet failure recovery. |
 | Inline floating content | The picker negative control preserves tree-scope relationships but demonstrates clipping beyond a constrained ancestor. | Validated as a negative control | None; clipping is why inline placement is not the selected escaping strategy. |
 | Native top-layer floating content | Picker stories verify clipping escape, hit testing, collision handling, hostile-CSS isolation, and resolved `aria-controls` relationships. | Validated in Chromium | Expand browser and assistive-technology coverage. |
-| Portal lifecycle | Unit and browser coverage exercise lazy creation, exit-animation retention, cleanup, and immediate reopen behavior. | Validated for shared primitives | Audit components that bypass the shared Popover wrapper. |
+| Portal lifecycle | Unit and browser coverage exercise lazy creation, exit-animation retention, cleanup, immediate reopen behavior, and the direct-Radix `VerseActionPopover` consumer. | Validated for shared primitives and the known bypass | Repeat the consumer audit when adding another direct overlay primitive. |
 | Dialog relationships | Chromium resolves title and description relationships inside the component tree. | Validated in Chromium | Verify announcements with real assistive technology. |
 | Dialog keyboard containment | Browser coverage exercises initial focus, programmatic escape redirection, forward and reverse traversal, radio-group collapsing, negative `tabindex`, and wraparound. | Validated in Chromium | Expand the browser and assistive-technology matrix. |
 | Dialog modal lifetime | Coverage verifies inert background content while open and through staggered Content and Overlay exit animations. | Validated for one modal | Define ownership before supporting nested or competing overlays. |
 | Dialog dismissal and restoration | Coverage exercises Escape, backdrop click, full-viewport hit testing, overlay-only focus, and restoration after both modal nodes unmount. | Validated in Chromium | Verify real screen-reader and cross-browser behavior. |
+
+## Direct overlay inventory
+
+| Location | Classification | Shadow portal requirement |
+| --- | --- | --- |
+| `components/ui/dialog.tsx` | Shared Radix Dialog infrastructure | Already owns shadow-aware portal and modal-focus coordination. |
+| `components/ui/popover.tsx` | Shared Radix Popover infrastructure | Already owns shadow-aware portal state. |
+| `components/verse-action-popover.tsx` | Intentional direct Radix Popover consumer | Uses the shared portal-state seam while retaining its virtual anchor, reader-edge docking, custom pill surface, and verse-selection interaction rules. |
+| `components/verse.tsx` | React portals into existing YVDOM footnote anchors, not floating overlays | No overlay migration required; each target remains in the rendered verse tree. |
+
+No other production direct-overlay bypass was found. The inventory therefore
+produced no equivalent low-risk migration and no materially different case that
+requires follow-up work. Nested and concurrent overlay ownership remains a
+separate decision.
 
 ## Blocking production-readiness decisions
 
@@ -49,8 +65,6 @@ This is a working plan, not approval for package-wide rollout.
   custom properties, and existing bare references such as
   `BibleVersionPicker`'s `var(--spacing)` must be classified rather than fixed as
   isolated symptoms.
-- Audit components that use Radix primitives directly instead of the shared
-  wrappers. `VerseActionPopover` is a known direct Popover consumer.
 
 ## Functional and compatibility audits
 
@@ -81,7 +95,7 @@ This is a working plan, not approval for package-wide rollout.
 
 ## Rollout sequence
 
-1. Complete the custom-property and direct-Radix-consumer audits.
+1. Complete the custom-property audit.
 2. Resolve SSR/hydration, rollout-control, and overlay-ownership decisions.
 3. Select the next public component and add component-specific compatibility,
    browser, and accessibility coverage before enabling isolation.

--- a/packages/ui/src/components/bible-reader.stories.tsx
+++ b/packages/ui/src/components/bible-reader.stories.tsx
@@ -161,6 +161,65 @@ export const Default: Story = {
   },
 };
 
+export const VerseActionPointerInteractions: Story = {
+  tags: ['integration'],
+  args: {
+    defaultVersionId: 111,
+    lineSpacing: 1.7,
+    fontFamily: INTER_FONT,
+    showVerseNumbers: true,
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('*/v1/fonts/1/stylesheet', () =>
+          HttpResponse.text('', { headers: { 'Content-Type': 'text/css' } }),
+        ),
+        ...globalHandlers,
+      ],
+    },
+  },
+  render: (args) => (
+    <div className="yv:grid yv:h-screen yv:grid-rows-[auto_1fr] yv:bg-background">
+      <button type="button" data-testid="outside-reader-control">
+        Outside reader
+      </button>
+      <BibleReader.Root {...args}>
+        <BibleReader.Content />
+        <BibleReader.Toolbar />
+      </BibleReader.Root>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const firstVerse = await waitFor(() => {
+      const element = canvasElement.querySelector<HTMLElement>('.yv-v[v="1"]');
+      if (!element) throw new Error('first verse not rendered');
+      return element;
+    });
+    const secondVerse = canvasElement.querySelector<HTMLElement>('.yv-v[v="2"]');
+    const secondVerseLabel = secondVerse?.querySelector<HTMLElement>('.yv-vlbl');
+    const outsideControl = canvasElement.querySelector<HTMLButtonElement>(
+      '[data-testid="outside-reader-control"]',
+    );
+    if (!secondVerse || !secondVerseLabel || !outsideControl)
+      throw new Error('reader interaction controls not rendered');
+
+    await userEvent.click(firstVerse);
+    const dialog = await screen.findByRole('dialog');
+
+    await userEvent.click(secondVerseLabel);
+    await expect(firstVerse).toHaveClass('yv-v-selected');
+    await expect(secondVerse).toHaveClass('yv-v-selected');
+    await expect(dialog).toBeInTheDocument();
+
+    await userEvent.pointer({ keys: '[MouseLeft>]', target: outsideControl });
+    await waitFor(() => expect(dialog).not.toBeInTheDocument());
+    await expect(firstVerse).not.toHaveClass('yv-v-selected');
+    await expect(secondVerse).not.toHaveClass('yv-v-selected');
+    await userEvent.pointer({ keys: '[/MouseLeft]', target: outsideControl });
+  },
+};
+
 /**
  * Dark theme
  */

--- a/packages/ui/src/components/bible-reader.stories.tsx
+++ b/packages/ui/src/components/bible-reader.stories.tsx
@@ -161,7 +161,7 @@ export const Default: Story = {
   },
 };
 
-export const VerseActionPointerInteractions: Story = {
+export const VerseActionPopoverInteractions: Story = {
   tags: ['integration'],
   args: {
     defaultVersionId: 111,
@@ -181,7 +181,7 @@ export const VerseActionPointerInteractions: Story = {
   },
   render: (args) => (
     <div className="yv:grid yv:h-screen yv:grid-rows-[auto_1fr] yv:bg-background">
-      <button type="button" data-testid="outside-reader-control">
+      <button type="button" data-testid="outside-reader-control" autoFocus>
         Outside reader
       </button>
       <BibleReader.Root {...args}>
@@ -204,19 +204,40 @@ export const VerseActionPointerInteractions: Story = {
     if (!secondVerse || !secondVerseLabel || !outsideControl)
       throw new Error('reader interaction controls not rendered');
 
+    const ownerDocument = canvasElement.ownerDocument;
+    await waitFor(() => expect(ownerDocument.activeElement).toBe(outsideControl));
     await userEvent.click(firstVerse);
-    const dialog = await screen.findByRole('dialog');
+    let dialog = await screen.findByRole('dialog');
+
+    await expect(dialog.getRootNode()).toBe(ownerDocument);
+    await expect(ownerDocument.body).toContainElement(dialog);
+    await waitFor(() => expect(ownerDocument.activeElement).toBe(dialog));
+
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    await expect(ownerDocument.activeElement).toBe(outsideControl);
+
+    await userEvent.click(firstVerse);
+    dialog = await screen.findByRole('dialog');
+    const firstDialogRect = dialog.getBoundingClientRect();
 
     await userEvent.click(secondVerseLabel);
     await expect(firstVerse).toHaveClass('yv-v-selected');
     await expect(secondVerse).toHaveClass('yv-v-selected');
     await expect(dialog).toBeInTheDocument();
+    await waitFor(() => {
+      const reanchoredRect = dialog.getBoundingClientRect();
+      const movedInline = Math.abs(reanchoredRect.left - firstDialogRect.left) > 8;
+      const movedBlock = Math.abs(reanchoredRect.top - firstDialogRect.top) > 8;
+      void expect(movedInline || movedBlock).toBe(true);
+    });
 
     await userEvent.pointer({ keys: '[MouseLeft>]', target: outsideControl });
     await waitFor(() => expect(dialog).not.toBeInTheDocument());
     await expect(firstVerse).not.toHaveClass('yv-v-selected');
     await expect(secondVerse).not.toHaveClass('yv-v-selected');
     await userEvent.pointer({ keys: '[/MouseLeft]', target: outsideControl });
+    await expect(ownerDocument.activeElement).toBe(outsideControl);
   },
 };
 

--- a/packages/ui/src/components/verse-action-popover.shadow-isolation.stories.tsx
+++ b/packages/ui/src/components/verse-action-popover.shadow-isolation.stories.tsx
@@ -1,0 +1,310 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { http, HttpResponse } from 'msw';
+import { useRef, useState } from 'react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import i18n from '../i18n';
+import { ShadowRootHost } from '../lib/shadow-root-host';
+import { requireShadowRoot } from '../test/dom-stubs';
+import { VerseActionPopover } from './verse-action-popover';
+
+function IsolatedVerseActionPopover(): React.ReactNode {
+  const [open, setOpen] = useState(false);
+  const [anchorElement, setAnchorElement] = useState<HTMLElement | null>(null);
+  const [readerScrollRoot, setReaderScrollRoot] = useState<HTMLDivElement | null>(null);
+  const [selectedVerses, setSelectedVerses] = useState<number[]>([]);
+  const [closeRequests, setCloseRequests] = useState(0);
+  const rejectNextCloseRef = useRef(false);
+  const deferNextCloseRef = useRef(false);
+
+  const selectVerse = (verse: number, element: HTMLElement): void => {
+    setAnchorElement(element);
+    setSelectedVerses([verse]);
+    setOpen(true);
+  };
+
+  return (
+    <div style={{ display: 'grid', gap: 24 }}>
+      <button type="button" data-testid="outside-control">
+        Outside control
+      </button>
+      <button
+        type="button"
+        data-testid="rejected-outside-control"
+        onPointerDown={() => {
+          rejectNextCloseRef.current = true;
+        }}
+      >
+        Reject outside close
+      </button>
+      <button
+        type="button"
+        data-testid="delayed-outside-control"
+        onPointerDown={() => {
+          deferNextCloseRef.current = true;
+        }}
+      >
+        Delay outside close
+      </button>
+      <div
+        data-testid="clipping-container"
+        style={{ inlineSize: 800, blockSize: 72, overflow: 'hidden' }}
+      >
+        <ShadowRootHost portalStrategy="local-top-layer">
+          <div
+            ref={setReaderScrollRoot}
+            data-testid="reader-scroll-root"
+            style={{ blockSize: 64, overflowY: 'auto' }}
+          >
+            <div style={{ display: 'grid', gap: 8 }}>
+              <button type="button" data-testid="prior-control">
+                Prior control
+              </button>
+              <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <span
+                  ref={(element) => {
+                    element?.setAttribute('v', '1');
+                  }}
+                  className="yv-v"
+                  data-testid="verse-1"
+                  onClick={(event) => selectVerse(1, event.currentTarget)}
+                >
+                  First verse
+                </span>
+                <span
+                  ref={(element) => {
+                    element?.setAttribute('v', '2');
+                  }}
+                  className="yv-v"
+                  data-testid="verse-2"
+                  onClick={(event) => selectVerse(2, event.currentTarget)}
+                >
+                  Second verse
+                </span>
+              </div>
+              <output data-testid="close-requests" data-count={closeRequests} />
+              <div aria-hidden="true" style={{ blockSize: 280 }} />
+            </div>
+          </div>
+          <VerseActionPopover
+            open={open}
+            onOpenChange={(nextOpen) => {
+              if (!nextOpen) setCloseRequests((count) => count + 1);
+              if (!nextOpen && rejectNextCloseRef.current) {
+                rejectNextCloseRef.current = false;
+                return;
+              }
+              if (!nextOpen && deferNextCloseRef.current) {
+                deferNextCloseRef.current = false;
+                setTimeout(() => setOpen(false), 25);
+                return;
+              }
+              setOpen(nextOpen);
+            }}
+            activeHighlights={new Set()}
+            selectedVerses={selectedVerses}
+            highlightedVerses={{}}
+            anchorElement={anchorElement}
+            scrollRoot={readerScrollRoot}
+            onHighlight={() => setOpen(false)}
+            onClearHighlight={() => setOpen(false)}
+            onCopy={() => setOpen(false)}
+            onShare={() => setOpen(false)}
+          />
+        </ShadowRootHost>
+      </div>
+    </div>
+  );
+}
+
+const meta = {
+  title: 'Spikes/VerseActionPopover Shadow DOM isolation',
+  component: IsolatedVerseActionPopover,
+  tags: ['integration'],
+  parameters: {
+    layout: 'centered',
+    msw: {
+      handlers: [
+        http.get('*/v1/fonts/1/stylesheet', () =>
+          HttpResponse.text('', { headers: { 'Content-Type': 'text/css' } }),
+        ),
+      ],
+    },
+  },
+} satisfies Meta<typeof IsolatedVerseActionPopover>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+async function waitForElement<ElementType extends Element>(
+  container: ParentNode,
+  selector: string,
+  message: string,
+): Promise<ElementType> {
+  return waitFor(() => {
+    const element = container.querySelector<ElementType>(selector);
+    if (!element) throw new Error(message);
+    return element;
+  });
+}
+
+async function waitForClosed(topLayer: HTMLElement): Promise<void> {
+  await waitFor(() => {
+    void expect(topLayer.querySelector('[role="dialog"]')).toBeNull();
+    void expect(topLayer.matches(':popover-open')).toBe(false);
+  });
+}
+
+function getCopyButton(dialog: HTMLElement): HTMLButtonElement {
+  return within(dialog).getByRole('button', { name: i18n.t('copy') });
+}
+
+export const PortalPlacementDockingReanchoringAndFocusRestoration: Story = {
+  play: async ({ canvasElement }) => {
+    const shadowRoot = await waitFor(() => requireShadowRoot(canvasElement));
+    const priorControl = await waitForElement<HTMLButtonElement>(
+      shadowRoot,
+      '[data-testid="prior-control"]',
+      'prior focus control not rendered',
+    );
+    const firstVerse = await waitForElement<HTMLElement>(
+      shadowRoot,
+      '[data-testid="verse-1"]',
+      'first verse not rendered',
+    );
+    const secondVerse = await waitForElement<HTMLElement>(
+      shadowRoot,
+      '[data-testid="verse-2"]',
+      'second verse not rendered',
+    );
+    const clippingContainer = canvasElement.querySelector<HTMLElement>(
+      '[data-testid="clipping-container"]',
+    );
+    const readerScrollRoot = await waitForElement<HTMLElement>(
+      shadowRoot,
+      '[data-testid="reader-scroll-root"]',
+      'reader scroll root not rendered',
+    );
+    const outsideControl = canvasElement.querySelector<HTMLButtonElement>(
+      '[data-testid="outside-control"]',
+    );
+    const rejectedOutsideControl = canvasElement.querySelector<HTMLButtonElement>(
+      '[data-testid="rejected-outside-control"]',
+    );
+    const delayedOutsideControl = canvasElement.querySelector<HTMLButtonElement>(
+      '[data-testid="delayed-outside-control"]',
+    );
+    if (!clippingContainer || !outsideControl || !rejectedOutsideControl || !delayedOutsideControl)
+      throw new Error('light DOM controls not rendered');
+
+    priorControl.focus();
+    await userEvent.click(firstVerse);
+    const topLayer = await waitForElement<HTMLElement>(
+      shadowRoot,
+      '[data-yv-shadow-local-overlay]',
+      'shadow-local top layer not created',
+    );
+    let dialog = await waitForElement<HTMLElement>(
+      topLayer,
+      '[role="dialog"]',
+      'verse action popover not rendered',
+    );
+
+    await waitFor(() => void expect(topLayer.matches(':popover-open')).toBe(true));
+    void expect(topLayer.getRootNode()).toBe(shadowRoot);
+    void expect(dialog.getRootNode()).toBe(shadowRoot);
+    void expect(canvasElement.ownerDocument.body.querySelector('[role="dialog"]')).toBeNull();
+    void expect(dialog).toHaveAccessibleName(/.+/);
+    void expect(dialog.querySelector('[role="group"]')).toHaveAccessibleName(/.+/);
+    await waitFor(() => void expect(shadowRoot.activeElement).toBe(dialog));
+
+    const clippingRect = clippingContainer.getBoundingClientRect();
+    const firstDialogRect = dialog.getBoundingClientRect();
+    const escapesAbove = firstDialogRect.top < clippingRect.top - 1;
+    const escapesBelow = firstDialogRect.bottom > clippingRect.bottom + 1;
+    void expect(escapesAbove || escapesBelow).toBe(true);
+    const sampleX = firstDialogRect.left + firstDialogRect.width / 2;
+    const sampleY = escapesBelow
+      ? Math.max(firstDialogRect.top + 2, clippingRect.bottom + 2)
+      : Math.min(firstDialogRect.bottom - 2, clippingRect.top - 2);
+    if (sampleY <= firstDialogRect.top || sampleY >= firstDialogRect.bottom)
+      throw new Error('popover did not escape clipping bounds');
+    const hit = shadowRoot.elementFromPoint(sampleX, sampleY);
+    void expect(hit === dialog || (hit !== null && dialog.contains(hit))).toBe(true);
+
+    readerScrollRoot.scrollTop = readerScrollRoot.scrollHeight;
+    await waitFor(() => {
+      const readerRect = readerScrollRoot.getBoundingClientRect();
+      const dockedRect = dialog.getBoundingClientRect();
+      void expect(Math.abs(dockedRect.top - (readerRect.top + 24))).toBeLessThan(12);
+      void expect(
+        Math.abs(dockedRect.left + dockedRect.width / 2 - (readerRect.left + readerRect.width / 2)),
+      ).toBeLessThan(2);
+    });
+    readerScrollRoot.scrollTop = 0;
+    await waitFor(() => {
+      const returnedRect = dialog.getBoundingClientRect();
+      void expect(Math.abs(returnedRect.left - firstDialogRect.left)).toBeLessThan(8);
+      void expect(Math.abs(returnedRect.top - firstDialogRect.top)).toBeLessThan(12);
+    });
+
+    await userEvent.click(secondVerse);
+    await waitFor(() => {
+      const nextRect = dialog.getBoundingClientRect();
+      void expect(nextRect.left).toBeGreaterThan(firstDialogRect.left + 20);
+    });
+    void expect(
+      shadowRoot.querySelector('[data-testid="close-requests"]')?.getAttribute('data-count'),
+    ).toBe('0');
+    void expect(topLayer).toContainElement(dialog);
+
+    await userEvent.keyboard('{Escape}');
+    await waitForClosed(topLayer);
+    void expect(shadowRoot.activeElement).toBe(priorControl);
+
+    priorControl.focus();
+    await userEvent.click(firstVerse);
+    dialog = await waitForElement(topLayer, '[role="dialog"]', 'popover did not reopen');
+    await userEvent.click(getCopyButton(dialog));
+    await waitForClosed(topLayer);
+    void expect(shadowRoot.activeElement).toBe(priorControl);
+
+    priorControl.focus();
+    await userEvent.click(firstVerse);
+    dialog = await waitForElement(
+      topLayer,
+      '[role="dialog"]',
+      'popover did not reopen for rejected outside close',
+    );
+    const closeRequestOutput = shadowRoot.querySelector<HTMLOutputElement>(
+      '[data-testid="close-requests"]',
+    );
+    if (!closeRequestOutput) throw new Error('close request output missing');
+    const closeRequestsBeforeRejection = Number(closeRequestOutput.getAttribute('data-count'));
+    await userEvent.click(rejectedOutsideControl);
+    await waitFor(
+      () =>
+        void expect(Number(closeRequestOutput.getAttribute('data-count'))).toBe(
+          closeRequestsBeforeRejection + 1,
+        ),
+    );
+    void expect(topLayer).toContainElement(dialog);
+    void expect(canvasElement.ownerDocument.activeElement).toBe(rejectedOutsideControl);
+    await userEvent.click(getCopyButton(dialog));
+    await waitForClosed(topLayer);
+    void expect(shadowRoot.activeElement).toBe(priorControl);
+
+    priorControl.focus();
+    await userEvent.click(firstVerse);
+    await waitForElement(topLayer, '[role="dialog"]', 'popover did not reopen for delayed close');
+    await userEvent.click(delayedOutsideControl);
+    await waitForClosed(topLayer);
+    void expect(canvasElement.ownerDocument.activeElement).toBe(delayedOutsideControl);
+
+    priorControl.focus();
+    await userEvent.click(firstVerse);
+    await waitForElement(topLayer, '[role="dialog"]', 'popover did not reopen for outside click');
+    await userEvent.click(outsideControl);
+    await waitForClosed(topLayer);
+    void expect(canvasElement.ownerDocument.activeElement).toBe(outsideControl);
+  },
+};

--- a/packages/ui/src/components/verse-action-popover.shadow-isolation.stories.tsx
+++ b/packages/ui/src/components/verse-action-popover.shadow-isolation.stories.tsx
@@ -53,7 +53,7 @@ function IsolatedVerseActionPopover(): React.ReactNode {
           <div
             ref={setReaderScrollRoot}
             data-testid="reader-scroll-root"
-            style={{ blockSize: 64, overflowY: 'auto' }}
+            style={{ blockSize: 64, overflowBlock: 'auto' }}
           >
             <div style={{ display: 'grid', gap: 8 }}>
               <button type="button" data-testid="prior-control">

--- a/packages/ui/src/components/verse-action-popover.test.tsx
+++ b/packages/ui/src/components/verse-action-popover.test.tsx
@@ -1,5 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ShadowRootHost } from '@/lib/shadow-root-host';
+import { requireShadowRoot } from '@/test/dom-stubs';
 import { fillFor } from '@/test/highlights-test-utils';
 import {
   VerseActionPopover,
@@ -8,8 +10,8 @@ import {
   type HighlightColor,
 } from './verse-action-popover';
 
-describe('VerseActionPopover', () => {
-  const defaultProps = {
+function createDefaultProps() {
+  return {
     open: true,
     onOpenChange: vi.fn(),
     activeHighlights: new Set<string>(),
@@ -21,14 +23,12 @@ describe('VerseActionPopover', () => {
     onCopy: vi.fn(),
     onShare: vi.fn(),
   };
+}
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
+describe('VerseActionPopover', () => {
   describe('AC1: Basic popover display', () => {
     it('should display 6 color circles when verse selected', () => {
-      render(<VerseActionPopover {...defaultProps} />);
+      render(<VerseActionPopover {...createDefaultProps()} />);
 
       const colorButtons = screen
         .getAllByRole('button')
@@ -38,7 +38,7 @@ describe('VerseActionPopover', () => {
     });
 
     it('should render the six apply colors', () => {
-      render(<VerseActionPopover {...defaultProps} />);
+      render(<VerseActionPopover {...createDefaultProps()} />);
 
       const applyButtons = screen
         .getAllByRole('button')
@@ -59,7 +59,7 @@ describe('VerseActionPopover', () => {
     // redirect initial focus to the (non-tabbable) content element instead, so
     // the ring only appears once the user actually Tabs to a swatch.
     it('moves initial focus to the popover content, not the first swatch', async () => {
-      render(<VerseActionPopover {...defaultProps} />);
+      render(<VerseActionPopover {...createDefaultProps()} />);
 
       const dialog = screen.getByRole('dialog');
       const firstSwatch = screen
@@ -76,7 +76,7 @@ describe('VerseActionPopover', () => {
   describe('AC2: Apply highlight', () => {
     it('should call onHighlight when color circle clicked', () => {
       const onHighlight = vi.fn();
-      render(<VerseActionPopover {...defaultProps} onHighlight={onHighlight} />);
+      render(<VerseActionPopover {...createDefaultProps()} onHighlight={onHighlight} />);
 
       const firstColorButton = screen
         .getAllByRole('button')
@@ -87,7 +87,7 @@ describe('VerseActionPopover', () => {
     });
 
     it('should render popover with color buttons', () => {
-      render(<VerseActionPopover {...defaultProps} />);
+      render(<VerseActionPopover {...createDefaultProps()} />);
 
       const dialog = screen.getByRole('dialog');
       expect(dialog).toBeTruthy();
@@ -102,14 +102,14 @@ describe('VerseActionPopover', () => {
 
   describe('AC3: Copy action', () => {
     it('should display copy button', () => {
-      render(<VerseActionPopover {...defaultProps} />);
+      render(<VerseActionPopover {...createDefaultProps()} />);
       const copyButton = screen.getByText('Copy');
       expect(copyButton).toBeTruthy();
     });
 
     it('should call onCopy when copy button clicked', () => {
       const onCopy = vi.fn();
-      render(<VerseActionPopover {...defaultProps} onCopy={onCopy} />);
+      render(<VerseActionPopover {...createDefaultProps()} onCopy={onCopy} />);
 
       const copyButton = screen.getByText('Copy');
       fireEvent.click(copyButton);
@@ -119,14 +119,14 @@ describe('VerseActionPopover', () => {
 
   describe('AC4: Share action', () => {
     it('should display share button', () => {
-      render(<VerseActionPopover {...defaultProps} />);
+      render(<VerseActionPopover {...createDefaultProps()} />);
       const shareButton = screen.getByText('Share');
       expect(shareButton).toBeTruthy();
     });
 
     it('should call onShare when share button clicked', () => {
       const onShare = vi.fn();
-      render(<VerseActionPopover {...defaultProps} onShare={onShare} />);
+      render(<VerseActionPopover {...createDefaultProps()} onShare={onShare} />);
 
       const shareButton = screen.getByText('Share');
       fireEvent.click(shareButton);
@@ -142,7 +142,7 @@ describe('VerseActionPopover', () => {
 
       render(
         <VerseActionPopover
-          {...defaultProps}
+          {...createDefaultProps()}
           activeHighlights={activeHighlights}
           selectedVerses={selectedVerses}
           highlightedVerses={highlightedVerses}
@@ -170,7 +170,7 @@ describe('VerseActionPopover', () => {
 
       render(
         <VerseActionPopover
-          {...defaultProps}
+          {...createDefaultProps()}
           activeHighlights={activeHighlights}
           selectedVerses={selectedVerses}
           highlightedVerses={highlightedVerses}
@@ -197,7 +197,7 @@ describe('VerseActionPopover', () => {
 
       render(
         <VerseActionPopover
-          {...defaultProps}
+          {...createDefaultProps()}
           activeHighlights={activeHighlights}
           selectedVerses={selectedVerses}
           highlightedVerses={highlightedVerses}
@@ -226,7 +226,7 @@ describe('VerseActionPopover', () => {
 
       render(
         <VerseActionPopover
-          {...defaultProps}
+          {...createDefaultProps()}
           activeHighlights={activeHighlights}
           selectedVerses={selectedVerses}
           highlightedVerses={highlightedVerses}
@@ -254,7 +254,7 @@ describe('VerseActionPopover', () => {
 
       render(
         <VerseActionPopover
-          {...defaultProps}
+          {...createDefaultProps()}
           activeHighlights={activeHighlights}
           selectedVerses={selectedVerses}
           highlightedVerses={highlightedVerses}
@@ -275,7 +275,7 @@ describe('VerseActionPopover', () => {
 
       render(
         <VerseActionPopover
-          {...defaultProps}
+          {...createDefaultProps()}
           activeHighlights={activeHighlights}
           selectedVerses={selectedVerses}
           highlightedVerses={highlightedVerses}
@@ -308,7 +308,7 @@ describe('VerseActionPopover', () => {
 
       render(
         <VerseActionPopover
-          {...defaultProps}
+          {...createDefaultProps()}
           activeHighlights={activeHighlights}
           selectedVerses={selectedVerses}
           highlightedVerses={highlightedVerses}
@@ -325,22 +325,15 @@ describe('VerseActionPopover', () => {
 
   describe('Popover visibility', () => {
     it('should not render content when open is false', () => {
-      render(<VerseActionPopover {...defaultProps} open={false} />);
+      render(<VerseActionPopover {...createDefaultProps()} open={false} />);
 
       expect(screen.queryByRole('dialog')).toBeNull();
     });
 
     it('should render content when open is true', () => {
-      render(<VerseActionPopover {...defaultProps} open={true} />);
+      render(<VerseActionPopover {...createDefaultProps()} open={true} />);
 
       expect(screen.getByRole('dialog')).toBeTruthy();
-    });
-
-    it('should use Radix popover with portal', () => {
-      render(<VerseActionPopover {...defaultProps} />);
-
-      const dialog = screen.getByRole('dialog');
-      expect(dialog).toBeTruthy();
     });
   });
 
@@ -352,7 +345,7 @@ describe('VerseActionPopover', () => {
 
       render(
         <VerseActionPopover
-          {...defaultProps}
+          {...createDefaultProps()}
           activeHighlights={activeHighlights}
           selectedVerses={selectedVerses}
           highlightedVerses={highlightedVerses}
@@ -373,7 +366,7 @@ describe('VerseActionPopover', () => {
     });
 
     it('should have dialog role with aria-label', () => {
-      render(<VerseActionPopover {...defaultProps} />);
+      render(<VerseActionPopover {...createDefaultProps()} />);
 
       const dialog = screen.getByRole('dialog');
       expect(dialog).toBeTruthy();
@@ -381,7 +374,7 @@ describe('VerseActionPopover', () => {
     });
 
     it('should have semantic color group', () => {
-      render(<VerseActionPopover {...defaultProps} />);
+      render(<VerseActionPopover {...createDefaultProps()} />);
 
       const colorGroup = screen.getByRole('group', { name: 'Highlight colors' });
       expect(colorGroup).toBeTruthy();
@@ -390,21 +383,21 @@ describe('VerseActionPopover', () => {
 
   describe('Styling', () => {
     it('should have data-yv-sdk attribute for scoping', () => {
-      render(<VerseActionPopover {...defaultProps} />);
+      render(<VerseActionPopover {...createDefaultProps()} />);
 
       const dialog = screen.getByRole('dialog');
       expect(dialog.getAttribute('data-yv-sdk')).not.toBeNull();
     });
 
     it('should apply theme attribute', () => {
-      render(<VerseActionPopover {...defaultProps} theme="dark" />);
+      render(<VerseActionPopover {...createDefaultProps()} theme="dark" />);
 
       const dialog = screen.getByRole('dialog');
       expect(dialog.getAttribute('data-yv-theme')).toBe('dark');
     });
 
     it('should default to light theme', () => {
-      render(<VerseActionPopover {...defaultProps} />);
+      render(<VerseActionPopover {...createDefaultProps()} />);
 
       const dialog = screen.getByRole('dialog');
       expect(dialog.getAttribute('data-yv-theme')).toBe('light');
@@ -416,7 +409,7 @@ describe('VerseActionPopover', () => {
       const custom = 'aabbcc';
       render(
         <VerseActionPopover
-          {...defaultProps}
+          {...createDefaultProps()}
           activeHighlights={new Set([custom])}
           selectedVerses={[1]}
           highlightedVerses={{ 1: custom }}
@@ -431,7 +424,7 @@ describe('VerseActionPopover', () => {
     it('shows leftover fffe00 as a remove swatch, not an apply swatch', () => {
       render(
         <VerseActionPopover
-          {...defaultProps}
+          {...createDefaultProps()}
           activeHighlights={new Set(['fffe00'])}
           selectedVerses={[1]}
           highlightedVerses={{ 1: 'fffe00' }}
@@ -449,7 +442,7 @@ describe('VerseActionPopover', () => {
     it('should handle empty active highlights', () => {
       const activeHighlights = new Set<HighlightColor>();
 
-      render(<VerseActionPopover {...defaultProps} activeHighlights={activeHighlights} />);
+      render(<VerseActionPopover {...createDefaultProps()} activeHighlights={activeHighlights} />);
 
       const applyButtons = screen
         .getAllByRole('button')
@@ -473,7 +466,7 @@ describe('VerseActionPopover', () => {
 
       render(
         <VerseActionPopover
-          {...defaultProps}
+          {...createDefaultProps()}
           activeHighlights={activeHighlights}
           selectedVerses={selectedVerses}
           highlightedVerses={highlightedVerses}
@@ -508,7 +501,7 @@ describe('VerseActionPopover', () => {
 
       render(
         <VerseActionPopover
-          {...defaultProps}
+          {...createDefaultProps()}
           activeHighlights={activeHighlights}
           selectedVerses={selectedVerses}
           highlightedVerses={highlightedVerses}
@@ -549,7 +542,7 @@ describe('VerseActionPopover', () => {
     it('renders a checkmark (not an X) on the active/remove swatch', () => {
       render(
         <VerseActionPopover
-          {...defaultProps}
+          {...createDefaultProps()}
           activeHighlights={new Set<HighlightColor>([HIGHLIGHT_COLORS[0]])}
           selectedVerses={[1]}
           highlightedVerses={{ 1: HIGHLIGHT_COLORS[0] }}
@@ -562,7 +555,7 @@ describe('VerseActionPopover', () => {
     });
 
     it('apply swatches render no icon', () => {
-      render(<VerseActionPopover {...defaultProps} />);
+      render(<VerseActionPopover {...createDefaultProps()} />);
       applyButtons().forEach((btn) => {
         expect(btn.querySelector('svg')).toBeNull();
       });
@@ -576,29 +569,29 @@ describe('VerseActionPopover', () => {
     }
 
     it('paints drawer dots with the unmixed stored hex in light mode', () => {
-      render(<VerseActionPopover {...defaultProps} theme="light" />);
+      render(<VerseActionPopover {...createDefaultProps()} theme="light" />);
       expect(firstApplySwatch().style.backgroundColor).toBe(fillFor(HIGHLIGHT_COLORS[0], 'card'));
     });
 
     it('paints drawer dots with the dark mix against the card surface', () => {
-      render(<VerseActionPopover {...defaultProps} theme="dark" />);
+      render(<VerseActionPopover {...createDefaultProps()} theme="dark" />);
       expect(firstApplySwatch().style.backgroundColor).toBe(fillFor(HIGHLIGHT_COLORS[0], 'card'));
       expect(firstApplySwatch().style.backgroundColor).toContain('var(--yv-card)');
     });
 
     it('uses a dark inner stroke in light mode and a light one in dark mode', () => {
-      const { unmount } = render(<VerseActionPopover {...defaultProps} theme="light" />);
+      const { unmount } = render(<VerseActionPopover {...createDefaultProps()} theme="light" />);
       expect(firstApplySwatch().style.border).toContain('rgba(18, 18, 18, 0.2)');
       unmount();
 
-      render(<VerseActionPopover {...defaultProps} theme="dark" />);
+      render(<VerseActionPopover {...createDefaultProps()} theme="dark" />);
       expect(firstApplySwatch().style.border).toContain('rgba(255, 255, 255, 0.2)');
     });
 
     it('keeps the active-swatch checkmark legible on the dimmed dark-mode fill', () => {
       render(
         <VerseActionPopover
-          {...defaultProps}
+          {...createDefaultProps()}
           theme="dark"
           activeHighlights={new Set<HighlightColor>([HIGHLIGHT_COLORS[0]])}
           selectedVerses={[1]}
@@ -612,7 +605,7 @@ describe('VerseActionPopover', () => {
     it('keeps the light-mode checkmark in the Text/Everdark color', () => {
       render(
         <VerseActionPopover
-          {...defaultProps}
+          {...createDefaultProps()}
           theme="light"
           activeHighlights={new Set<HighlightColor>([HIGHLIGHT_COLORS[0]])}
           selectedVerses={[1]}
@@ -627,7 +620,7 @@ describe('VerseActionPopover', () => {
       const custom = '000000';
       render(
         <VerseActionPopover
-          {...defaultProps}
+          {...createDefaultProps()}
           theme="light"
           activeHighlights={new Set([custom])}
           selectedVerses={[1]}
@@ -645,7 +638,7 @@ describe('VerseActionPopover', () => {
     // way to reach it. The pill is now capped to the viewport and the swatch row
     // scrolls horizontally inside it.
     it('caps the popover content to the min of the Radix available width and the live viewport', () => {
-      render(<VerseActionPopover {...defaultProps} />);
+      render(<VerseActionPopover {...createDefaultProps()} />);
       const dialog = screen.getByRole('dialog');
       // The `min(..., calc(100vw-24px))` term is what keeps the cap honest when
       // the viewport shrinks under an open popover — Radix's own var goes stale
@@ -656,7 +649,7 @@ describe('VerseActionPopover', () => {
     });
 
     it('makes the swatch row horizontally scrollable with a hidden scrollbar', () => {
-      render(<VerseActionPopover {...defaultProps} />);
+      render(<VerseActionPopover {...createDefaultProps()} />);
       const swatchRow = screen.getByRole('group', { name: 'Highlight colors' });
       expect(swatchRow.className).toContain('yv:overflow-x-auto');
       expect(swatchRow.className).toContain('yv:scrollbar-hide');
@@ -666,7 +659,7 @@ describe('VerseActionPopover', () => {
     });
 
     it('keeps swatches from squishing when the row is capped', () => {
-      render(<VerseActionPopover {...defaultProps} />);
+      render(<VerseActionPopover {...createDefaultProps()} />);
       const applyButton = screen
         .getAllByRole('button')
         .find((btn) => btn.getAttribute('aria-label')?.includes('Apply'))!;
@@ -684,7 +677,7 @@ describe('VerseActionPopover', () => {
     it('engages the edge-fade mask on scroll once the row overflows', () => {
       render(
         <VerseActionPopover
-          {...defaultProps}
+          {...createDefaultProps()}
           activeHighlights={new Set<HighlightColor>(HIGHLIGHT_COLORS)}
           selectedVerses={[1, 2, 3, 4, 5]}
           highlightedVerses={{
@@ -765,7 +758,7 @@ describe('VerseActionPopover', () => {
     it('hides the color row and remove circles but keeps Copy / Share', () => {
       render(
         <VerseActionPopover
-          {...defaultProps}
+          {...createDefaultProps()}
           highlightsEnabled={false}
           activeHighlights={new Set<HighlightColor>([HIGHLIGHT_COLORS[0]])}
           selectedVerses={[1]}
@@ -783,4 +776,31 @@ describe('VerseActionPopover', () => {
       expect(screen.getByText('Share')).toBeTruthy();
     });
   });
+});
+
+it('keeps isolated content in its shadow tree and preserves the document portal otherwise', async () => {
+  const isolatedRender = render(
+    <ShadowRootHost portalStrategy="local-inline">
+      <VerseActionPopover {...createDefaultProps()} />
+    </ShadowRootHost>,
+  );
+  const shadowRoot = requireShadowRoot(isolatedRender.container);
+
+  const isolatedDialog = await waitFor(() => {
+    const element = shadowRoot.querySelector<HTMLElement>('[role="dialog"]');
+    if (!element) throw new Error('isolated verse action popover not rendered');
+    return element;
+  });
+  expect(isolatedDialog.getRootNode()).toBe(shadowRoot);
+  expect(shadowRoot.querySelector('[data-yv-shadow-inline-overlay]')).toContainElement(
+    isolatedDialog,
+  );
+  expect(document.body.querySelector('[role="dialog"]')).toBeNull();
+  isolatedRender.unmount();
+
+  const documentRender = render(<VerseActionPopover {...createDefaultProps()} />);
+  const documentDialog = screen.getByRole('dialog');
+  expect(documentDialog.getRootNode()).toBe(document);
+  expect(document.body).toContainElement(documentDialog);
+  expect(documentRender.container).not.toContainElement(documentDialog);
 });

--- a/packages/ui/src/components/verse-action-popover.test.tsx
+++ b/packages/ui/src/components/verse-action-popover.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useRef, useState } from 'react';
 import { ShadowRootHost } from '@/lib/shadow-root-host';
 import { requireShadowRoot } from '@/test/dom-stubs';
 import { fillFor } from '@/test/highlights-test-utils';
@@ -23,6 +25,64 @@ function createDefaultProps() {
     onCopy: vi.fn(),
     onShare: vi.fn(),
   };
+}
+
+function FocusRestorationScenario() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        Prior control
+      </button>
+      <VerseActionPopover
+        {...createDefaultProps()}
+        open={open}
+        onOpenChange={setOpen}
+        onCopy={() => setOpen(false)}
+      />
+    </>
+  );
+}
+
+function ControlledCloseScenario() {
+  const [open, setOpen] = useState(false);
+  const [closeRequests, setCloseRequests] = useState(0);
+  const rejectNextCloseRef = useRef(false);
+  const deferNextCloseRef = useRef(false);
+
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        Prior control
+      </button>
+      <button type="button" onPointerDown={() => (rejectNextCloseRef.current = true)}>
+        Reject outside close
+      </button>
+      <button type="button" onPointerDown={() => (deferNextCloseRef.current = true)}>
+        Delay outside close
+      </button>
+      <output data-testid="close-requests">{closeRequests}</output>
+      <VerseActionPopover
+        {...createDefaultProps()}
+        open={open}
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen) setCloseRequests((count) => count + 1);
+          if (!nextOpen && rejectNextCloseRef.current) {
+            rejectNextCloseRef.current = false;
+            return;
+          }
+          if (!nextOpen && deferNextCloseRef.current) {
+            deferNextCloseRef.current = false;
+            setTimeout(() => setOpen(false), 25);
+            return;
+          }
+          setOpen(nextOpen);
+        }}
+        onCopy={() => setOpen(false)}
+      />
+    </>
+  );
 }
 
 describe('VerseActionPopover', () => {
@@ -803,4 +863,138 @@ it('keeps isolated content in its shadow tree and preserves the document portal 
   expect(documentDialog.getRootNode()).toBe(document);
   expect(document.body).toContainElement(documentDialog);
   expect(documentRender.container).not.toContainElement(documentDialog);
+});
+
+it('restores document focus after Escape and an action closes the popover', async () => {
+  render(<FocusRestorationScenario />);
+  const priorControl = screen.getByRole('button', { name: 'Prior control' });
+
+  priorControl.focus();
+  fireEvent.click(priorControl);
+  let dialog = await screen.findByRole('dialog');
+  await waitFor(() => expect(document.activeElement).toBe(dialog));
+
+  fireEvent.keyDown(dialog, { key: 'Escape' });
+  await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+  expect(document.activeElement).toBe(priorControl);
+
+  fireEvent.click(priorControl);
+  dialog = await screen.findByRole('dialog');
+  fireEvent.pointerDown(screen.getByRole('button', { name: 'Copy' }));
+  fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+  await waitFor(() => expect(dialog).not.toBeInTheDocument());
+  expect(document.activeElement).toBe(priorControl);
+});
+
+it('restores shadow focus after Escape and an action closes the popover', async () => {
+  const isolatedRender = render(
+    <ShadowRootHost portalStrategy="local-inline">
+      <FocusRestorationScenario />
+    </ShadowRootHost>,
+  );
+  const shadowRoot = requireShadowRoot(isolatedRender.container);
+  const priorControl = await waitFor(() => {
+    const element = shadowRoot.querySelector<HTMLButtonElement>('button');
+    if (!element) throw new Error('prior focus control not rendered');
+    return element;
+  });
+
+  priorControl.focus();
+  fireEvent.click(priorControl);
+  let dialog = await waitFor(() => {
+    const element = shadowRoot.querySelector<HTMLElement>('[role="dialog"]');
+    if (!element) throw new Error('isolated verse action popover not rendered');
+    return element;
+  });
+  await waitFor(() => expect(shadowRoot.activeElement).toBe(dialog));
+
+  fireEvent.keyDown(dialog, { key: 'Escape' });
+  await waitFor(() => expect(shadowRoot.querySelector('[role="dialog"]')).toBeNull());
+  expect(shadowRoot.activeElement).toBe(priorControl);
+
+  fireEvent.click(priorControl);
+  dialog = await waitFor(() => {
+    const element = shadowRoot.querySelector<HTMLElement>('[role="dialog"]');
+    if (!element) throw new Error('isolated verse action popover did not reopen');
+    return element;
+  });
+  const copyButton = Array.from(dialog.querySelectorAll('button')).find(
+    (button) => button.textContent === 'Copy',
+  );
+  if (!copyButton) throw new Error('copy action not rendered');
+  fireEvent.pointerDown(copyButton);
+  fireEvent.click(copyButton);
+  await waitFor(() => expect(shadowRoot.querySelector('[role="dialog"]')).toBeNull());
+  expect(shadowRoot.activeElement).toBe(priorControl);
+});
+
+it('preserves document focus through rejected and delayed outside closes', async () => {
+  const user = userEvent.setup();
+  render(<ControlledCloseScenario />);
+  const priorControl = screen.getByRole('button', { name: 'Prior control' });
+  const rejectedOutsideControl = screen.getByRole('button', { name: 'Reject outside close' });
+  const delayedOutsideControl = screen.getByRole('button', { name: 'Delay outside close' });
+
+  await user.click(priorControl);
+  let dialog = await screen.findByRole('dialog');
+  await user.click(rejectedOutsideControl);
+  await waitFor(() => expect(screen.getByTestId('close-requests')).toHaveTextContent('1'));
+  expect(dialog).toBeInTheDocument();
+  expect(document.activeElement).toBe(rejectedOutsideControl);
+
+  await user.click(screen.getByRole('button', { name: 'Copy' }));
+  await waitFor(() => expect(dialog).not.toBeInTheDocument());
+  expect(document.activeElement).toBe(priorControl);
+
+  await user.click(priorControl);
+  dialog = await screen.findByRole('dialog');
+  await user.click(delayedOutsideControl);
+  await waitFor(() => expect(dialog).not.toBeInTheDocument());
+  expect(document.activeElement).toBe(delayedOutsideControl);
+});
+
+it('restores document focus without retaining another popover as its target', async () => {
+  let setFirstOpen = (_open: boolean): void => undefined;
+  let setSecondOpen = (_open: boolean): void => undefined;
+
+  function TwoPopovers() {
+    const [firstOpen, updateFirstOpen] = useState(false);
+    const [secondOpen, updateSecondOpen] = useState(false);
+    setFirstOpen = updateFirstOpen;
+    setSecondOpen = updateSecondOpen;
+
+    return (
+      <>
+        <button type="button">Prior control</button>
+        <VerseActionPopover
+          {...createDefaultProps()}
+          open={firstOpen}
+          onOpenChange={(nextOpen) => {
+            if (nextOpen) updateFirstOpen(true);
+          }}
+        />
+        <VerseActionPopover
+          {...createDefaultProps()}
+          open={secondOpen}
+          onOpenChange={updateSecondOpen}
+        />
+      </>
+    );
+  }
+
+  render(<TwoPopovers />);
+  const priorControl = screen.getByRole('button', { name: 'Prior control' });
+  priorControl.focus();
+
+  act(() => setFirstOpen(true));
+  await waitFor(() => expect(screen.getAllByRole('dialog')).toHaveLength(1));
+  act(() => setSecondOpen(true));
+  await waitFor(() => expect(screen.getAllByRole('dialog')).toHaveLength(2));
+
+  act(() => setFirstOpen(false));
+  await waitFor(() => expect(screen.getAllByRole('dialog')).toHaveLength(1));
+  act(() => setSecondOpen(false));
+
+  await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+  expect(document.activeElement).toBe(priorControl);
 });

--- a/packages/ui/src/components/verse-action-popover.tsx
+++ b/packages/ui/src/components/verse-action-popover.tsx
@@ -189,12 +189,36 @@ export const VerseActionPopover: FC<VerseActionPopoverProps> = ({
   // initial focus to the content container instead (see `onOpenAutoFocus`): focus
   // still enters the popover (Escape closes; screen readers announce the dialog),
   // but the ring only appears once the user actually Tabs to a swatch.
+  const popoverAnchorRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const focusRestoreTargetRef = useRef<HTMLElement | null>(null);
+  const documentFocusRestoreTargetRef = useRef<HTMLElement | null>(null);
   const retainOutsideFocusRef = useRef(false);
   const allowPriorFocusRestoration = (): void => {
     retainOutsideFocusRef.current = false;
   };
+
+  useEffect(() => {
+    const anchor = popoverAnchorRef.current;
+    if (!anchor || getOwnShadowRoot(anchor)) return;
+
+    const ownerDocument = anchor.ownerDocument;
+    const rememberFocusedElement = (target: EventTarget | null): void => {
+      if (
+        !isElementFromOwnerDocument(target, anchor, 'HTMLElement') ||
+        target.closest('[data-slot="verse-action-popover"]') ||
+        target.hasAttribute('data-radix-focus-guard')
+      ) {
+        return;
+      }
+      documentFocusRestoreTargetRef.current = target;
+    };
+    const handleFocusIn = (event: FocusEvent): void => rememberFocusedElement(event.target);
+
+    rememberFocusedElement(ownerDocument.activeElement);
+    ownerDocument.addEventListener('focusin', handleFocusIn);
+    return () => ownerDocument.removeEventListener('focusin', handleFocusIn);
+  }, []);
 
   // The swatch row is capped to the viewport width (see the Content max-width
   // below) and scrolls horizontally when it overflows. Track which edges have
@@ -326,38 +350,33 @@ export const VerseActionPopover: FC<VerseActionPopoverProps> = ({
     };
   }, [swatchRow, swatchCount]);
 
-  if (portal.awaitingPortalTarget) {
-    return (
-      <PopoverPrimitive.Root open={portal.open} onOpenChange={portal.onOpenChange}>
-        <PopoverPrimitive.Anchor virtualRef={view.virtualRef} />
-      </PopoverPrimitive.Root>
-    );
-  }
-
   return (
     <PopoverPrimitive.Root open={portal.open} onOpenChange={portal.onOpenChange}>
-      <PopoverPrimitive.Anchor virtualRef={view.virtualRef} />
-      <PopoverPrimitive.Portal container={portal.container}>
-        <PopoverPrimitive.Content
-          ref={contentRef}
-          role="dialog"
-          aria-label={t('verseActionsAriaLabel')}
-          tabIndex={-1}
-          data-yv-sdk
-          data-yv-theme={theme}
-          onOpenAutoFocus={(event) => {
-            // Keep focus contained in the popover but off the first swatch: land
-            // it on the (non-tabbable) content element so no `:focus-visible` ring
-            // shows on pointer-open. The first Tab still moves to the first swatch,
-            // and because Tab is keyboard modality the ring correctly appears then.
-            event.preventDefault();
-            const content = contentRef.current;
-            if (!content) return;
+      <PopoverPrimitive.Anchor ref={popoverAnchorRef} virtualRef={view.virtualRef} />
+      {!portal.awaitingPortalTarget && (
+        <PopoverPrimitive.Portal container={portal.container}>
+          <PopoverPrimitive.Content
+            ref={contentRef}
+            role="dialog"
+            data-slot="verse-action-popover"
+            aria-label={t('verseActionsAriaLabel')}
+            tabIndex={-1}
+            data-yv-sdk
+            data-yv-theme={theme}
+            onOpenAutoFocus={(event) => {
+              // Keep focus contained in the popover but off the first swatch: land
+              // it on the (non-tabbable) content element so no `:focus-visible` ring
+              // shows on pointer-open. The first Tab still moves to the first swatch,
+              // and because Tab is keyboard modality the ring correctly appears then.
+              event.preventDefault();
+              const content = contentRef.current;
+              if (!content) return;
 
-            const root = getOwnShadowRoot(content);
-            retainOutsideFocusRef.current = false;
-            if (root) {
-              const activeElement = root.activeElement ?? getShadowFocusRestoreTarget?.();
+              const root = getOwnShadowRoot(content);
+              retainOutsideFocusRef.current = false;
+              const activeElement = root
+                ? (root.activeElement ?? getShadowFocusRestoreTarget?.())
+                : documentFocusRestoreTargetRef.current;
               focusRestoreTargetRef.current = isElementFromOwnerDocument(
                 activeElement,
                 content,
@@ -365,147 +384,139 @@ export const VerseActionPopover: FC<VerseActionPopoverProps> = ({
               )
                 ? activeElement
                 : null;
-            } else {
+              content.focus({ preventScroll: true });
+            }}
+            onCloseAutoFocus={(event) => {
+              const root = portal.container ? getOwnShadowRoot(portal.container) : null;
+              const target = focusRestoreTargetRef.current;
+              const restoreTarget =
+                target?.isConnected && (!root || target.getRootNode() === root) ? target : null;
+              if (root || restoreTarget) event.preventDefault();
+              if (!retainOutsideFocusRef.current) restoreTarget?.focus();
+              retainOutsideFocusRef.current = false;
               focusRestoreTargetRef.current = null;
-            }
-            content.focus({ preventScroll: true });
-          }}
-          onCloseAutoFocus={(event) => {
-            const root = portal.container ? getOwnShadowRoot(portal.container) : null;
-            if (!root) return;
-
-            event.preventDefault();
-            const target = focusRestoreTargetRef.current;
-            if (
-              !retainOutsideFocusRef.current &&
-              target?.isConnected &&
-              target.getRootNode() === root
-            ) {
-              target.focus();
-            }
-            retainOutsideFocusRef.current = false;
-            focusRestoreTargetRef.current = null;
-          }}
-          onPointerDownCapture={allowPriorFocusRestoration}
-          onFocusCapture={allowPriorFocusRestoration}
-          onEscapeKeyDown={allowPriorFocusRestoration}
-          onInteractOutside={(event) => {
-            // Tapping another verse modifies the selection — it should re-anchor
-            // the popover, not dismiss it. Only a tap truly outside the reader
-            // dismisses (which clears the selection via onOpenChange).
-            const content = contentRef.current;
-            if (!content) return;
-            const originalEvent = event.detail.originalEvent;
-            const interactedWithVerse = originalEvent
-              .composedPath()
-              .some(
-                (target) =>
-                  isElementFromOwnerDocument(target, content, 'Element') &&
-                  target.matches('.yv-v[v]'),
-              );
-            if (interactedWithVerse) {
-              event.preventDefault();
-              return;
-            }
-            if (getOwnShadowRoot(content)) {
+            }}
+            onPointerDownCapture={allowPriorFocusRestoration}
+            onFocusCapture={allowPriorFocusRestoration}
+            onEscapeKeyDown={allowPriorFocusRestoration}
+            onInteractOutside={(event) => {
+              // Tapping another verse modifies the selection — it should re-anchor
+              // the popover, not dismiss it. Only a tap truly outside the reader
+              // dismisses (which clears the selection via onOpenChange).
+              const content = contentRef.current;
+              if (!content) return;
+              const originalEvent = event.detail.originalEvent;
+              const interactedWithVerse = originalEvent
+                .composedPath()
+                .some(
+                  (target) =>
+                    isElementFromOwnerDocument(target, content, 'Element') &&
+                    target.matches('.yv-v[v]'),
+                );
+              if (interactedWithVerse) {
+                event.preventDefault();
+                return;
+              }
               retainOutsideFocusRef.current = true;
-            }
-          }}
-          side={view.side}
-          sideOffset={view.sideOffset}
-          align="center"
-          // Keep the pill off the screen edges; this also shrinks Radix's
-          // `--radix-popover-content-available-width`, which we cap to below.
-          collisionPadding={12}
-          className={cn(
-            'yv:bg-card yv:text-popover-foreground',
-            'yv:rounded-full yv:drop-shadow-[0px_4.8432px_20px_rgba(0,0,0,0.19)]',
-            'yv:px-4 yv:py-2',
-            'yv:flex yv:items-center yv:gap-3',
-            // Never wider than the viewport (minus collision padding). When the
-            // swatch row can't fit, it scrolls inside instead of overflowing the
-            // screen. Radix sets `--radix-popover-content-available-width`, but
-            // only recomputes it on reposition — it goes stale on a plain window
-            // resize. `min()` with a live `100vw` term keeps the cap honest when
-            // the viewport shrinks under an open popover (24px = 2×collisionPadding).
-            'yv:max-w-[min(var(--radix-popover-content-available-width),calc(100vw-24px))]',
-            'yv:z-50 yv:outline-hidden',
-            'yv:overflow-visible yv:relative',
-            'yv:origin-(--radix-popover-content-transform-origin)',
-            'yv:data-[state=open]:animate-in yv:data-[state=closed]:animate-out',
-            'yv:data-[state=closed]:fade-out-0 yv:data-[state=open]:fade-in-0',
-            'yv:data-[state=closed]:zoom-out-95 yv:data-[state=open]:zoom-in-95',
-            'yv:data-[side=bottom]:slide-in-from-top-2',
-            'yv:data-[side=top]:slide-in-from-bottom-2',
-          )}
-          style={popoverMotionStyle}
-        >
-          {/* Caret — matches the card background in both themes, pointing at the
+            }}
+            side={view.side}
+            sideOffset={view.sideOffset}
+            align="center"
+            // Keep the pill off the screen edges; this also shrinks Radix's
+            // `--radix-popover-content-available-width`, which we cap to below.
+            collisionPadding={12}
+            className={cn(
+              'yv:bg-card yv:text-popover-foreground',
+              'yv:rounded-full yv:drop-shadow-[0px_4.8432px_20px_rgba(0,0,0,0.19)]',
+              'yv:px-4 yv:py-2',
+              'yv:flex yv:items-center yv:gap-3',
+              // Never wider than the viewport (minus collision padding). When the
+              // swatch row can't fit, it scrolls inside instead of overflowing the
+              // screen. Radix sets `--radix-popover-content-available-width`, but
+              // only recomputes it on reposition — it goes stale on a plain window
+              // resize. `min()` with a live `100vw` term keeps the cap honest when
+              // the viewport shrinks under an open popover (24px = 2×collisionPadding).
+              'yv:max-w-[min(var(--radix-popover-content-available-width),calc(100vw-24px))]',
+              'yv:z-50 yv:outline-hidden',
+              'yv:overflow-visible yv:relative',
+              'yv:origin-(--radix-popover-content-transform-origin)',
+              'yv:data-[state=open]:animate-in yv:data-[state=closed]:animate-out',
+              'yv:data-[state=closed]:fade-out-0 yv:data-[state=open]:fade-in-0',
+              'yv:data-[state=closed]:zoom-out-95 yv:data-[state=open]:zoom-in-95',
+              'yv:data-[side=bottom]:slide-in-from-top-2',
+              'yv:data-[side=top]:slide-in-from-bottom-2',
+            )}
+            style={popoverMotionStyle}
+          >
+            {/* Caret — matches the card background in both themes, pointing at the
               verse. Hidden when docked: the bar is no longer tied to a verse. */}
-          {view.showCaret && (
-            <svg
-              className="yv:text-card yv:absolute yv:-top-[16px] yv:left-1/2 yv:-translate-x-1/2"
-              width="33"
-              height="17"
-              viewBox="0 0 33 17"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-              aria-hidden="true"
-            >
-              <path d="M16.0215 0L32.0429 16.5H0L16.0215 0Z" fill="currentColor" />
-            </svg>
-          )}
-
-          {/* Highlights UI is hidden entirely when the feature is off (flag off):
-              only Copy / Share remain. */}
-          {highlightsEnabled && (
-            <>
-              <div
-                ref={setSwatchRow}
-                // `min-w-0` lets this flex child actually shrink below its
-                // content size so `overflow-x-auto` engages instead of widening
-                // the pill. `py-1 -my-1` gives the hover:scale-110 swatches
-                // vertical breathing room inside the (now-clipping) scroll box
-                // without shifting the row's resting position. Scrollbar hidden;
-                // the edge fade signals there's more to scroll.
-                className="yv:flex yv:items-center yv:gap-2 yv:min-w-0 yv:overflow-x-auto yv:scrollbar-hide yv:py-1 yv:-my-1"
-                style={scrollFadeMask(scrollFade)}
-                role="group"
-                aria-label={t('highlightColorsAriaLabel')}
+            {view.showCaret && (
+              <svg
+                className="yv:text-card yv:absolute yv:-top-[16px] yv:left-1/2 yv:-translate-x-1/2"
+                width="33"
+                height="17"
+                viewBox="0 0 33 17"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
               >
-                {view.colorCircles.map(({ color, showRemove, key }) => (
-                  <ColorCircle
-                    key={key}
-                    color={color}
-                    showRemove={showRemove}
-                    theme={theme}
-                    label={showRemove ? t('clearHighlightAriaLabel') : t('applyHighlightAriaLabel')}
-                    onClick={() => (showRemove ? onClearHighlight(color) : onHighlight(color))}
-                  />
-                ))}
-              </div>
+                <path d="M16.0215 0L32.0429 16.5H0L16.0215 0Z" fill="currentColor" />
+              </svg>
+            )}
 
-              {/* Separator — never shrinks, so only the swatch row scrolls. */}
-              <div className="yv:w-px yv:h-8 yv:shrink-0 yv:bg-border" aria-hidden="true" />
-            </>
-          )}
+            {/* Highlights UI is hidden entirely when the feature is off (flag off):
+              only Copy / Share remain. */}
+            {highlightsEnabled && (
+              <>
+                <div
+                  ref={setSwatchRow}
+                  // `min-w-0` lets this flex child actually shrink below its
+                  // content size so `overflow-x-auto` engages instead of widening
+                  // the pill. `py-1 -my-1` gives the hover:scale-110 swatches
+                  // vertical breathing room inside the (now-clipping) scroll box
+                  // without shifting the row's resting position. Scrollbar hidden;
+                  // the edge fade signals there's more to scroll.
+                  className="yv:flex yv:items-center yv:gap-2 yv:min-w-0 yv:overflow-x-auto yv:scrollbar-hide yv:py-1 yv:-my-1"
+                  style={scrollFadeMask(scrollFade)}
+                  role="group"
+                  aria-label={t('highlightColorsAriaLabel')}
+                >
+                  {view.colorCircles.map(({ color, showRemove, key }) => (
+                    <ColorCircle
+                      key={key}
+                      color={color}
+                      showRemove={showRemove}
+                      theme={theme}
+                      label={
+                        showRemove ? t('clearHighlightAriaLabel') : t('applyHighlightAriaLabel')
+                      }
+                      onClick={() => (showRemove ? onClearHighlight(color) : onHighlight(color))}
+                    />
+                  ))}
+                </div>
 
-          {/* Copy / Share stay pinned and fully visible; only the swatch row
+                {/* Separator — never shrinks, so only the swatch row scrolls. */}
+                <div className="yv:w-px yv:h-8 yv:shrink-0 yv:bg-border" aria-hidden="true" />
+              </>
+            )}
+
+            {/* Copy / Share stay pinned and fully visible; only the swatch row
               scrolls when space is tight. */}
-          <div className="yv:flex yv:items-center yv:gap-1 yv:shrink-0">
-            <ActionButton
-              icon={<BoxStackIcon className="yv:size-5" />}
-              label={t('copy')}
-              onClick={onCopy}
-            />
-            <ActionButton
-              icon={<Share className="yv:size-5" />}
-              label={t('share')}
-              onClick={onShare}
-            />
-          </div>
-        </PopoverPrimitive.Content>
-      </PopoverPrimitive.Portal>
+            <div className="yv:flex yv:items-center yv:gap-1 yv:shrink-0">
+              <ActionButton
+                icon={<BoxStackIcon className="yv:size-5" />}
+                label={t('copy')}
+                onClick={onCopy}
+              />
+              <ActionButton
+                icon={<Share className="yv:size-5" />}
+                label={t('share')}
+                onClick={onShare}
+              />
+            </div>
+          </PopoverPrimitive.Content>
+        </PopoverPrimitive.Portal>
+      )}
     </PopoverPrimitive.Root>
   );
 };

--- a/packages/ui/src/components/verse-action-popover.tsx
+++ b/packages/ui/src/components/verse-action-popover.tsx
@@ -6,7 +6,13 @@ import { cn } from '../lib/utils';
 import { BoxStackIcon } from './icons/box-stack';
 import { Share } from './icons/share';
 import { CheckIcon } from './icons/check';
+import { useShadowPortalState } from './ui/use-shadow-portal-state';
 import { buildVerseActionSwatches, highlightFillColorMix } from '@/lib/highlight-colors';
+import {
+  getOwnShadowRoot,
+  isElementFromOwnerDocument,
+  useShadowFocusRestoreTarget,
+} from '@/lib/shadow-root-host';
 import { isDarkHighlightHex } from './verse';
 
 /** Re-export for back-compat; prefer `@/lib/highlight-colors` for new code. */
@@ -173,6 +179,8 @@ export const VerseActionPopover: FC<VerseActionPopoverProps> = ({
   theme = 'light',
 }) => {
   const { t } = useTranslation(undefined, { i18n });
+  const portal = useShadowPortalState({ open, onOpenChange });
+  const getShadowFocusRestoreTarget = useShadowFocusRestoreTarget();
 
   // On open, Radix's FocusScope would autofocus the first swatch. Because the bar
   // opens from a mouse/tap on non-focusable verse text, Chromium treats that
@@ -182,6 +190,11 @@ export const VerseActionPopover: FC<VerseActionPopoverProps> = ({
   // still enters the popover (Escape closes; screen readers announce the dialog),
   // but the ring only appears once the user actually Tabs to a swatch.
   const contentRef = useRef<HTMLDivElement>(null);
+  const focusRestoreTargetRef = useRef<HTMLElement | null>(null);
+  const retainOutsideFocusRef = useRef(false);
+  const allowPriorFocusRestoration = (): void => {
+    retainOutsideFocusRef.current = false;
+  };
 
   // The swatch row is capped to the viewport width (see the Content max-width
   // below) and scrolls horizontally when it overflows. Track which edges have
@@ -313,10 +326,18 @@ export const VerseActionPopover: FC<VerseActionPopoverProps> = ({
     };
   }, [swatchRow, swatchCount]);
 
+  if (portal.awaitingPortalTarget) {
+    return (
+      <PopoverPrimitive.Root open={portal.open} onOpenChange={portal.onOpenChange}>
+        <PopoverPrimitive.Anchor virtualRef={view.virtualRef} />
+      </PopoverPrimitive.Root>
+    );
+  }
+
   return (
-    <PopoverPrimitive.Root open={open} onOpenChange={onOpenChange}>
+    <PopoverPrimitive.Root open={portal.open} onOpenChange={portal.onOpenChange}>
       <PopoverPrimitive.Anchor virtualRef={view.virtualRef} />
-      <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Portal container={portal.container}>
         <PopoverPrimitive.Content
           ref={contentRef}
           role="dialog"
@@ -330,15 +351,64 @@ export const VerseActionPopover: FC<VerseActionPopoverProps> = ({
             // shows on pointer-open. The first Tab still moves to the first swatch,
             // and because Tab is keyboard modality the ring correctly appears then.
             event.preventDefault();
-            contentRef.current?.focus({ preventScroll: true });
+            const content = contentRef.current;
+            if (!content) return;
+
+            const root = getOwnShadowRoot(content);
+            retainOutsideFocusRef.current = false;
+            if (root) {
+              const activeElement = root.activeElement ?? getShadowFocusRestoreTarget?.();
+              focusRestoreTargetRef.current = isElementFromOwnerDocument(
+                activeElement,
+                content,
+                'HTMLElement',
+              )
+                ? activeElement
+                : null;
+            } else {
+              focusRestoreTargetRef.current = null;
+            }
+            content.focus({ preventScroll: true });
           }}
+          onCloseAutoFocus={(event) => {
+            const root = portal.container ? getOwnShadowRoot(portal.container) : null;
+            if (!root) return;
+
+            event.preventDefault();
+            const target = focusRestoreTargetRef.current;
+            if (
+              !retainOutsideFocusRef.current &&
+              target?.isConnected &&
+              target.getRootNode() === root
+            ) {
+              target.focus();
+            }
+            retainOutsideFocusRef.current = false;
+            focusRestoreTargetRef.current = null;
+          }}
+          onPointerDownCapture={allowPriorFocusRestoration}
+          onFocusCapture={allowPriorFocusRestoration}
+          onEscapeKeyDown={allowPriorFocusRestoration}
           onInteractOutside={(event) => {
             // Tapping another verse modifies the selection — it should re-anchor
             // the popover, not dismiss it. Only a tap truly outside the reader
             // dismisses (which clears the selection via onOpenChange).
-            const target = event.detail.originalEvent.target;
-            if (target instanceof Element && target.closest('.yv-v[v]')) {
+            const content = contentRef.current;
+            if (!content) return;
+            const originalEvent = event.detail.originalEvent;
+            const interactedWithVerse = originalEvent
+              .composedPath()
+              .some(
+                (target) =>
+                  isElementFromOwnerDocument(target, content, 'Element') &&
+                  target.matches('.yv-v[v]'),
+              );
+            if (interactedWithVerse) {
               event.preventDefault();
+              return;
+            }
+            if (getOwnShadowRoot(content)) {
+              retainOutsideFocusRef.current = true;
             }
           }}
           side={view.side}

--- a/packages/ui/src/lib/shadow-root-host.tsx
+++ b/packages/ui/src/lib/shadow-root-host.tsx
@@ -21,6 +21,7 @@ type ShadowPortalStrategy = 'local-inline' | 'local-top-layer';
 
 interface ShadowPortalController {
   container: HTMLElement | null;
+  getLastFocusedElement: () => HTMLElement | null;
   prepareOpen: (instanceId: string) => void;
   requestClose: (instanceId: string) => void;
   setModalPresent: (instanceId: string, present: boolean) => void;
@@ -69,6 +70,11 @@ export function useShadowModalPresence(
   }, [instanceId, present, setModalPresent]);
 
   return controller?.restoreFocusWhenModalReleased;
+}
+
+/** @internal Returns the most recent focus target from the component's non-overlay content. */
+export function useShadowFocusRestoreTarget(): (() => HTMLElement | null) | undefined {
+  return useContext(ShadowPortalContext)?.getLastFocusedElement;
 }
 
 /** @internal Returns the node's own ShadowRoot, or null when it isn't attached inside one. */
@@ -142,6 +148,7 @@ export function ShadowRootHost({ children, portalStrategy }: ShadowRootHostProps
   const contentWrapperRef = useRef<HTMLDivElement | null>(null);
   const presentModalIdsRef = useRef(new Set<string>());
   const pendingFocusTargetRef = useRef<HTMLElement | null>(null);
+  const lastFocusedElementRef = useRef<HTMLElement | null>(null);
   const [shadowRoot, setShadowRoot] = useState<ShadowRoot | null>(null);
   const [portalContainer, setPortalContainer] = useState<HTMLElement | null>(null);
   const [needsStyleFallback, setNeedsStyleFallback] = useState(false);
@@ -247,11 +254,17 @@ export function ShadowRootHost({ children, portalStrategy }: ShadowRootHostProps
     if (target.isConnected) target.focus();
   }, []);
 
+  const getLastFocusedElement = useCallback(
+    (): HTMLElement | null => lastFocusedElementRef.current,
+    [],
+  );
+
   const portalController = useMemo<ShadowPortalController | null>(
     () =>
       portalStrategy
         ? {
             container: portalContainer,
+            getLastFocusedElement,
             prepareOpen,
             requestClose,
             setModalPresent,
@@ -261,6 +274,7 @@ export function ShadowRootHost({ children, portalStrategy }: ShadowRootHostProps
     [
       portalContainer,
       portalStrategy,
+      getLastFocusedElement,
       prepareOpen,
       requestClose,
       restoreFocusWhenModalReleased,
@@ -297,6 +311,7 @@ export function ShadowRootHost({ children, portalStrategy }: ShadowRootHostProps
       portalContainerRef.current = null;
       presentModalIdsRef.current.clear();
       pendingFocusTargetRef.current = null;
+      lastFocusedElementRef.current = null;
       if (contentWrapperRef.current) contentWrapperRef.current.inert = false;
     };
   }, []);
@@ -316,6 +331,14 @@ export function ShadowRootHost({ children, portalStrategy }: ShadowRootHostProps
                 ref={contentWrapperRef}
                 data-yv-shadow-content-wrapper
                 style={{ all: 'initial', display: 'contents' }}
+                onFocusCapture={(event) => {
+                  if (
+                    isElementFromOwnerDocument(event.target, event.currentTarget, 'HTMLElement') &&
+                    event.currentTarget.contains(event.target)
+                  ) {
+                    lastFocusedElementRef.current = event.target;
+                  }
+                }}
               >
                 {children}
               </div>


### PR DESCRIPTION
## Summary

- route the direct-Radix `VerseActionPopover` through the shared shadow-aware portal state
- keep the popover in its component tree while preserving clipping escape, reanchoring, dismissal, and focus restoration
- inventory direct overlay consumers and document why no additional low-risk migrations are required for this ticket
- add unit and Chromium story coverage for shadow/non-shadow placement and pointer/focus workflows

## Jira

- [YPE-5353](https://youversion.atlassian.net/browse/YPE-5353)

## Testing

- `pnpm --filter @youversion/platform-react-ui exec vitest run --project unit src/components/verse-action-popover.test.tsx` (48 passed)
- `pnpm --filter @youversion/platform-react-ui exec vitest run --project storybook src/components/verse-action-popover.shadow-isolation.stories.tsx src/components/bible-reader.stories.tsx -t "Verse Action Pointer Interactions|Portal Placement Docking Reanchoring And Focus Restoration"` (2 passed)
- `pnpm --filter @youversion/platform-react-ui typecheck`
- `pnpm lint`
- Prettier check and `git diff --check`


[YPE-5353]: https://lifechurch.atlassian.net/browse/YPE-5353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR routes `VerseActionPopover` through the shared shadow-aware portal state while adding explicit focus restoration and interaction coverage.
- Keeps isolated popover content in its owning shadow tree while preserving the normal document portal.
- Adds document and shadow-root tests for placement, docking, reanchoring, dismissal, and focus restoration.
- Extends `ShadowRootHost` to remember the latest focused non-overlay element.
- Documents the direct-overlay inventory and includes a patch changeset.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains in the eligible follow-up review scope.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/ui/src/components/verse-action-popover.tsx | Routes the direct Radix popover through shared portal state and adds root-aware interaction and focus-restoration handling. |
| packages/ui/src/lib/shadow-root-host.tsx | Extends the shadow portal controller to expose the latest focused element from non-overlay content. |
| packages/ui/src/components/verse-action-popover.test.tsx | Adds unit coverage for portal placement, document and shadow focus restoration, controlled closes, and overlapping instances. |
| packages/ui/src/components/verse-action-popover.shadow-isolation.stories.tsx | Adds Chromium integration coverage for shadow-local top-layer placement, clipping escape, docking, reanchoring, dismissal, and focus. |
| packages/ui/src/components/bible-reader.stories.tsx | Adds an end-to-end reader story covering verse selection, reanchoring, dismissal, and document focus restoration. |
| docs/shadow-dom-isolation-plan.md | Records the direct-overlay inventory and the completed VerseActionPopover migration. |
| .changeset/shadow-aware-verse-actions.md | Declares the shadow-aware verse-action behavior as a patch release. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant User
  participant Verse as Verse selection
  participant Popover as VerseActionPopover
  participant Portal as Shadow portal state
  participant Host as ShadowRootHost

  User->>Verse: Select verse
  Verse->>Popover: Set anchor and open
  Popover->>Portal: Prepare portal target
  Portal->>Host: Create or reuse local overlay
  Host-->>Popover: Return shadow-local container
  Popover->>Popover: Capture prior focus
  Popover->>Host: Render action content in portal
  User->>Popover: Dismiss or invoke action
  Popover->>Portal: Request close
  Popover->>Popover: Restore eligible prior focus
```

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/jou..."](https://github.com/youversion/platform-sdk-react/commit/1381ce08931df06a8bf7ada56e40bd83feee8611) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58300292)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Bible content widgets](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/ui-content-components.md)
- Knowledge Base — [Bible reader and navigation](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/ui-bible-reader.md)
- Knowledge Base — [Monorepo build, validation, and release](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/monorepo-build-release.md)
</details>


<!-- /greptile_comment -->