### PR TITLE
docs: add verify-sdk-demo agent skill

### DIFF
--- a/.cursor/skills/verify-sdk-demo/SKILL.md
+++ b/.cursor/skills/verify-sdk-demo/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: verify-sdk-demo
+description: Drive the YouVersion SDK Demo (Vite React web UI at examples/vite-react) to prove Bible Reader, Verse of the Day, Bible Card, sign-in chrome, and theme behavior. Use when verifying UI changes, demo regressions, or live API integration in the example app.
+---
+
+# Verify the YouVersion SDK Demo
+
+This repo is an SDK monorepo. The surface a user actually touches is the Vite demo in `examples/vite-react` (page title **YouVersion SDK Demo**). It hosts `@youversion/platform-react-ui` against the live YouVersion Platform API.
+
+Other surfaces (do not treat as the primary harness unless the change is isolated there):
+
+- Storybook on port 6006 (`pnpm --filter @youversion/platform-react-ui storybook`) — mocked/composition journeys, not the demo.
+- Package unit/RTL/Storybook `play` tests — not a substitute for driving the demo.
+- Hosted demo at https://youversion.github.io/platform-sdk-react/ — production build, not this checkout.
+
+There is no local API, Docker Compose, or database. Scripture comes from `api.youversion.com`.
+
+## Launch
+
+From the monorepo root, after `pnpm install` and `pnpm build` (`packages/ui` exports only `dist/`):
+
+```bash
+.cursor/skills/verify-sdk-demo/scripts/launch.sh
+```
+
+That starts:
+
+```bash
+pnpm --filter vite-react dev --host 127.0.0.1 --port 5177
+```
+
+Do **not** insert an extra `--` before `--host`. `pnpm --filter vite-react dev -- --host 127.0.0.1` becomes `vite -- --host 127.0.0.1`; Vite then ignores `--host` and may bind `::1` only, so `curl http://127.0.0.1:5177` fails. Root `pnpm dev:web` is stale (it still filters a removed `nextjs` package).
+
+**Ready when** `curl -fsS http://127.0.0.1:5177/` returns HTML containing `YouVersion SDK Demo` and launch prints `ready pid=… origin=http://127.0.0.1:5177`. Instance metadata is `${VERIFY_DIR:-/tmp/verify-sdk-demo}/instance.json`.
+
+**Env** (never commit secrets). `launch.sh` loads in this order and only exports into the Vite process:
+
+1. Already-set `VITE_YVP_APP_KEY`
+2. Monorepo-root `.env.local` / `.env` (AGENTS.md: use the main checkout, not a worktree-local file)
+3. `examples/vite-react/.env.local` if the Vite-prefixed key is still empty
+4. `YVP_APP_KEY` mapped to `VITE_YVP_APP_KEY` (Cloud injects this secret)
+
+Without a non-empty app key, `YouVersionProvider` replaces the whole tree with the missing-app-key `role="alert"` panel. Bible features are not driveable.
+
+`VITE_YVP_AUTH_REDIRECT_URL` defaults to the launch origin (`http://127.0.0.1:5177`). Navbar Sign in requests only `profile` and `email`. Highlights are granted later in the reader (tap a verse, tap a color).
+
+Override isolation with `VERIFY_HOST`, `VERIFY_PORT`, `VERIFY_DIR`. Default port is **5177** so a human demo on 5173 is left alone.
+
+## Doctor
+
+```bash
+.cursor/skills/verify-sdk-demo/scripts/doctor.sh
+```
+
+Read-only. Answers “is this instance worth driving?”
+
+1. `${VERIFY_DIR}/instance.json` exists and the recorded pid is alive.
+2. Something is listening on the instance origin, and that listener is our pid or a child of it. If the port belongs to someone else, **stop** — do not drive a shared session.
+3. `GET /` is 200 and the shell title is `YouVersion SDK Demo`.
+4. Playwright probe (`node …/drive.mjs doctor`): desktop nav **Bible Reader** is present, the missing-app-key alert is absent, and `[data-slot="yv-bible-renderer"]` plus at least one `.yv-v[v]` verse wrapper have loaded.
+
+If step 4 fails with the missing-app-key copy, relaunch after setting `VITE_YVP_APP_KEY` / `YVP_APP_KEY`. If packages were edited, `pnpm build` (or `turbo build --force` when the cache looks stale) and relaunch.
+
+## Drive
+
+Harness: Playwright from `@youversion/platform-react-ui` (`playwright` 1.56), launching system Chrome (`/usr/local/bin/google-chrome` or `VERIFY_CHROME`). Default viewport **1280×800** so the desktop navbar is visible (`hidden md:flex` below `md`).
+
+```bash
+node .cursor/skills/verify-sdk-demo/scripts/drive.mjs bible-reader
+node .cursor/skills/verify-sdk-demo/scripts/drive.mjs verse-of-the-day
+node .cursor/skills/verify-sdk-demo/scripts/drive.mjs bible-card
+node .cursor/skills/verify-sdk-demo/scripts/drive.mjs theme
+```
+
+The demo is a client-side page switcher (`App` state: `bible-reader` | `votd` | `bible-card`), not a router. There are no URL paths. Desktop nav buttons:
+
+| Visible name | Page |
+| --- | --- |
+| Bible Reader | default |
+| Verse of the Day | `votd` |
+| Bible Card | `bible-card` |
+
+Mobile: `getByRole('button', { name: 'Toggle menu' })` then the same labels.
+
+Stable SDK handles (English locale; prefer roles over copy blobs when asserting):
+
+| Control | Handle |
+| --- | --- |
+| Scripture body | `[data-slot="yv-bible-renderer"]` |
+| A verse | `.yv-v[v="1"]` (attribute `v` is the verse number) |
+| Selected verse | `.yv-v-selected` |
+| Previous / next chapter | `getByRole('button', { name: /previous chapter/i })` / `/next chapter/i` |
+| Book + chapter picker | `getByRole('button', { name: /change bible book and chapter/i })` |
+| Version picker | `getByRole('button', { name: /change bible version/i })` |
+| Reader settings | `getByRole('button', { name: /settings/i })` |
+| Font size | `getByTestId('increase-font-size')` / `decrease-font-size` |
+| Line spacing | `getByTestId('line-spacing')` |
+| Verse actions | `getByRole('dialog', { name: /verse actions/i })` |
+| Highlight colors | `getByRole('group', { name: /highlight colors/i })` |
+| Passage loading | `getByRole('status', { name: /loading passage/i })` |
+| Sign in (navbar, `size="short"`) | `getByRole('button', { name: /^sign in$/i })` |
+| Sign out (navbar) | `getByRole('button', { name: /^sign out$/i })` |
+| Theme | `getByRole('button', { name: 'Toggle theme' })` then menuitems Light / Dark / System |
+| Missing app key | `getByRole('alert')` (replaces the whole app) |
+| SDK scope | `[data-yv-sdk]` |
+
+Reader defaults in this demo: book `JHN`, chapter `1`, version id `3034` (license-free default). VOTD and Bible Card also use `3034`. Bible Card reference is `JHN.3.16`.
+
+Feature recipes: `.cursor/skills/verify-sdk-demo/features/`. A proof that only hits one entry point is incomplete when the map lists others for that change.
+
+Do not complete YouVersion OAuth in an unattended run unless a real account and a registered redirect for this origin exist. Navbar Sign in starts PKCE and leaves the demo. Highlights are per Bible version and need the highlights permission (reader color tap, not the navbar button).
+
+## Evidence
+
+Proof artifacts go to **`/tmp/verify-sdk-demo/evidence/`** (`VERIFY_EVIDENCE_DIR` to override). Cleanup must not delete this directory.
+
+Each drive writes a timestamped folder:
+
+- `01-*.png` / `02-*.png` — state **before** the action and **after**
+- `result.json` — origin, feature, `ok`, and the observable that changed (picker label, heading, `localStorage`)
+
+Standards:
+
+- Exercise the real demo (Vite + live API), not Storybook, not `YouVersionContext.hookOverrides`, not test-only endpoints.
+- Capture the action and the resulting state, not only the final screen.
+- Side effects to observe: `localStorage` keys `yv-sdk-demo-theme`, `youversion-platform:reader:font-size`, `youversion-platform:reader:font-family`; verse class `yv-v-selected`; network calls to `api.youversion.com` when diagnosing load failures.
+- Mocks only where the production boundary already isolates the system (Storybook MSW). The demo has no mock mode.
+
+## Cleanup
+
+```bash
+.cursor/skills/verify-sdk-demo/scripts/cleanup.sh
+```
+
+Kills **only** the pid recorded in `instance.json` (the `pnpm --filter vite-react dev` process this launch started). Never `pkill vite` / `pkill node`. Removes `instance.json`. Leaves `/tmp/verify-sdk-demo/evidence/` and the last `vite.log` (overwritten on the next launch).
+
+## Isolate
+
+Two Vite processes can run side by side on different ports. Default verification port is 5177. A developer demo on 5173 is a **different origin** (theme and reader `localStorage` are origin-scoped) but must not be driven or killed.
+
+- If `instance.json` already points at a live pid, `launch.sh` refuses a second start in the same `VERIFY_DIR`.
+- If port 5177 is owned by some other process, launch refuses.
+- For a second instance: `VERIFY_DIR=/tmp/verify-sdk-demo-b VERIFY_PORT=5178 …/launch.sh`.
+- Never attach Playwright to an origin you did not start.
+
+## Helpers
+
+All invocations are from the monorepo root. Shell scripts are executable.
+
+| Script | Command |
+| --- | --- |
+| Launch | `.cursor/skills/verify-sdk-demo/scripts/launch.sh` |
+| Doctor | `.cursor/skills/verify-sdk-demo/scripts/doctor.sh` |
+| Drive | `node .cursor/skills/verify-sdk-demo/scripts/drive.mjs <feature>` |
+| Cleanup | `.cursor/skills/verify-sdk-demo/scripts/cleanup.sh` |
+
+`scripts/lib.sh` is sourced by the shell helpers (paths, env load, port pid). `drive.mjs` resolves `playwright` from `packages/ui`. Chrome needs `--no-sandbox` in this Cloud image; the script passes that.
+
+## Feature map
+
+Index: `.cursor/skills/verify-sdk-demo/features/README.md`.

--- a/.cursor/skills/verify-sdk-demo/features/README.md
+++ b/.cursor/skills/verify-sdk-demo/features/README.md
@@ -1,0 +1,13 @@
+# SDK Demo feature map
+
+User-facing surfaces in `examples/vite-react`. Drive with `node .cursor/skills/verify-sdk-demo/scripts/drive.mjs <feature>`.
+
+| Feature | Drive id | How a user gets there |
+| --- | --- | --- |
+| [Bible Reader](bible-reader.md) | `bible-reader` | Default page; nav **Bible Reader** |
+| [Verse of the Day](verse-of-the-day.md) | `verse-of-the-day` | Nav **Verse of the Day** |
+| [Bible Card](bible-card.md) | `bible-card` | Nav **Bible Card** |
+| [Sign in](sign-in.md) | *(manual / account)* | Navbar **Sign in**; or tap a verse then a highlight color |
+| [Theme](theme.md) | `theme` | Navbar **Toggle theme** |
+
+There is no client router. `App` swaps `bible-reader` \| `votd` \| `bible-card` in memory. A proof that only loads the default reader is incomplete when the change also touches VOTD, the card, auth, or theme.

--- a/.cursor/skills/verify-sdk-demo/features/bible-card.md
+++ b/.cursor/skills/verify-sdk-demo/features/bible-card.md
@@ -1,0 +1,37 @@
+# Bible Card
+
+Single embeddable card for **John 3:16** (`JHN.3.16`) in version `3034`, with the version picker enabled.
+
+## Sub-features
+
+- Passage reference heading (`h2`, uppercase tracking)
+- Version picker trigger (**Change Bible version**)
+- Scripture body in `[data-slot="yv-bible-renderer"]`
+- Footer copyright + Bible App lockup
+- Footnotes when the passage has them (`[data-verse-footnote] button`)
+
+## How to get to it (user POV)
+
+1. Open the demo.
+2. Click **Bible Card** in the header (or the hamburger menu).
+
+## Driving it with Playwright
+
+```bash
+node .cursor/skills/verify-sdk-demo/scripts/drive.mjs bible-card
+```
+
+1. Screenshot the current page (before).
+2. Click **Bible Card**.
+3. Wait for `section[data-yv-sdk]` with an `h2`, the version trigger, and the renderer.
+4. Screenshot (`02-bible-card.png`).
+
+To prove the picker (not in the helper): click **Change Bible version**, choose another abbreviation, wait for the `h2` to include the new abbreviation and the body to refresh (loading spinner on the header during refetch).
+
+**End state that proves it:** heading is a passage reference (John 3:16 / localized equivalent plus abbreviation), renderer has verse text, version button is enabled.
+
+## Gotchas
+
+- The demo hard-codes `reference="JHN.3.16"` and `showVersionPicker`. A 404/unavailable passage in the selected version keeps the picker so the user can switch — that error heading is `Error` in the `h2` slot, not a crash.
+- Card verses do not use the reader toolbar. Do not look for next/previous chapter here.
+- Max width is the SDK default (700px), centered in the demo page padding.

--- a/.cursor/skills/verify-sdk-demo/features/bible-reader.md
+++ b/.cursor/skills/verify-sdk-demo/features/bible-reader.md
@@ -1,0 +1,51 @@
+# Bible Reader
+
+Full-height reader: John 1 in version `3034` by default, with a bottom toolbar for chapter, version, and settings. This is the demo landing page.
+
+## Sub-features
+
+- Chapter next / previous (`JHN.1` → `JHN.2` on first Next)
+- Book + chapter picker (popover heading **Books**, search placeholder **Search**, chapter grid; intro cells use `data-testid="intro-chapter-button"`)
+- Version picker (abbreviation on the trigger; language trigger aria **Select language**)
+- Reader settings: font size (`increase-font-size` / `decrease-font-size`), font family (Inter / Untitled Serif / Source Serif), line spacing (`line-spacing`)
+- Verse tap selects `.yv-v[v]` and opens **Verse actions** (copy, share, highlight colors when live)
+- Highlight apply / clear (self-contained; needs a signed-in user with the **highlights** permission — not the navbar Sign in scopes)
+
+## How to get to it (user POV)
+
+1. Open the demo origin. The first screen is already the reader.
+2. Or click **Bible Reader** in the desktop header (or hamburger **Toggle menu** on narrow viewports).
+
+## Driving it with Playwright
+
+```bash
+node .cursor/skills/verify-sdk-demo/scripts/drive.mjs bible-reader
+```
+
+Recipe the helper runs:
+
+1. Confirm desktop nav **Bible Reader**, no missing-app-key alert.
+2. Wait for `[data-slot="yv-bible-renderer"]` and `.yv-v[v]`.
+3. Screenshot (`01-john-1.png`).
+4. Read the **Change Bible book and chapter** button label.
+5. Click **Next chapter**.
+6. Wait out `role="status"` **Loading passage** if it appears; wait until the chapter-picker label changes.
+7. Screenshot (`02-after-next-chapter.png`).
+
+Further probes (not in the helper; use the same page):
+
+- `getByRole('button', { name: /change bible version/i })` then pick another abbreviation; renderer text/copyright should follow.
+- `getByRole('button', { name: /settings/i })` → **Reader Settings**; click `getByTestId('increase-font-size')` and read `localStorage['youversion-platform:reader:font-size']`.
+- Click `.yv-v[v="1"]`; expect `.yv-v-selected` and `getByRole('dialog', { name: /verse actions/i })`.
+
+**End state that proves it:** chapter-picker label is no longer the John 1 label; renderer still has verse wrappers; loading status is gone.
+
+## Gotchas
+
+- Missing or empty `VITE_YVP_APP_KEY` replaces the entire app (no navbar, no reader).
+- Desktop nav is `hidden` below the `md` breakpoint — keep the 1280×800 viewport or open the hamburger.
+- Next on John 1 is John 2, not a new book. Previous on John 1 goes to the prior book’s last chapter and may disable at the start of the canon.
+- `HIGHLIGHTS_LIVE` is on in this package. Color taps while signed out open the sign-in dialog (`Yes Please` / `No Thanks`), not a silent write. Navbar Sign in does **not** request the highlights permission.
+- Highlights are per Bible version. Changing version hides another version’s marks.
+- Toolbar version button shows **Loading Bible version** while metadata is in flight — wait for **Change Bible version** before asserting the abbreviation.
+- Do not attach to a human’s `localhost:5173` session; reader `localStorage` and auth tokens are origin-scoped.

--- a/.cursor/skills/verify-sdk-demo/features/sign-in.md
+++ b/.cursor/skills/verify-sdk-demo/features/sign-in.md
@@ -1,0 +1,33 @@
+# Sign in
+
+YouVersion account session for the demo. Two different entry points request different grants.
+
+## Sub-features
+
+- Navbar **Sign in** (`YouVersionAuthButton` `size="short"`, scopes `profile` and `email` only)
+- Navbar **Sign out** when `auth.isAuthenticated`
+- Reader **highlight auth flow**: signed-out color tap → sign-in dialog (**INTRODUCING**, **Yes Please**, **No Thanks**); signed-in without highlights → data-exchange permission dialog
+- Toolbar user menu (`data-testid="user-menu-trigger"`) inside `BibleReader` when auth is enabled on the provider
+
+## How to get to it (user POV)
+
+- **Profile/email only:** click **Sign in** in the header. Completing OAuth returns to `VITE_YVP_AUTH_REDIRECT_URL` (launch defaults this to the verification origin).
+- **Highlights:** on the reader, tap a verse, tap a color. That is the grant path AGENTS.md describes. Navbar Sign in does not request `highlights`.
+
+## Driving it with Playwright
+
+There is no unattended `drive.mjs` command that finishes OAuth. Prove chrome only:
+
+1. Unsigned: `getByRole('button', { name: /^sign in$/i })` is visible next to **Toggle theme**.
+2. Click it only if you will complete the YouVersion login yourself. The tab leaves the demo (PKCE).
+3. After a real return: header shows the user’s name when present and **Sign out**.
+4. For highlights: select `.yv-v[v="1"]`, open **Verse actions**, click a color in **Highlight colors**. Signed out → dialog with **Yes Please**. Confirming starts the same redirect with `requested_permissions` including highlights.
+
+**End state that proves navbar chrome:** Sign in is present and enabled while signed out. **End state that proves a session:** Sign out is present and scripture still loads. **End state that proves highlight consent:** after return, a color tap paints `.yv-v` with a background and does not re-open the dialog.
+
+## Gotchas
+
+- Redirect URL must be registered for the app key (docs mention `http://localhost:5173` for the human demo). Verification uses `http://127.0.0.1:5177` by default — OAuth will fail if that origin is not registered.
+- Do not drive a shared origin that already has someone else’s session cookies.
+- Pending highlight intent lives in `sessionStorage` (~10 min) across the redirect. An abandoned flow must not apply later.
+- Highlights are account data, per Bible version, never local-only.

--- a/.cursor/skills/verify-sdk-demo/features/theme.md
+++ b/.cursor/skills/verify-sdk-demo/features/theme.md
@@ -1,0 +1,36 @@
+# Theme
+
+Demo chrome dark/light/system toggle. It drives `ThemeProvider` (`storageKey="yv-sdk-demo-theme"`) and is passed into `YouVersionProvider` as `theme`, so SDK surfaces (`data-yv-theme`) follow the page.
+
+## Sub-features
+
+- Toggle control (sun/moon icons, accessible name **Toggle theme**)
+- Menu: **Light**, **Dark**, **System**
+- `document.documentElement` class `dark` when dark
+- Persistence in `localStorage['yv-sdk-demo-theme']`
+
+## How to get to it (user POV)
+
+The control is always in the header, right of Sign in / Sign out, on every page.
+
+## Driving it with Playwright
+
+```bash
+node .cursor/skills/verify-sdk-demo/scripts/drive.mjs theme
+```
+
+1. Screenshot current theme.
+2. Click **Toggle theme** → **Dark**.
+3. Wait for `document.documentElement.classList.contains('dark')`.
+4. Assert `localStorage.getItem('yv-sdk-demo-theme') === 'dark'`.
+5. Screenshot (`02-dark.png`).
+
+Also check a page that shares the provider: after Dark, click **Bible Card** or **Verse of the Day** and confirm `[data-yv-theme="dark"]` on an SDK `section`.
+
+**End state that proves it:** `html` has class `dark`, storage is `dark`, and at least one `[data-yv-sdk][data-yv-theme="dark"]` node is present.
+
+## Gotchas
+
+- Origin-scoped storage. A run on port 5177 does not see a human’s 5173 theme.
+- System follows `prefers-color-scheme`. In headless Chrome that is usually light unless you emulate `colorScheme: 'dark'`.
+- Missing-app-key panel still honors `theme` on `YouVersionProvider`, but the demo navbar (including this toggle) is **not** rendered in that state.

--- a/.cursor/skills/verify-sdk-demo/features/verse-of-the-day.md
+++ b/.cursor/skills/verify-sdk-demo/features/verse-of-the-day.md
@@ -1,0 +1,38 @@
+# Verse of the Day
+
+Two stacked `VerseOfTheDay` cards (sizes `default` and `lg`) for version `3034` and today’s passage.
+
+## Sub-features
+
+- Daily reference + verse body (no verse numbers)
+- Share button (`aria-label` **Share**) on each card
+- Loading status **Loading verse**
+- Optional sun icon / Bible App attribution (SDK defaults; the demo does not pass those props)
+
+## How to get to it (user POV)
+
+1. Open the demo.
+2. Click **Verse of the Day** in the header (or the hamburger menu).
+
+## Driving it with Playwright
+
+```bash
+node .cursor/skills/verify-sdk-demo/scripts/drive.mjs verse-of-the-day
+```
+
+1. Screenshot the reader (before).
+2. Click **Verse of the Day**.
+3. Wait for two `section[data-yv-sdk][data-size]` cards and a `[data-slot="yv-bible-renderer"]` inside.
+4. Confirm a **Share** button is visible.
+5. Screenshot (`02-votd.png`).
+
+**End state that proves it:** two cards, each with scripture (or a distinct error `role="alert"` if the API refused the version — that is a product state, not a harness miss). Share is present. The page is no longer the full-height reader toolbar.
+
+Do not click Share in unattended runs unless you intend to exercise `navigator.share` / clipboard; headed Chrome may show a native sheet.
+
+## Gotchas
+
+- Same app-key requirement as the reader.
+- Passage id changes every calendar day — assert structure (cards, renderer, share), not a fixed USFM or English verse blob.
+- `data-size` is `default` vs `lg` (larger type on the second card).
+- Self-contained highlight paint needs a signed-in user with highlights permission; the demo does not pass a `highlights` prop.

--- a/.cursor/skills/verify-sdk-demo/scripts/cleanup.sh
+++ b/.cursor/skills/verify-sdk-demo/scripts/cleanup.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Tear down the instance this run started. Keeps ${VERIFY_EVIDENCE_DIR}.
+# Usage: .cursor/skills/verify-sdk-demo/scripts/cleanup.sh
+
+set -euo pipefail
+# shellcheck source=lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+if [[ ! -f "${VERIFY_INSTANCE_FILE}" ]]; then
+  echo "verify-sdk-demo cleanup: no instance file; nothing to stop"
+  echo "verify-sdk-demo cleanup: evidence left at ${VERIFY_EVIDENCE_DIR}"
+  exit 0
+fi
+
+pid="$(verify_read_instance_pid || true)"
+if verify_pid_alive "${pid}"; then
+  echo "verify-sdk-demo cleanup: stopping pid ${pid}"
+  kill "${pid}" 2>/dev/null || true
+  for _ in $(seq 1 20); do
+    if ! verify_pid_alive "${pid}"; then
+      break
+    fi
+    sleep 0.25
+  done
+  if verify_pid_alive "${pid}"; then
+    echo "verify-sdk-demo cleanup: pid ${pid} still alive; sending TERM to process group" >&2
+    kill -TERM "-${pid}" 2>/dev/null || kill -TERM "${pid}" 2>/dev/null || true
+    sleep 1
+  fi
+  if verify_pid_alive "${pid}"; then
+    echo "verify-sdk-demo cleanup: pid ${pid} still alive; sending KILL" >&2
+    kill -KILL "${pid}" 2>/dev/null || true
+  fi
+else
+  echo "verify-sdk-demo cleanup: recorded pid ${pid} already gone"
+fi
+
+rm -f "${VERIFY_INSTANCE_FILE}"
+# Keep the log for post-mortems; it is not evidence and may be overwritten next launch.
+echo "verify-sdk-demo cleanup: instance stopped"
+echo "verify-sdk-demo cleanup: evidence left at ${VERIFY_EVIDENCE_DIR}"

--- a/.cursor/skills/verify-sdk-demo/scripts/cleanup.sh
+++ b/.cursor/skills/verify-sdk-demo/scripts/cleanup.sh
@@ -13,26 +13,14 @@ if [[ ! -f "${VERIFY_INSTANCE_FILE}" ]]; then
 fi
 
 pid="$(verify_read_instance_pid || true)"
-if verify_pid_alive "${pid}"; then
-  echo "verify-sdk-demo cleanup: stopping pid ${pid}"
-  kill "${pid}" 2>/dev/null || true
-  for _ in $(seq 1 20); do
-    if ! verify_pid_alive "${pid}"; then
-      break
-    fi
-    sleep 0.25
-  done
-  if verify_pid_alive "${pid}"; then
-    echo "verify-sdk-demo cleanup: pid ${pid} still alive; sending TERM to process group" >&2
-    kill -TERM "-${pid}" 2>/dev/null || kill -TERM "${pid}" 2>/dev/null || true
-    sleep 1
-  fi
-  if verify_pid_alive "${pid}"; then
-    echo "verify-sdk-demo cleanup: pid ${pid} still alive; sending KILL" >&2
-    kill -KILL "${pid}" 2>/dev/null || true
-  fi
-else
-  echo "verify-sdk-demo cleanup: recorded pid ${pid} already gone"
+listener_pid="$(verify_read_instance_listener_pid || true)"
+if [[ -n "${pid}" ]]; then
+  echo "verify-sdk-demo cleanup: stopping pid ${pid} and descendants"
+  verify_stop_tree "${pid}"
+fi
+if [[ -n "${listener_pid}" && "${listener_pid}" != "${pid}" ]]; then
+  echo "verify-sdk-demo cleanup: stopping listener pid ${listener_pid} and descendants"
+  verify_stop_tree "${listener_pid}"
 fi
 
 rm -f "${VERIFY_INSTANCE_FILE}"

--- a/.cursor/skills/verify-sdk-demo/scripts/doctor.sh
+++ b/.cursor/skills/verify-sdk-demo/scripts/doctor.sh
@@ -31,20 +31,8 @@ port_pid="$(verify_port_pid || true)"
 if [[ -z "${port_pid}" ]]; then
   fail "nothing listening on $(verify_origin)"
 fi
-if [[ "${port_pid}" != "${pid}" ]]; then
-  # Vite's listener is often a child of the pnpm wrapper we recorded.
-  if [[ "/proc/${port_pid}/" -ef "/proc/${pid}/" ]] || \
-     grep -q "^PPid:[[:space:]]*${pid}$" "/proc/${port_pid}/status" 2>/dev/null || \
-     grep -q "^PPid:[[:space:]]*${port_pid}$" "/proc/${pid}/status" 2>/dev/null; then
-    :
-  else
-    # Walk one more parent — pnpm -> node -> vite is common.
-    listener_ppid="$(awk '/^PPid:/{print $2}' "/proc/${port_pid}/status" 2>/dev/null || true)"
-    if [[ "${listener_ppid}" != "${pid}" ]] && \
-       ! grep -q "^PPid:[[:space:]]*${pid}$" "/proc/${listener_ppid}/status" 2>/dev/null; then
-      fail "port ${VERIFY_PORT} is pid ${port_pid}, not our instance ${pid} — refuse to drive a shared listener"
-    fi
-  fi
+if ! verify_pid_in_tree "${port_pid}" "${pid}"; then
+  fail "port ${VERIFY_PORT} is pid ${port_pid}, not in the tree of instance ${pid} — refuse to drive a shared listener"
 fi
 
 html="$(curl -fsS --max-time 5 "$(verify_origin)/")" || fail "GET $(verify_origin)/ failed"

--- a/.cursor/skills/verify-sdk-demo/scripts/doctor.sh
+++ b/.cursor/skills/verify-sdk-demo/scripts/doctor.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Read-only: is the verification instance worth driving?
+# Usage: .cursor/skills/verify-sdk-demo/scripts/doctor.sh
+
+set -euo pipefail
+# shellcheck source=lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+fail() {
+  echo "verify-sdk-demo doctor: FAIL: $*" >&2
+  exit 1
+}
+
+if [[ ! -f "${VERIFY_INSTANCE_FILE}" ]]; then
+  fail "no instance file at ${VERIFY_INSTANCE_FILE} — run launch.sh"
+fi
+
+pid="$(verify_read_instance_pid || true)"
+instance_port="$(verify_read_instance_port || true)"
+
+if ! verify_pid_alive "${pid}"; then
+  fail "recorded pid ${pid} is not running"
+fi
+
+if [[ "${instance_port}" != "${VERIFY_PORT}" ]]; then
+  echo "verify-sdk-demo doctor: WARN: instance port ${instance_port} != VERIFY_PORT ${VERIFY_PORT}" >&2
+  VERIFY_PORT="${instance_port}"
+fi
+
+port_pid="$(verify_port_pid || true)"
+if [[ -z "${port_pid}" ]]; then
+  fail "nothing listening on $(verify_origin)"
+fi
+if [[ "${port_pid}" != "${pid}" ]]; then
+  # Vite's listener is often a child of the pnpm wrapper we recorded.
+  if [[ "/proc/${port_pid}/" -ef "/proc/${pid}/" ]] || \
+     grep -q "^PPid:[[:space:]]*${pid}$" "/proc/${port_pid}/status" 2>/dev/null || \
+     grep -q "^PPid:[[:space:]]*${port_pid}$" "/proc/${pid}/status" 2>/dev/null; then
+    :
+  else
+    # Walk one more parent — pnpm -> node -> vite is common.
+    listener_ppid="$(awk '/^PPid:/{print $2}' "/proc/${port_pid}/status" 2>/dev/null || true)"
+    if [[ "${listener_ppid}" != "${pid}" ]] && \
+       ! grep -q "^PPid:[[:space:]]*${pid}$" "/proc/${listener_ppid}/status" 2>/dev/null; then
+      fail "port ${VERIFY_PORT} is pid ${port_pid}, not our instance ${pid} — refuse to drive a shared listener"
+    fi
+  fi
+fi
+
+html="$(curl -fsS --max-time 5 "$(verify_origin)/")" || fail "GET $(verify_origin)/ failed"
+if ! printf '%s' "${html}" | grep -q 'YouVersion SDK Demo'; then
+  fail "HTML title/body is not the SDK demo"
+fi
+
+echo "verify-sdk-demo doctor: process pid=${pid} listening on $(verify_origin)"
+echo "verify-sdk-demo doctor: static shell ok (title YouVersion SDK Demo)"
+
+node "${VERIFY_SKILL_DIR}/scripts/drive.mjs" doctor

--- a/.cursor/skills/verify-sdk-demo/scripts/drive.mjs
+++ b/.cursor/skills/verify-sdk-demo/scripts/drive.mjs
@@ -1,0 +1,281 @@
+#!/usr/bin/env node
+/**
+ * Playwright harness for the YouVersion SDK Demo.
+ *
+ * Usage (from repo root):
+ *   node .cursor/skills/verify-sdk-demo/scripts/drive.mjs doctor
+ *   node .cursor/skills/verify-sdk-demo/scripts/drive.mjs bible-reader
+ *   node .cursor/skills/verify-sdk-demo/scripts/drive.mjs verse-of-the-day
+ *   node .cursor/skills/verify-sdk-demo/scripts/drive.mjs bible-card
+ *   node .cursor/skills/verify-sdk-demo/scripts/drive.mjs theme
+ *
+ * Reads /tmp/verify-sdk-demo/instance.json (or VERIFY_DIR). Writes evidence
+ * under ${VERIFY_EVIDENCE_DIR:-$VERIFY_DIR/evidence}/ — never deleted by cleanup.
+ */
+
+import { createRequire } from 'node:module';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const skillDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const repoRoot = resolve(skillDir, '../../..');
+const verifyDir = process.env.VERIFY_DIR || '/tmp/verify-sdk-demo';
+const evidenceRoot = process.env.VERIFY_EVIDENCE_DIR || join(verifyDir, 'evidence');
+const instanceFile = join(verifyDir, 'instance.json');
+
+const require = createRequire(join(repoRoot, 'packages/ui/package.json'));
+
+function loadPlaywright() {
+  try {
+    return require('playwright');
+  } catch (first) {
+    try {
+      return require(join(repoRoot, 'node_modules/playwright'));
+    } catch {
+      throw new Error(
+        `Playwright not found via packages/ui. Run pnpm install. (${first instanceof Error ? first.message : first})`,
+      );
+    }
+  }
+}
+
+function readInstance() {
+  if (!existsSync(instanceFile)) {
+    throw new Error(`No instance file at ${instanceFile}. Run scripts/launch.sh first.`);
+  }
+  return JSON.parse(readFileSync(instanceFile, 'utf8'));
+}
+
+function stamp() {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+function evidenceDir(feature) {
+  const dir = join(evidenceRoot, `${stamp()}-${feature}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+async function launchBrowser() {
+  const { chromium } = loadPlaywright();
+  const chromePath =
+    process.env.VERIFY_CHROME ||
+    (existsSync('/usr/local/bin/google-chrome') ? '/usr/local/bin/google-chrome' : undefined);
+  return chromium.launch({
+    headless: process.env.VERIFY_HEADED === '1' ? false : true,
+    executablePath: chromePath,
+    args: ['--no-sandbox', '--disable-dev-shm-usage'],
+  });
+}
+
+async function openPage(browser, origin) {
+  const page = await browser.newPage({
+    viewport: { width: 1280, height: 800 },
+    locale: 'en-US',
+  });
+  page.on('pageerror', (err) => {
+    console.error('verify-sdk-demo drive: pageerror', err.message);
+  });
+  await page.goto(origin, { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  return page;
+}
+
+async function waitForDemoChrome(page) {
+  await page.getByRole('button', { name: 'Bible Reader' }).waitFor({ timeout: 15_000 });
+}
+
+async function waitForBibleRenderer(page) {
+  const renderer = page.locator('[data-slot="yv-bible-renderer"]');
+  await renderer.waitFor({ state: 'visible', timeout: 30_000 });
+  await page.locator('.yv-v[v]').first().waitFor({ state: 'visible', timeout: 30_000 });
+  return renderer;
+}
+
+async function assertNotMissingAppKey(page) {
+  const alert = page.getByRole('alert');
+  if ((await alert.count()) === 0) return;
+  const text = (await alert.innerText()).replace(/\s+/g, ' ').trim();
+  if (/app key is missing or invalid/i.test(text) || /couldn't be loaded because the app key/i.test(text)) {
+    throw new Error(
+      `Demo rendered the missing-app-key panel: "${text}". Set VITE_YVP_APP_KEY (or YVP_APP_KEY) and relaunch.`,
+    );
+  }
+}
+
+async function withBrowser(feature, fn) {
+  const instance = readInstance();
+  const origin = instance.origin;
+  const out = evidenceDir(feature);
+  const browser = await launchBrowser();
+  try {
+    const page = await openPage(browser, origin);
+    const result = await fn({ page, origin, out, instance });
+    writeFileSync(
+      join(out, 'result.json'),
+      `${JSON.stringify({ feature, origin, ok: true, ...result }, null, 2)}\n`,
+    );
+    console.log(`verify-sdk-demo drive: ${feature} ok`);
+    console.log(`verify-sdk-demo drive: evidence ${out}`);
+    return result;
+  } catch (err) {
+    writeFileSync(
+      join(out, 'result.json'),
+      `${JSON.stringify(
+        { feature, origin, ok: false, error: err instanceof Error ? err.message : String(err) },
+        null,
+        2,
+      )}\n`,
+    );
+    console.error(`verify-sdk-demo drive: ${feature} FAILED`);
+    console.error(`verify-sdk-demo drive: evidence ${out}`);
+    throw err;
+  } finally {
+    await browser.close();
+  }
+}
+
+async function cmdDoctor() {
+  await withBrowser('doctor', async ({ page, out }) => {
+    await page.screenshot({ path: join(out, '01-shell.png'), fullPage: true });
+    await waitForDemoChrome(page);
+    await assertNotMissingAppKey(page);
+    const renderer = await waitForBibleRenderer(page);
+    const verseCount = await page.locator('.yv-v[v]').count();
+    await page.screenshot({ path: join(out, '02-reader-ready.png'), fullPage: true });
+    const html = await renderer.innerText();
+    if (verseCount < 1) {
+      throw new Error('Bible renderer mounted but no .yv-v[v] verse wrappers found');
+    }
+    console.log(`verify-sdk-demo doctor: renderer ready (${verseCount} verse wrappers)`);
+    return { verseCount, preview: html.slice(0, 160) };
+  });
+}
+
+async function cmdBibleReader() {
+  await withBrowser('bible-reader', async ({ page, out }) => {
+    await waitForDemoChrome(page);
+    await page.getByRole('button', { name: 'Bible Reader' }).click();
+    await assertNotMissingAppKey(page);
+    await waitForBibleRenderer(page);
+    await page.screenshot({ path: join(out, '01-john-1.png'), fullPage: true });
+
+    const chapterTrigger = page.getByRole('button', { name: /change bible book and chapter/i });
+    const beforeLabel = (await chapterTrigger.innerText()).replace(/\s+/g, ' ').trim();
+    const next = page.getByRole('button', { name: /next chapter/i });
+    await next.click();
+
+    await page
+      .getByRole('status', { name: /loading passage/i })
+      .waitFor({ state: 'visible', timeout: 5_000 })
+      .catch(() => undefined);
+    await page
+      .getByRole('status', { name: /loading passage/i })
+      .waitFor({ state: 'hidden', timeout: 30_000 })
+      .catch(() => undefined);
+
+    await waitForBibleRenderer(page);
+    await page.waitForFunction(
+      (prev) => {
+        const buttons = [...document.querySelectorAll('button[aria-label]')];
+        const btn = buttons.find((el) =>
+          /change bible book and chapter/i.test(el.getAttribute('aria-label') || ''),
+        );
+        return Boolean(btn && btn.textContent && btn.textContent.replace(/\s+/g, ' ').trim() !== prev);
+      },
+      beforeLabel,
+      { timeout: 30_000 },
+    );
+
+    const afterLabel = (await chapterTrigger.innerText()).replace(/\s+/g, ' ').trim();
+    if (afterLabel === beforeLabel) {
+      throw new Error(`Next chapter did not change the picker label (still "${beforeLabel}")`);
+    }
+    await page.screenshot({ path: join(out, '02-after-next-chapter.png'), fullPage: true });
+    return { beforeLabel, afterLabel };
+  });
+}
+
+async function cmdVerseOfTheDay() {
+  await withBrowser('verse-of-the-day', async ({ page, out }) => {
+    await waitForDemoChrome(page);
+    await page.screenshot({ path: join(out, '01-before-nav.png'), fullPage: true });
+    await page.getByRole('button', { name: 'Verse of the Day' }).click();
+    await assertNotMissingAppKey(page);
+    const cards = page.locator('section[data-yv-sdk][data-size]');
+    await cards.first().waitFor({ state: 'visible', timeout: 30_000 });
+    await page.locator('[data-slot="yv-bible-renderer"]').first().waitFor({
+      state: 'visible',
+      timeout: 30_000,
+    });
+    const count = await cards.count();
+    if (count < 2) {
+      throw new Error(`Expected two VOTD cards (default + lg); found ${count}`);
+    }
+    await page.getByRole('button', { name: /^share$/i }).first().waitFor({ state: 'visible' });
+    await page.screenshot({ path: join(out, '02-votd.png'), fullPage: true });
+    return { cardCount: count };
+  });
+}
+
+async function cmdBibleCard() {
+  await withBrowser('bible-card', async ({ page, out }) => {
+    await waitForDemoChrome(page);
+    await page.screenshot({ path: join(out, '01-before-nav.png'), fullPage: true });
+    await page.getByRole('button', { name: 'Bible Card' }).click();
+    await assertNotMissingAppKey(page);
+    const card = page.locator('section[data-yv-sdk]').filter({ has: page.locator('h2') });
+    await card.first().waitFor({ state: 'visible', timeout: 30_000 });
+    await page.getByRole('heading', { level: 2 }).first().waitFor({ state: 'visible' });
+    await page.getByRole('button', { name: /change bible version/i }).waitFor({
+      state: 'visible',
+      timeout: 30_000,
+    });
+    await page.locator('[data-slot="yv-bible-renderer"]').waitFor({
+      state: 'visible',
+      timeout: 30_000,
+    });
+    const heading = (await page.getByRole('heading', { level: 2 }).first().innerText()).trim();
+    await page.screenshot({ path: join(out, '02-bible-card.png'), fullPage: true });
+    return { heading };
+  });
+}
+
+async function cmdTheme() {
+  await withBrowser('theme', async ({ page, out }) => {
+    await waitForDemoChrome(page);
+    await assertNotMissingAppKey(page);
+    const before = await page.evaluate(() => document.documentElement.className);
+    await page.screenshot({ path: join(out, '01-before-theme.png'), fullPage: true });
+    await page.getByRole('button', { name: 'Toggle theme' }).click();
+    await page.getByRole('menuitem', { name: 'Dark' }).click();
+    await page.waitForFunction(() => document.documentElement.classList.contains('dark'));
+    const after = await page.evaluate(() => document.documentElement.className);
+    const stored = await page.evaluate(() => localStorage.getItem('yv-sdk-demo-theme'));
+    if (stored !== 'dark') {
+      throw new Error(`Expected localStorage yv-sdk-demo-theme=dark; got ${JSON.stringify(stored)}`);
+    }
+    await page.screenshot({ path: join(out, '02-dark.png'), fullPage: true });
+    return { beforeClass: before, afterClass: after, stored };
+  });
+}
+
+const commands = {
+  doctor: cmdDoctor,
+  'bible-reader': cmdBibleReader,
+  'verse-of-the-day': cmdVerseOfTheDay,
+  'bible-card': cmdBibleCard,
+  theme: cmdTheme,
+};
+
+const feature = process.argv[2] || 'bible-reader';
+const run = commands[feature];
+if (!run) {
+  console.error(`Unknown feature "${feature}". Try: ${Object.keys(commands).join(', ')}`);
+  process.exit(2);
+}
+
+run().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/.cursor/skills/verify-sdk-demo/scripts/launch.sh
+++ b/.cursor/skills/verify-sdk-demo/scripts/launch.sh
@@ -98,6 +98,19 @@ if [[ "${ready}" -ne 1 ]]; then
   exit 1
 fi
 
+listener_pid="$(verify_port_pid || true)"
+python3 - "${VERIFY_INSTANCE_FILE}" "${listener_pid}" <<'PY'
+import json, sys
+path, listener = sys.argv[1], sys.argv[2]
+with open(path, encoding="utf-8") as fh:
+    data = json.load(fh)
+if listener:
+    data["listenerPid"] = int(listener)
+with open(path, "w", encoding="utf-8") as fh:
+    json.dump(data, fh, indent=2)
+    fh.write("\n")
+PY
+
 echo "verify-sdk-demo: ready pid=${vite_pid} origin=$(verify_origin)"
 echo "verify-sdk-demo: instance ${VERIFY_INSTANCE_FILE}"
 echo "verify-sdk-demo: log ${VERIFY_LOG_FILE}"

--- a/.cursor/skills/verify-sdk-demo/scripts/launch.sh
+++ b/.cursor/skills/verify-sdk-demo/scripts/launch.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Start an isolated Vite demo for verification. Writes ${VERIFY_DIR}/instance.json.
+# Usage (from repo root): .cursor/skills/verify-sdk-demo/scripts/launch.sh
+
+set -euo pipefail
+# shellcheck source=lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+mkdir -p "${VERIFY_DIR}" "${VERIFY_EVIDENCE_DIR}"
+verify_load_env
+
+if [[ -f "${VERIFY_INSTANCE_FILE}" ]]; then
+  existing_pid="$(verify_read_instance_pid || true)"
+  if verify_pid_alive "${existing_pid}"; then
+    existing_port="$(verify_read_instance_port)"
+    echo "verify-sdk-demo: already running pid=${existing_pid} port=${existing_port}" >&2
+    echo "verify-sdk-demo: origin=$(verify_origin)" >&2
+    echo "verify-sdk-demo: refuse to start a second process in ${VERIFY_DIR}" >&2
+    echo "verify-sdk-demo: set VERIFY_DIR and VERIFY_PORT to isolate another instance" >&2
+    exit 1
+  fi
+  rm -f "${VERIFY_INSTANCE_FILE}"
+fi
+
+port_pid="$(verify_port_pid || true)"
+if [[ -n "${port_pid}" ]]; then
+  echo "verify-sdk-demo: port ${VERIFY_PORT} is already owned by pid ${port_pid}" >&2
+  echo "verify-sdk-demo: refusing to share that listener. Pick VERIFY_PORT or stop that process." >&2
+  exit 1
+fi
+
+if ! verify_ui_built; then
+  echo "verify-sdk-demo: packages/ui/dist/index.js is missing. From ${REPO_ROOT} run: pnpm build" >&2
+  exit 1
+fi
+
+if [[ -z "${VITE_YVP_APP_KEY:-}" ]]; then
+  echo "verify-sdk-demo: VITE_YVP_APP_KEY is empty. The demo will render the missing-app-key panel." >&2
+  echo "verify-sdk-demo: set VITE_YVP_APP_KEY or YVP_APP_KEY, or add it to ${REPO_ROOT}/.env.local" >&2
+fi
+
+: >"${VERIFY_LOG_FILE}"
+
+echo "verify-sdk-demo: starting vite on $(verify_origin)" >&2
+
+(
+  cd "${REPO_ROOT}"
+  exec pnpm --filter vite-react dev --host "${VERIFY_HOST}" --port "${VERIFY_PORT}"
+) >>"${VERIFY_LOG_FILE}" 2>&1 &
+vite_pid=$!
+
+python3 - "${VERIFY_INSTANCE_FILE}" "${vite_pid}" "${VERIFY_HOST}" "${VERIFY_PORT}" "${VERIFY_LOG_FILE}" "${REPO_ROOT}" <<'PY'
+import json, sys
+path, pid, host, port, log, root = sys.argv[1:]
+with open(path, "w", encoding="utf-8") as fh:
+    json.dump(
+        {
+            "pid": int(pid),
+            "host": host,
+            "port": int(port),
+            "origin": f"http://{host}:{port}",
+            "log": log,
+            "repoRoot": root,
+        },
+        fh,
+        indent=2,
+    )
+    fh.write("\n")
+PY
+
+cleanup_on_fail() {
+  if verify_pid_alive "${vite_pid}"; then
+    kill "${vite_pid}" 2>/dev/null || true
+    wait "${vite_pid}" 2>/dev/null || true
+  fi
+  rm -f "${VERIFY_INSTANCE_FILE}"
+}
+
+ready=0
+for _ in $(seq 1 60); do
+  if ! verify_pid_alive "${vite_pid}"; then
+    echo "verify-sdk-demo: vite exited before ready. Last log lines:" >&2
+    tail -n 40 "${VERIFY_LOG_FILE}" >&2 || true
+    cleanup_on_fail
+    exit 1
+  fi
+  if curl -fsS --max-time 2 "$(verify_origin)/" >/dev/null 2>&1; then
+    ready=1
+    break
+  fi
+  sleep 0.5
+done
+
+if [[ "${ready}" -ne 1 ]]; then
+  echo "verify-sdk-demo: timed out waiting for $(verify_origin)" >&2
+  tail -n 40 "${VERIFY_LOG_FILE}" >&2 || true
+  cleanup_on_fail
+  exit 1
+fi
+
+echo "verify-sdk-demo: ready pid=${vite_pid} origin=$(verify_origin)"
+echo "verify-sdk-demo: instance ${VERIFY_INSTANCE_FILE}"
+echo "verify-sdk-demo: log ${VERIFY_LOG_FILE}"

--- a/.cursor/skills/verify-sdk-demo/scripts/lib.sh
+++ b/.cursor/skills/verify-sdk-demo/scripts/lib.sh
@@ -70,6 +70,65 @@ verify_port_pid() {
   fi
 }
 
+# True if $1 is $2 or a descendant of $2 (pnpm → sh → vite).
+verify_pid_in_tree() {
+  local candidate="$1"
+  local root="$2"
+  local guard=0
+  while [[ -n "${candidate}" && "${candidate}" != "0" && "${candidate}" != "1" ]]; do
+    if [[ "${candidate}" == "${root}" ]]; then
+      return 0
+    fi
+    candidate="$(awk '/^PPid:/{print $2}' "/proc/${candidate}/status" 2>/dev/null || true)"
+    guard=$((guard + 1))
+    if [[ "${guard}" -gt 32 ]]; then
+      break
+    fi
+  done
+  return 1
+}
+
+# Prints recorded pid plus descendants (children first). Used by cleanup only.
+verify_process_tree() {
+  local root="$1"
+  local children
+  local child
+  children="$(ps -o pid= --ppid "${root}" 2>/dev/null || true)"
+  for child in ${children}; do
+    verify_process_tree "${child}"
+  done
+  printf '%s\n' "${root}"
+}
+
+verify_stop_tree() {
+  local root="$1"
+  local pid
+  local pids
+  pids="$(verify_process_tree "${root}" | tr '\n' ' ')"
+  for pid in ${pids}; do
+    if verify_pid_alive "${pid}"; then
+      kill -TERM "${pid}" 2>/dev/null || true
+    fi
+  done
+  for _ in $(seq 1 20); do
+    local any=0
+    for pid in ${pids}; do
+      if verify_pid_alive "${pid}"; then
+        any=1
+      fi
+    done
+    if [[ "${any}" -eq 0 ]]; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  for pid in ${pids}; do
+    if verify_pid_alive "${pid}"; then
+      kill -KILL "${pid}" 2>/dev/null || true
+    fi
+  done
+}
+
 verify_read_instance_pid() {
   if [[ ! -f "${VERIFY_INSTANCE_FILE}" ]]; then
     return 1
@@ -80,5 +139,10 @@ verify_read_instance_pid() {
 
 verify_read_instance_port() {
   python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("port",""))' \
+    "${VERIFY_INSTANCE_FILE}"
+}
+
+verify_read_instance_listener_pid() {
+  python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("listenerPid",""))' \
     "${VERIFY_INSTANCE_FILE}"
 }

--- a/.cursor/skills/verify-sdk-demo/scripts/lib.sh
+++ b/.cursor/skills/verify-sdk-demo/scripts/lib.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Shared paths and env resolution for verify-sdk-demo helpers.
+# Source from the other scripts. Do not execute directly.
+
+set -euo pipefail
+
+_skill_scripts_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VERIFY_SKILL_DIR="$(cd "${_skill_scripts_dir}/.." && pwd)"
+REPO_ROOT="$(cd "${VERIFY_SKILL_DIR}/../../.." && pwd)"
+
+VERIFY_HOST="${VERIFY_HOST:-127.0.0.1}"
+VERIFY_PORT="${VERIFY_PORT:-5177}"
+VERIFY_DIR="${VERIFY_DIR:-/tmp/verify-sdk-demo}"
+VERIFY_EVIDENCE_DIR="${VERIFY_EVIDENCE_DIR:-${VERIFY_DIR}/evidence}"
+VERIFY_INSTANCE_FILE="${VERIFY_DIR}/instance.json"
+VERIFY_LOG_FILE="${VERIFY_DIR}/vite.log"
+
+verify_origin() {
+  printf 'http://%s:%s' "${VERIFY_HOST}" "${VERIFY_PORT}"
+}
+
+# Load VITE_* for the demo. Prefer process env, then monorepo-root env files
+# (AGENTS.md: not worktree-local), then examples/vite-react/.env.local.
+# Maps YVP_APP_KEY → VITE_YVP_APP_KEY when the Vite-prefixed var is unset.
+# Never writes secrets to disk.
+verify_load_env() {
+  _verify_source_env_file() {
+    local file="$1"
+    if [[ -f "${file}" ]]; then
+      set -a
+      # shellcheck disable=SC1090
+      . "${file}"
+      set +a
+    fi
+  }
+
+  _verify_source_env_file "${REPO_ROOT}/.env.local"
+  _verify_source_env_file "${REPO_ROOT}/.env"
+  if [[ -z "${VITE_YVP_APP_KEY:-}" ]]; then
+    _verify_source_env_file "${REPO_ROOT}/examples/vite-react/.env.local"
+  fi
+
+  if [[ -z "${VITE_YVP_APP_KEY:-}" && -n "${YVP_APP_KEY:-}" ]]; then
+    export VITE_YVP_APP_KEY="${YVP_APP_KEY}"
+  fi
+
+  export VITE_YVP_API_HOST="${VITE_YVP_API_HOST:-${YVP_API_HOST:-api.youversion.com}}"
+  export VITE_YVP_AUTH_REDIRECT_URL="${VITE_YVP_AUTH_REDIRECT_URL:-$(verify_origin)}"
+}
+
+verify_ui_built() {
+  [[ -f "${REPO_ROOT}/packages/ui/dist/index.js" ]]
+}
+
+verify_pid_alive() {
+  local pid="$1"
+  [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null
+}
+
+# Prints the PID listening on VERIFY_HOST:VERIFY_PORT, or empty.
+verify_port_pid() {
+  if command -v ss >/dev/null 2>&1; then
+    ss -ltnp "sport = :${VERIFY_PORT}" 2>/dev/null \
+      | sed -n 's/.*pid=\([0-9][0-9]*\).*/\1/p' \
+      | head -n 1
+    return
+  fi
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -nP -iTCP:"${VERIFY_PORT}" -sTCP:LISTEN -t 2>/dev/null | head -n 1
+  fi
+}
+
+verify_read_instance_pid() {
+  if [[ ! -f "${VERIFY_INSTANCE_FILE}" ]]; then
+    return 1
+  fi
+  python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("pid",""))' \
+    "${VERIFY_INSTANCE_FILE}"
+}
+
+verify_read_instance_port() {
+  python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("port",""))' \
+    "${VERIFY_INSTANCE_FILE}"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,10 @@ yarn-error.log*
 # Claude Code
 .claude/
 .omc/
-.cursor/
+# Cursor local state — keep versioned agent skills
+.cursor/*
+!.cursor/skills/
+!.cursor/skills/**
 
 # Storybook
 *storybook.log


### PR DESCRIPTION
I ran Poteto's `/create-verification-skill` on the React Web SDK. 

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a project-local Cursor skill (`.cursor/skills/verify-sdk-demo/`) so later agents can launch the Vite SDK demo, check that the instance is worth driving, and exercise the live UI with Playwright.

## What
- Skill + feature map for the demo’s user-facing surfaces: Bible Reader, Verse of the Day, Bible Card, Sign in, Theme
- Helpers: `launch.sh`, `doctor.sh`, `drive.mjs`, `cleanup.sh`
- `.gitignore` exception so `.cursor/skills/` can be versioned (other `.cursor/` local state stays ignored)

## Proven on this branch
Ran the skill’s own loop against a live `YVP_APP_KEY`:

1. `launch.sh` → `http://127.0.0.1:5177`
2. `doctor.sh` → renderer ready (57 verse wrappers)
3. `drive.mjs bible-reader` → chapter picker **John 1** → **John 2**, screenshots + `result.json`
4. `cleanup.sh` → instance and port gone; evidence left at `/tmp/verify-sdk-demo/evidence/`

## Notes
- Default verification port is **5177** so a human demo on 5173 is left alone
- Live Bible content still needs `VITE_YVP_APP_KEY` or injected `YVP_APP_KEY`
- Sign-in OAuth is documented but not completed unattended
- Keep the feature map honest with `/maintain-verification-skill` as the demo changes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08715cb7-f9d6-4db9-a375-0600ea0a68fe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08715cb7-f9d6-4db9-a375-0600ea0a68fe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

