### PR TITLE
fix(ui): harden A2 revert-layer contract checks

### DIFF
--- a/packages/ui/scripts/strip-layer-blocks.d.ts
+++ b/packages/ui/scripts/strip-layer-blocks.d.ts
@@ -1,0 +1,1 @@
+export function stripLayerBlocks(css: string): string;

--- a/packages/ui/scripts/strip-layer-blocks.js
+++ b/packages/ui/scripts/strip-layer-blocks.js
@@ -1,0 +1,143 @@
+/**
+ * Return CSS with `@layer` statements and blocks removed so leftover text is
+ * only unlayered. Braces, `@layer`, and escapes inside strings or comments
+ * are not treated as structure — the release gate would otherwise false-pass
+ * layered `revert-layer` (e.g. `content:"}"`) or false-fail a real A2 rule
+ * (e.g. `content:"@layer"`).
+ */
+
+function isHex(ch) {
+  return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F');
+}
+
+function isIdentContinue(ch) {
+  if (!ch) return false;
+  const code = ch.codePointAt(0);
+  return (
+    (code >= 48 && code <= 57) ||
+    (code >= 65 && code <= 90) ||
+    (code >= 97 && code <= 122) ||
+    ch === '_' ||
+    ch === '-' ||
+    code >= 128
+  );
+}
+
+function isWhitespace(ch) {
+  return ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r' || ch === '\f';
+}
+
+function skipEscape(css, i) {
+  if (i + 1 >= css.length) return css.length;
+  const next = css[i + 1];
+  if (next === '\n' || next === '\f') return i + 2;
+  if (next === '\r') return css[i + 2] === '\n' ? i + 3 : i + 2;
+  if (isHex(next)) {
+    let j = i + 1;
+    const max = Math.min(j + 6, css.length);
+    while (j < max && isHex(css[j])) j += 1;
+    if (isWhitespace(css[j])) {
+      return css[j] === '\r' && css[j + 1] === '\n' ? j + 2 : j + 1;
+    }
+    return j;
+  }
+  return i + 2;
+}
+
+function skipString(css, i) {
+  const quote = css[i];
+  let j = i + 1;
+  while (j < css.length) {
+    if (css[j] === '\\') {
+      j = skipEscape(css, j);
+      continue;
+    }
+    if (css[j] === quote) return j + 1;
+    j += 1;
+  }
+  return j;
+}
+
+function skipComment(css, i) {
+  const end = css.indexOf('*/', i + 2);
+  return end === -1 ? css.length : end + 2;
+}
+
+function nextCodeIndex(css, i) {
+  while (i < css.length) {
+    if (css[i] === '/' && css[i + 1] === '*') {
+      i = skipComment(css, i);
+      continue;
+    }
+    if (css[i] === '"' || css[i] === "'") {
+      i = skipString(css, i);
+      continue;
+    }
+    if (css[i] === '\\') {
+      i = skipEscape(css, i);
+      continue;
+    }
+    return i;
+  }
+  return i;
+}
+
+function isLayerAtRule(css, i) {
+  if (css.slice(i, i + 6).toLowerCase() !== '@layer') return false;
+  return !isIdentContinue(css[i + 6]);
+}
+
+function indexOfLayerAtRule(css, from) {
+  let i = from;
+  while (i < css.length) {
+    i = nextCodeIndex(css, i);
+    if (i >= css.length) return -1;
+    if (isLayerAtRule(css, i)) return i;
+    i += 1;
+  }
+  return -1;
+}
+
+function skipLayerAtRule(css, start) {
+  let i = nextCodeIndex(css, start + 6);
+  while (i < css.length) {
+    i = nextCodeIndex(css, i);
+    if (i >= css.length) return i;
+    if (css[i] === ';') return i + 1;
+    if (css[i] === '{') {
+      let depth = 0;
+      while (i < css.length) {
+        i = nextCodeIndex(css, i);
+        if (i >= css.length) return i;
+        if (css[i] === '{') {
+          depth += 1;
+          i += 1;
+        } else if (css[i] === '}') {
+          depth -= 1;
+          i += 1;
+          if (depth === 0) return i;
+        } else {
+          i += 1;
+        }
+      }
+      return i;
+    }
+    i += 1;
+  }
+  return i;
+}
+
+export function stripLayerBlocks(css) {
+  let result = '';
+  let i = 0;
+  while (i < css.length) {
+    const start = indexOfLayerAtRule(css, i);
+    if (start === -1) {
+      result += css.slice(i);
+      break;
+    }
+    result += css.slice(i, start);
+    i = skipLayerAtRule(css, start);
+  }
+  return result;
+}

--- a/packages/ui/scripts/verify-styles.js
+++ b/packages/ui/scripts/verify-styles.js
@@ -1,42 +1,10 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { stripLayerBlocks } from './strip-layer-blocks.js';
 
 const dist = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'dist');
 const errors = [];
-
-function stripLayerBlocks(css) {
-  let result = '';
-  let i = 0;
-  while (i < css.length) {
-    const start = css.indexOf('@layer', i);
-    if (start === -1) {
-      result += css.slice(i);
-      break;
-    }
-    result += css.slice(i, start);
-    const brace = css.indexOf('{', start);
-    const semi = css.indexOf(';', start);
-    if (brace === -1 || (semi !== -1 && semi < brace)) {
-      i = (semi === -1 ? start + 6 : semi) + 1;
-      continue;
-    }
-    let depth = 0;
-    let j = brace;
-    for (; j < css.length; j++) {
-      if (css[j] === '{') depth += 1;
-      else if (css[j] === '}') {
-        depth -= 1;
-        if (depth === 0) {
-          j += 1;
-          break;
-        }
-      }
-    }
-    i = j;
-  }
-  return result;
-}
 
 const cssPath = resolve(dist, 'tailwind.css');
 const css = existsSync(cssPath) ? readFileSync(cssPath, 'utf-8') : '';

--- a/packages/ui/src/styles/host-revert-layer.test.ts
+++ b/packages/ui/src/styles/host-revert-layer.test.ts
@@ -10,7 +10,11 @@ import { resolve } from 'node:path';
  */
 const globalCss = readFileSync(resolve(import.meta.dirname, './global.css'), 'utf8');
 
-const SELECTOR = '[data-yv-sdk] *, [data-yv-sdk] *::before, [data-yv-sdk] *::after';
+const EXPECTED_SELECTORS = [
+  '[data-yv-sdk] *',
+  '[data-yv-sdk] *::before',
+  '[data-yv-sdk] *::after',
+] as const;
 
 const REVERT_PROPERTIES = [
   'box-sizing',
@@ -33,22 +37,58 @@ function stripComments(css: string): string {
   return css.replace(/\/\*[\s\S]*?\*\//g, '');
 }
 
+function declarationMap(body: string): Map<string, string> {
+  const declarations = new Map<string, string>();
+  for (const part of body.split(';')) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    const colon = trimmed.indexOf(':');
+    if (colon === -1) continue;
+    declarations.set(trimmed.slice(0, colon).trim(), trimmed.slice(colon + 1).trim());
+  }
+  return declarations;
+}
+
+function revertLayerRules(css: string): [selectors: string[], body: string][] {
+  const rules: [string[], string][] = [];
+  let from = 0;
+  while (from < css.length) {
+    const marker = css.indexOf('revert-layer', from);
+    if (marker === -1) break;
+    const open = css.lastIndexOf('{', marker);
+    const close = css.indexOf('}', marker);
+    if (open === -1 || close === -1) break;
+    const prevClose = css.lastIndexOf('}', open);
+    const selectors = css
+      .slice(prevClose + 1, open)
+      .split(',')
+      .map((part) => part.trim())
+      .filter(Boolean);
+    rules.push([selectors, css.slice(open + 1, close)]);
+    from = close + 1;
+  }
+  return rules;
+}
+
 describe('A2 host isolation rule in global.css', () => {
   it('declares revert-layer on the listed shorthands, on descendants only, and not via all', () => {
     const withoutComments = stripComments(globalCss);
     const collapsed = withoutComments.replace(/\s+/g, ' ');
 
-    expect(collapsed).toContain(SELECTOR);
-    expect(withoutComments).not.toMatch(/\[data-yv-sdk\]\s*,/);
     expect(collapsed).not.toMatch(/\ball\s*:\s*revert/);
 
-    const open = collapsed.indexOf(SELECTOR);
-    const body = collapsed.slice(collapsed.indexOf('{', open) + 1, collapsed.indexOf('}', open));
-    expect(body).not.toMatch(/\bdisplay\s*:/);
-    expect(body).not.toMatch(/\bmax-width\s*:/);
+    const rules = revertLayerRules(collapsed);
+    expect(rules.length, 'expected at least one revert-layer rule').toBeGreaterThan(0);
 
-    for (const property of REVERT_PROPERTIES) {
-      expect(body, property).toMatch(new RegExp(`${property}\\s*:\\s*revert-layer`));
+    for (const [selectors, body] of rules) {
+      expect(selectors).toEqual([...EXPECTED_SELECTORS]);
+      expect(body).not.toMatch(/\bdisplay\s*:/);
+      expect(body).not.toMatch(/\bmax-width\s*:/);
+
+      const declarations = declarationMap(body);
+      for (const property of REVERT_PROPERTIES) {
+        expect(declarations.get(property), property).toBe('revert-layer');
+      }
     }
   });
 });

--- a/packages/ui/src/styles/strip-layer-blocks.test.ts
+++ b/packages/ui/src/styles/strip-layer-blocks.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { stripLayerBlocks } from '../../scripts/strip-layer-blocks.js';
+
+const A2_RULE = '[data-yv-sdk] *{appearance:revert-layer;-webkit-appearance:revert-layer}';
+
+describe('stripLayerBlocks', () => {
+  it('keeps unlayered A2 rules and drops layered lookalikes that fooled a brace scan', () => {
+    const layeredTrap = `
+@layer yv-sdk-styles {
+  .x::before { content: "}"; }
+  .trap { appearance: revert-layer; }
+}
+`;
+    expect(stripLayerBlocks(layeredTrap)).not.toContain('revert-layer');
+    expect(stripLayerBlocks(layeredTrap)).not.toContain('.trap');
+
+    const escapedBraceTrap = `
+@layer yv-sdk-styles {
+  .foo\\} { appearance: revert-layer; }
+}
+`;
+    expect(stripLayerBlocks(escapedBraceTrap)).not.toContain('revert-layer');
+
+    const commentTrap = `
+/* @layer yv-sdk-styles { */
+${A2_RULE}
+/* } */
+`;
+    const fromComment = stripLayerBlocks(commentTrap);
+    expect(fromComment).toContain('appearance:revert-layer');
+    expect(fromComment).toContain('-webkit-appearance:revert-layer');
+
+    const quotedAtLayer = `
+[data-yv-sdk] *::before { content: "@layer"; }
+${A2_RULE}
+`;
+    const fromQuoted = stripLayerBlocks(quotedAtLayer);
+    expect(fromQuoted).toContain('content: "@layer"');
+    expect(fromQuoted).toContain('appearance:revert-layer');
+    expect(fromQuoted).toContain('-webkit-appearance:revert-layer');
+
+    const singleQuotedAtLayer = `
+[data-yv-sdk] *::before { content: '@layer'; }
+${A2_RULE}
+`;
+    expect(stripLayerBlocks(singleQuotedAtLayer)).toContain('appearance:revert-layer');
+
+    const layerStatementThenA2 = `@layer yv-sdk-styles, yv-sdk-theme;${A2_RULE}`;
+    const fromStatement = stripLayerBlocks(layerStatementThenA2);
+    expect(fromStatement).not.toContain('@layer');
+    expect(fromStatement).toContain(A2_RULE);
+
+    const nestedLayer = `
+@layer yv-sdk-styles {
+  @layer utilities {
+    .x::before { content: "}"; appearance: revert-layer; }
+  }
+}
+${A2_RULE}
+`;
+    const fromNested = stripLayerBlocks(nestedLayer);
+    expect(fromNested).not.toContain('.x::before');
+    expect(fromNested).toContain(A2_RULE);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked on #363. Addresses Austin’s review comments on the A2 `revert-layer` experiment.

## Review comments

1. **issue** (`verify-styles.js`): `stripLayerBlocks` treated `@layer`, `{`, and `}` inside strings, comments, and escapes as CSS structure. That could false-pass a layered `content:"}"` trap and false-fail an unlayered `content:"@layer"` next to a real A2 rule.
2. **suggestion** (`host-revert-layer.test.ts`): the descendants-only check only rejected a bare `[data-yv-sdk]` when it was followed by a comma, so a trailing root selector still passed.
3. **suggestion** (`host-revert-layer.test.ts`): the `appearance` regex also matched inside `-webkit-appearance: revert-layer`, so deleting the unprefixed declaration left the test green.

## Change

- Extract a quote/comment/escape-aware `stripLayerBlocks` used by the release-gating verify script.
- Add regression cases for both false-pass and false-fail directions.
- Compare the A2 selector list exactly (`[data-yv-sdk] *`, `::before`, `::after`).
- Assert each required property from a parsed declaration map so `appearance` and `-webkit-appearance` are independent.

No change to the shipped A2 isolation rule in `global.css`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50ff2e21-8f4e-4277-b98b-17859c89c5fb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50ff2e21-8f4e-4277-b98b-17859c89c5fb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts and hardens the CSS layer-block scanner used by release verification and strengthens the source-level A2 isolation tests.
- Adds a quote-, comment-, brace-, and escape-aware `stripLayerBlocks` helper with regression coverage.
- Requires the exact descendants-only selector list for every detected `revert-layer` source rule.
- Parses declarations by property so prefixed and unprefixed `appearance` checks remain independent.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with one non-blocking parser-hardening gap for escaped spellings of the `layer` at-keyword.

The strengthened checks correctly cover the current stylesheet, but the extracted scanner’s literal `@layer` comparison does not fully satisfy its escape-aware layer-removal contract.

**Files Needing Attention:** packages/ui/scripts/strip-layer-blocks.js, packages/ui/src/styles/strip-layer-blocks.test.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/ui/scripts/strip-layer-blocks.js | Adds the release-gate layer scanner; literal at-keyword matching leaves escaped spellings unsupported. |
| packages/ui/scripts/verify-styles.js | Replaces the inline implementation with the extracted scanner without otherwise changing verification behavior. |
| packages/ui/src/styles/host-revert-layer.test.ts | Strengthens selector and declaration assertions for the current flat A2 source rule. |
| packages/ui/src/styles/strip-layer-blocks.test.ts | Covers the reported string, comment, nested-layer, and escaped-brace regressions but omits escaped at-keywords. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20youversion%2Fplatform-sdk-react%20PR%20%23374%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=youversion%2Fplatform-sdk-react&pr=374&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fui%2Fscripts%2Fstrip-layer-blocks.js%3A86-87%0A**Escaped%20layer%20keywords%20remain**%0A%0AA%20valid%20escaped%20at-keyword%20such%20as%20%60%40%5C6c%20ayer%60%20is%20skipped%20rather%20than%20decoded%2C%20while%20%60isLayerAtRule%60%20recognizes%20only%20the%20literal%20substring%20%60%40layer%60.%20Such%20a%20layer%20remains%20in%20the%20purportedly%20unlayered%20output%2C%20allowing%20its%20%60revert-layer%60%20declarations%20to%20satisfy%20the%20release%20gate%20even%20when%20the%20required%20unlayered%20A2%20rule%20is%20absent.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=youversion%2Fplatform-sdk-react&pr=374&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Fui%2Fscripts%2Fstrip-layer-blocks.js%3A86-87%0A**Escaped%20layer%20keywords%20remain**%0A%0AA%20valid%20escaped%20at-keyword%20such%20as%20%60%40%5C6c%20ayer%60%20is%20skipped%20rather%20than%20decoded%2C%20while%20%60isLayerAtRule%60%20recognizes%20only%20the%20literal%20substring%20%60%40layer%60.%20Such%20a%20layer%20remains%20in%20the%20purportedly%20unlayered%20output%2C%20allowing%20its%20%60revert-layer%60%20declarations%20to%20satisfy%20the%20release%20gate%20even%20when%20the%20required%20unlayered%20A2%20rule%20is%20absent.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=374&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youversion%2Fplatform-sdk-react%22%20on%20the%20existing%20branch%20%22cursor%2Fcp%2Ffix-a2-review-comments-c5fb%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Fcp%2Ffix-a2-review-comments-c5fb%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Fui%2Fscripts%2Fstrip-layer-blocks.js%3A86-87%0A**Escaped%20layer%20keywords%20remain**%0A%0AA%20valid%20escaped%20at-keyword%20such%20as%20%60%40%5C6c%20ayer%60%20is%20skipped%20rather%20than%20decoded%2C%20while%20%60isLayerAtRule%60%20recognizes%20only%20the%20literal%20substring%20%60%40layer%60.%20Such%20a%20layer%20remains%20in%20the%20purportedly%20unlayered%20output%2C%20allowing%20its%20%60revert-layer%60%20declarations%20to%20satisfy%20the%20release%20gate%20even%20when%20the%20required%20unlayered%20A2%20rule%20is%20absent.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=youversion%2Fplatform-sdk-react&pr=374&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/ui/scripts/strip-layer-blocks.js:86-87
**Escaped layer keywords remain**

A valid escaped at-keyword such as `@\6c ayer` is skipped rather than decoded, while `isLayerAtRule` recognizes only the literal substring `@layer`. Such a layer remains in the purportedly unlayered output, allowing its `revert-layer` declarations to satisfy the release gate even when the required unlayered A2 rule is absent.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): harden A2 revert-layer contract..."](https://github.com/youversion/platform-sdk-react/commit/70147a639354117726cb632f97cff6041804ec8c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59102909)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->