### PR TITLE
fix(ui): address shadow DOM review regressions (YPE-5713)

### DIFF
--- a/.changeset/friendly-verses-scroll.md
+++ b/.changeset/friendly-verses-scroll.md
@@ -1,0 +1,5 @@
+---
+'@youversion/platform-react-ui': patch
+---
+
+Keep verse actions open when touch selection moves to another verse, restore focus for initially anchored or conditionally mounted verse actions, and keep reader settings scrollable in constrained popovers. Clarify the Shadow DOM prototype's document-owned font and root-sizing dependencies without expanding its rollout scope.

--- a/.changeset/tidy-shadows-reset.md
+++ b/.changeset/tidy-shadows-reset.md
@@ -2,4 +2,4 @@
 '@youversion/platform-react-ui': patch
 ---
 
-Harden Shadow DOM style isolation so only text direction crosses the boundary and host custom properties cannot alter known SDK spacing or radius values.
+Harden Shadow DOM style isolation so text direction is the only intentionally inherited CSS property and host custom properties cannot alter known SDK spacing or radius values. Document-root font sizing still affects the prototype's rem-based dimensions.

--- a/docs/adr/0007-prototype-shadow-dom-style-isolation.md
+++ b/docs/adr/0007-prototype-shadow-dom-style-isolation.md
@@ -13,14 +13,18 @@ prototype therefore uses Shadow DOM as the browser-enforced style boundary.
 `YouVersionAuthButton` automatically creates an open shadow root and renders its
 existing implementation into it through a React portal. Consumers continue to
 use the same component API; they do not need to discover or enable isolation.
-The SDK's compiled Tailwind CSS is installed inside the root, the light-DOM host
+The SDK's compiled Tailwind component rules are installed inside the root, the light-DOM host
 receives a protected box reset, and an internal wrapper resets inherited visual
 properties.
 
-Writing direction is the only intentional inherited visual input: both reset
+Writing direction is the only intentional inherited CSS property: both reset
 boundaries explicitly preserve `direction`, while `all: initial` restores
 horizontal writing, mixed text orientation, SDK typography, and other visual
-properties. Vertical host writing modes and host typography are unsupported.
+properties. Vertical host writing modes and inherited host typography are unsupported.
+This is selector and inheritance isolation, not independent document sizing:
+the prototype retains `rem` units, so the owning document's root font size still
+scales SDK text, spacing, and controls. That sizing input is accepted for the
+prototype; it is not reset by a shadow boundary.
 Known ambient custom-property dependencies are closed by using SDK-owned
 `--yv-spacing` and `--yv-radius` values and by defining a local `--spacing`
 compatibility alias for `tw-animate-css`. YPE-5400 owns the full custom-property
@@ -29,7 +33,14 @@ inventory and a compiled-CSS prevention guard.
 Constructable stylesheets are cached per owning `Document`, because a sheet from
 the top-level document cannot be adopted into a same-origin iframe's shadow
 root. Environments without constructable stylesheets receive a `<style>` element
-instead.
+instead. Font loading remains document-owned: `CSSStyleSheet.replaceSync()`
+discards `@import`, so the adopted sheet does not load the Google Fonts import
+from the compiled CSS (and Chromium warns once when the cached sheet is created).
+`YouVersionProvider` installs the document stylesheet and brand-font stylesheet;
+an isolated component still depends on those document-level font registrations.
+The local `<style>` fallback retains the import but is not a substitute for
+document-owned font loading. For iframe consumers, fonts must be loaded in the
+iframe's owning document, not merely in the parent document.
 
 The same infrastructure was exercised as an internal opt-in with
 `BibleVersionPicker` and the shared Dialog and Popover primitives. Floating

--- a/docs/shadow-dom-isolation-plan.md
+++ b/docs/shadow-dom-isolation-plan.md
@@ -72,9 +72,9 @@ open.
 
 No other production direct-overlay bypass was found. The inventory therefore
 produced no equivalent low-risk migration and no materially different case that
-requires follow-up work. YPE-5355 found that any added overlay coordination
-should extend the controller already owned by `ShadowRootHost`; YPE-5356 owns
-that runtime decision and implementation.
+requires follow-up work. Extending the controller already owned by
+`ShadowRootHost` is a candidate seam for added overlay coordination, not an ADR
+decision. YPE-5356 owns whether and how to implement that coordination.
 
 ## Blocking production-readiness decisions
 
@@ -83,9 +83,9 @@ that runtime decision and implementation.
 - Define SSR, hydration, and first-paint behavior. The current effect-attached
   root renders an empty host on the server and delays content and forwarded refs.
 - Resolve the YPE-5355 peer-dismissal and final focus-restoration gaps before
-  shipping nested and concurrent overlays (YPE-5356). ADR 0007 limits any new
-  coordination to the existing root-owned controller and requires it to account
-  for trigger-time peer dismissal as well as overlay order and restore targets.
+  shipping nested and concurrent overlays (YPE-5356). The decision must consider
+  trigger-time peer dismissal as well as overlay order and restore targets;
+  ADR 0007 records the gaps but does not select a coordination design.
   Cross-browser and assistive-technology coverage still remain.
 - Complete the package-wide custom-property inventory and prevention guard in
   YPE-5400. The known `BibleVersionPicker`, `InputGroup`, and `tw-animate-css`
@@ -98,9 +98,11 @@ that runtime decision and implementation.
   to every proposed rollout component. Native outer-form participation and
   external `label`, `aria-labelledby`, and `aria-describedby` relationships are
   unsupported across tree scopes in the current Chromium evidence.
-- Preserve `direction` as the only intentional inherited visual input. Vertical
-  writing modes, text orientation, host typography, and undeclared host custom
-  properties are not supported customization inputs.
+- Preserve `direction` as the only intentional inherited CSS property. Vertical
+  writing modes, text orientation, inherited host typography, and undeclared
+  host custom properties are not supported customization inputs. The prototype
+  retains `rem` sizing, which still responds to the owning document's root font
+  size; review that accepted sizing input for each rollout component.
 - Repeat the documented event, ref, nested-root, and shadow-aware automation
   checks for every public component selected for rollout.
 - Verify stylesheet construction and adoption failure recovery beyond the
@@ -110,6 +112,12 @@ that runtime decision and implementation.
 
 ## Accepted boundaries and unresolved environment coverage
 
+- Component rules are installed locally, but font loading is document-owned.
+  Constructable stylesheets discard the compiled Google Fonts `@import` and
+  Chromium warns when the per-document cached sheet is created. The `<style>`
+  fallback retains the import; neither path replaces the provider's document
+  stylesheet and brand-font registration. Fonts must be loaded in each owning
+  document, including same-origin iframes.
 - Host `@font-face` registrations are document-scoped and can collide with the
   public font family names used inside a shadow root. This limitation is
   accepted for the prototype; avoiding it requires private family names and

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -70,13 +70,15 @@ Language tags are BCP 47 (`en`, `es`, `zh-Hans`). Version ids are YouVersion Bib
 
 All component CSS is automatically injected when you wrap your app with `YouVersionProvider` — no extra imports or build steps needed. Under the hood, it uses React 19's [`<style precedence>`](https://react.dev/reference/react-dom/components/style) to hoist styles into `<head>` with built-in deduplication and SSR/Suspense support.
 
+Prototype exception: `YouVersionAuthButton` automatically renders inside an open shadow root, which installs its component styles locally. Fonts still depend on the provider's styles in the owning document, and `rem` sizing still follows that document's root font size. Other public components are not automatically isolated. See the [Shadow DOM ADR](../../docs/adr/0007-prototype-shadow-dom-style-isolation.md) and [consumer compatibility contract](../../docs/shadow-dom-consumer-compatibility.md) for the prototype's DOM, ref, event, and styling limitations.
+
 **Non-React or manual CSS import:**
 
 ```tsx
 import '@youversion/platform-react-ui/styles.css';
 ```
 
-All component classes are prefixed with `yv:` to avoid collisions with your app's styles. Override design tokens with CSS variables on `[data-yv-sdk]` (see [Custom CSS variables](#custom-css-variables)).
+All component classes are prefixed with `yv:` to avoid collisions with your app's styles. For light-DOM components, override design tokens with CSS variables on `[data-yv-sdk]` (see [Custom CSS variables](#custom-css-variables)). Document selectors cannot reach the isolated auth button's internal styled root.
 
 ### Content Security Policy
 
@@ -161,6 +163,8 @@ Individual components accept a `background` prop to override the provider theme 
 ```
 
 ### Custom CSS variables
+
+These document-level overrides apply to light-DOM components, not to the automatically isolated `YouVersionAuthButton`. The prototype does not expose a public shadow-root token override API.
 
 ```css
 [data-yv-sdk] {

--- a/packages/ui/src/components/bible-reader.stories.tsx
+++ b/packages/ui/src/components/bible-reader.stories.tsx
@@ -244,6 +244,10 @@ export const VerseSelectionReanchoringDismissalAndFocusRestoration: Story = {
     const touchUser = userEvent.setup({ document: ownerDocument });
     await touchUser.pointer({ keys: '[TouchA]', target: firstVerse });
     dialog = await screen.findByRole('dialog');
+    // Radix disables animations until placement completes. Measure after both
+    // so initial positioning or animation cannot count as verse reanchoring.
+    await waitFor(() => expect(dialog.style.animation).not.toBe('none'));
+    await Promise.all(dialog.getAnimations().map((animation) => animation.finished));
     const touchDialogRect = dialog.getBoundingClientRect();
     await touchUser.pointer({ keys: '[TouchA]', target: secondVerseLabel });
     await expect(firstVerse).toHaveClass('yv-v-selected');

--- a/packages/ui/src/components/bible-reader.stories.tsx
+++ b/packages/ui/src/components/bible-reader.stories.tsx
@@ -161,7 +161,7 @@ export const Default: Story = {
   },
 };
 
-export const VerseActionPopoverInteractions: Story = {
+export const VerseSelectionReanchoringDismissalAndFocusRestoration: Story = {
   tags: ['integration'],
   args: {
     defaultVersionId: 111,
@@ -261,6 +261,7 @@ export const VerseActionPopoverInteractions: Story = {
     await waitFor(() => expect(dialog).not.toBeInTheDocument());
     await expect(firstVerse).not.toHaveClass('yv-v-selected');
     await expect(secondVerse).not.toHaveClass('yv-v-selected');
+    await expect(ownerDocument.activeElement).toBe(outsideControl);
   },
 };
 

--- a/packages/ui/src/components/bible-reader.stories.tsx
+++ b/packages/ui/src/components/bible-reader.stories.tsx
@@ -238,6 +238,29 @@ export const VerseActionPopoverInteractions: Story = {
     await expect(secondVerse).not.toHaveClass('yv-v-selected');
     await userEvent.pointer({ keys: '[/MouseLeft]', target: outsideControl });
     await expect(ownerDocument.activeElement).toBe(outsideControl);
+
+    // Touch outside events are deferred until click: the original pointerdown's
+    // composed path is already empty when Radix asks whether to dismiss.
+    const touchUser = userEvent.setup({ document: ownerDocument });
+    await touchUser.pointer({ keys: '[TouchA]', target: firstVerse });
+    dialog = await screen.findByRole('dialog');
+    const touchDialogRect = dialog.getBoundingClientRect();
+    await touchUser.pointer({ keys: '[TouchA]', target: secondVerseLabel });
+    await expect(firstVerse).toHaveClass('yv-v-selected');
+    await expect(secondVerse).toHaveClass('yv-v-selected');
+    await expect(dialog).toHaveAttribute('data-state', 'open');
+    await waitFor(() => {
+      const nextRect = dialog.getBoundingClientRect();
+      const movedInline = Math.abs(nextRect.left - touchDialogRect.left) > 8;
+      const movedBlock = Math.abs(nextRect.top - touchDialogRect.top) > 8;
+      void expect(movedInline || movedBlock).toBe(true);
+    });
+    await touchUser.pointer({ keys: '[TouchA>]', target: outsideControl });
+    await expect(dialog).toHaveAttribute('data-state', 'open');
+    await touchUser.pointer({ keys: '[/TouchA]', target: outsideControl });
+    await waitFor(() => expect(dialog).not.toBeInTheDocument());
+    await expect(firstVerse).not.toHaveClass('yv-v-selected');
+    await expect(secondVerse).not.toHaveClass('yv-v-selected');
   },
 };
 

--- a/packages/ui/src/components/bible-reader.tsx
+++ b/packages/ui/src/components/bible-reader.tsx
@@ -1259,7 +1259,11 @@ export function BibleThemeSettingsContent({
 }: BibleThemeSettingsContentProps): ReactElement {
   const { t } = useTranslation(undefined, { i18n });
   return (
-    <div data-yv-sdk data-yv-theme={theme} className="yv:flex yv:flex-col yv:gap-4 yv:p-4">
+    <div
+      data-yv-sdk
+      data-yv-theme={theme}
+      className="yv:flex yv:min-h-0 yv:flex-col yv:gap-4 yv:overflow-y-auto yv:p-4"
+    >
       <div className="yv:flex yv:justify-between yv:items-stretch yv:gap-4">
         <div className="yv:flex yv:flex-1">
           <Button

--- a/packages/ui/src/components/bible-theme-settings.stories.tsx
+++ b/packages/ui/src/components/bible-theme-settings.stories.tsx
@@ -1,0 +1,102 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { http, HttpResponse } from 'msw';
+import { useState } from 'react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import i18n from '../i18n';
+import { INTER_FONT, UNTITLED_SERIF_FONT, type FontFamily } from '../lib/verse-html-utils';
+import { BibleThemeSettingsContent } from './bible-reader';
+import { Popover, PopoverContent, PopoverTrigger } from './ui/popover';
+
+function ConstrainedSettings(): React.ReactNode {
+  const [boundary, setBoundary] = useState<HTMLDivElement | null>(null);
+  const [fontFamily, setFontFamily] = useState<FontFamily>(INTER_FONT);
+  return (
+    <div
+      ref={setBoundary}
+      data-testid="settings-boundary"
+      data-font-family={fontFamily}
+      style={{ position: 'relative', blockSize: 360, inlineSize: 800 }}
+    >
+      <div style={{ position: 'absolute', insetBlockStart: '53%', insetInlineStart: '50%' }}>
+        <Popover>
+          <PopoverTrigger data-testid="settings-trigger">Settings</PopoverTrigger>
+          <PopoverContent heading="Reader settings" collisionBoundary={boundary} sideOffset={16}>
+            <BibleThemeSettingsContent
+              theme="light"
+              fontFamily={fontFamily}
+              fontSize={16}
+              lineSpacing={1.7}
+              onFontSelected={setFontFamily}
+              onFontIncreased={() => undefined}
+              onFontDecreased={() => undefined}
+              onChangeLineSpacing={() => undefined}
+            />
+          </PopoverContent>
+        </Popover>
+      </div>
+    </div>
+  );
+}
+
+const meta = {
+  title: 'Components/BibleReader/Settings',
+  component: ConstrainedSettings,
+  tags: ['integration'],
+  parameters: {
+    layout: 'fullscreen',
+    msw: {
+      handlers: [
+        http.get('*/v1/fonts/1/stylesheet', () =>
+          HttpResponse.text('', { headers: { 'Content-Type': 'text/css' } }),
+        ),
+      ],
+    },
+  },
+} satisfies Meta<typeof ConstrainedSettings>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FontControlsRemainReachableInConstrainedSpace: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByTestId('settings-trigger'));
+    const ownerDocument = canvasElement.ownerDocument;
+    const dialog = await within(ownerDocument.body).findByRole('dialog');
+    const serifButton = within(dialog).getByRole('button', {
+      name: `${i18n.t('fontLabel')} ${i18n.t('untitledSerifFontName')}`,
+    });
+    // Use the real settings body and Radix collision cap. Unlike a click helper,
+    // hit testing can detect controls rendered but clipped below the panel.
+    const settingsBody = serifButton.closest<HTMLElement>('[data-yv-sdk]');
+    if (!settingsBody) throw new Error('settings body not rendered');
+    await waitFor(() => {
+      void expect(settingsBody.scrollHeight).toBeGreaterThan(settingsBody.clientHeight);
+    });
+    await Promise.all(dialog.getAnimations().map((animation) => animation.finished));
+    const header = within(dialog).getByRole('heading');
+    const headerTop = header.getBoundingClientRect().top;
+    settingsBody.scrollTop = settingsBody.scrollHeight;
+    await waitFor(() => {
+      void expect(settingsBody.scrollTop).toBeGreaterThan(0);
+      const buttonRect = serifButton.getBoundingClientRect();
+      const bodyRect = settingsBody.getBoundingClientRect();
+      void expect(buttonRect.top).toBeGreaterThanOrEqual(bodyRect.top);
+      void expect(buttonRect.bottom).toBeLessThanOrEqual(bodyRect.bottom);
+      const hit = ownerDocument.elementFromPoint(
+        buttonRect.left + buttonRect.width / 2,
+        buttonRect.top + buttonRect.height / 2,
+      );
+      void expect(serifButton.contains(hit)).toBe(true);
+      void expect(header.getBoundingClientRect().top).toBe(headerTop);
+    });
+    await userEvent.click(serifButton);
+    void expect(canvas.getByTestId('settings-boundary')).toHaveAttribute(
+      'data-font-family',
+      UNTITLED_SERIF_FONT,
+    );
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => void expect(dialog).not.toBeInTheDocument());
+    void expect(ownerDocument.activeElement).toBe(canvas.getByTestId('settings-trigger'));
+  },
+};

--- a/packages/ui/src/components/verse-action-popover.shadow-isolation.stories.tsx
+++ b/packages/ui/src/components/verse-action-popover.shadow-isolation.stories.tsx
@@ -18,8 +18,14 @@ function IsolatedVerseActionPopover(): React.ReactNode {
 
   const selectVerse = (verse: number, element: HTMLElement): void => {
     setAnchorElement(element);
-    setSelectedVerses([verse]);
+    setSelectedVerses((selected) => (selected.includes(verse) ? selected : [...selected, verse]));
     setOpen(true);
+  };
+
+  const closeAndClearSelection = (): void => {
+    setOpen(false);
+    setAnchorElement(null);
+    setSelectedVerses([]);
   };
 
   return (
@@ -64,7 +70,7 @@ function IsolatedVerseActionPopover(): React.ReactNode {
                   ref={(element) => {
                     element?.setAttribute('v', '1');
                   }}
-                  className="yv-v"
+                  className={selectedVerses.includes(1) ? 'yv-v yv-v-selected' : 'yv-v'}
                   data-testid="verse-1"
                   onClick={(event) => selectVerse(1, event.currentTarget)}
                 >
@@ -74,7 +80,7 @@ function IsolatedVerseActionPopover(): React.ReactNode {
                   ref={(element) => {
                     element?.setAttribute('v', '2');
                   }}
-                  className="yv-v"
+                  className={selectedVerses.includes(2) ? 'yv-v yv-v-selected' : 'yv-v'}
                   data-testid="verse-2"
                   onClick={(event) => selectVerse(2, event.currentTarget)}
                 >
@@ -95,20 +101,21 @@ function IsolatedVerseActionPopover(): React.ReactNode {
               }
               if (!nextOpen && deferNextCloseRef.current) {
                 deferNextCloseRef.current = false;
-                setTimeout(() => setOpen(false), 25);
+                setTimeout(closeAndClearSelection, 25);
                 return;
               }
-              setOpen(nextOpen);
+              if (nextOpen) setOpen(true);
+              else closeAndClearSelection();
             }}
             activeHighlights={new Set()}
             selectedVerses={selectedVerses}
             highlightedVerses={{}}
             anchorElement={anchorElement}
             scrollRoot={readerScrollRoot}
-            onHighlight={() => setOpen(false)}
-            onClearHighlight={() => setOpen(false)}
-            onCopy={() => setOpen(false)}
-            onShare={() => setOpen(false)}
+            onHighlight={closeAndClearSelection}
+            onClearHighlight={closeAndClearSelection}
+            onCopy={closeAndClearSelection}
+            onShare={closeAndClearSelection}
           />
         </ShadowRootHost>
       </div>
@@ -313,6 +320,8 @@ export const PortalPlacementDockingReanchoringAndFocusRestoration: Story = {
     dialog = await waitForElement(topLayer, '[role="dialog"]', 'popover did not open for touch');
     const touchDialogRect = dialog.getBoundingClientRect();
     await touchUser.pointer({ keys: '[TouchA]', target: secondVerse });
+    void expect(firstVerse).toHaveClass('yv-v-selected');
+    void expect(secondVerse).toHaveClass('yv-v-selected');
     void expect(dialog).toHaveAttribute('data-state', 'open');
     void expect(Number(closeRequestOutput.getAttribute('data-count'))).toBe(
       closeRequestsBeforeTouch,
@@ -327,5 +336,6 @@ export const PortalPlacementDockingReanchoringAndFocusRestoration: Story = {
     void expect(Number(closeRequestOutput.getAttribute('data-count'))).toBe(
       closeRequestsBeforeTouch + 1,
     );
+    void expect(canvasElement.ownerDocument.activeElement).toBe(outsideControl);
   },
 };

--- a/packages/ui/src/components/verse-action-popover.shadow-isolation.stories.tsx
+++ b/packages/ui/src/components/verse-action-popover.shadow-isolation.stories.tsx
@@ -306,5 +306,26 @@ export const PortalPlacementDockingReanchoringAndFocusRestoration: Story = {
     await userEvent.click(outsideControl);
     await waitForClosed(topLayer);
     void expect(canvasElement.ownerDocument.activeElement).toBe(outsideControl);
+
+    const closeRequestsBeforeTouch = Number(closeRequestOutput.getAttribute('data-count'));
+    const touchUser = userEvent.setup({ document: canvasElement.ownerDocument });
+    await touchUser.pointer({ keys: '[TouchA]', target: firstVerse });
+    dialog = await waitForElement(topLayer, '[role="dialog"]', 'popover did not open for touch');
+    const touchDialogRect = dialog.getBoundingClientRect();
+    await touchUser.pointer({ keys: '[TouchA]', target: secondVerse });
+    void expect(dialog).toHaveAttribute('data-state', 'open');
+    void expect(Number(closeRequestOutput.getAttribute('data-count'))).toBe(
+      closeRequestsBeforeTouch,
+    );
+    await waitFor(() => {
+      void expect(dialog.getBoundingClientRect().left).toBeGreaterThan(touchDialogRect.left + 20);
+    });
+    await touchUser.pointer({ keys: '[TouchA>]', target: outsideControl });
+    void expect(dialog).toHaveAttribute('data-state', 'open');
+    await touchUser.pointer({ keys: '[/TouchA]', target: outsideControl });
+    await waitForClosed(topLayer);
+    void expect(Number(closeRequestOutput.getAttribute('data-count'))).toBe(
+      closeRequestsBeforeTouch + 1,
+    );
   },
 };

--- a/packages/ui/src/components/verse-action-popover.test.tsx
+++ b/packages/ui/src/components/verse-action-popover.test.tsx
@@ -27,7 +27,13 @@ function createDefaultProps() {
   };
 }
 
-function FocusRestorationScenario() {
+function FocusRestorationScenario({
+  anchorElement,
+  mountWhenOpen = false,
+}: {
+  anchorElement?: HTMLElement;
+  mountWhenOpen?: boolean;
+}) {
   const [open, setOpen] = useState(false);
 
   return (
@@ -35,12 +41,15 @@ function FocusRestorationScenario() {
       <button type="button" onClick={() => setOpen(true)}>
         Prior control
       </button>
-      <VerseActionPopover
-        {...createDefaultProps()}
-        open={open}
-        onOpenChange={setOpen}
-        onCopy={() => setOpen(false)}
-      />
+      {(!mountWhenOpen || open) && (
+        <VerseActionPopover
+          {...createDefaultProps()}
+          anchorElement={anchorElement}
+          open={open}
+          onOpenChange={setOpen}
+          onCopy={() => setOpen(false)}
+        />
+      )}
     </>
   );
 }
@@ -885,6 +894,36 @@ it('restores document focus after Escape and an action closes the popover', asyn
   await waitFor(() => expect(dialog).not.toBeInTheDocument());
   expect(document.activeElement).toBe(priorControl);
 });
+
+it.each([false, true])(
+  'restores focus with an existing virtual anchor (mount only when open: %s)',
+  async (mountWhenOpen) => {
+    const anchorElement = document.createElement('span');
+    document.body.append(anchorElement);
+    const user = userEvent.setup();
+    const view = render(
+      <FocusRestorationScenario anchorElement={anchorElement} mountWhenOpen={mountWhenOpen} />,
+    );
+    try {
+      const priorControl = screen.getByRole('button', { name: 'Prior control' });
+      await user.click(priorControl);
+      const dialog = await screen.findByRole('dialog');
+      await waitFor(() => expect(document.activeElement).toBe(dialog));
+      await user.click(screen.getByRole('button', { name: 'Copy' }));
+      await waitFor(() => expect(dialog).not.toBeInTheDocument());
+      await waitFor(() => expect(document.activeElement).toBe(priorControl));
+
+      await user.click(priorControl);
+      await screen.findByRole('dialog');
+      await user.keyboard('{Escape}');
+      await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+      await waitFor(() => expect(document.activeElement).toBe(priorControl));
+    } finally {
+      view.unmount();
+      anchorElement.remove();
+    }
+  },
+);
 
 it('restores shadow focus after Escape and an action closes the popover', async () => {
   const isolatedRender = render(

--- a/packages/ui/src/components/verse-action-popover.tsx
+++ b/packages/ui/src/components/verse-action-popover.tsx
@@ -1,4 +1,12 @@
-import { useEffect, useMemo, useRef, useState, type CSSProperties, type FC } from 'react';
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type FC,
+} from 'react';
 import * as PopoverPrimitive from '@radix-ui/react-popover';
 import { useTranslation } from 'react-i18next';
 import i18n from '@/i18n';
@@ -66,6 +74,15 @@ function scrollFadeMask({ start, end }: ScrollFade): React.CSSProperties | undef
   const right = end ? 'transparent' : '#000';
   const mask = `linear-gradient(to right, ${left} 0, #000 ${SCROLL_FADE_PX}px, #000 calc(100% - ${SCROLL_FADE_PX}px), ${right} 100%)`;
   return { maskImage: mask, WebkitMaskImage: mask };
+}
+
+function isVerseEvent(event: Event, owner: HTMLElement): boolean {
+  return event
+    .composedPath()
+    .some(
+      (target) =>
+        isElementFromOwnerDocument(target, owner, 'Element') && target.matches('.yv-v[v]'),
+    );
 }
 
 type VerseActionPopoverProps = {
@@ -189,36 +206,15 @@ export const VerseActionPopover: FC<VerseActionPopoverProps> = ({
   // initial focus to the content container instead (see `onOpenAutoFocus`): focus
   // still enters the popover (Escape closes; screen readers announce the dialog),
   // but the ring only appears once the user actually Tabs to a swatch.
-  const popoverAnchorRef = useRef<HTMLDivElement>(null);
+  const [popoverAnchor, setPopoverAnchor] = useState<HTMLDivElement | null>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const focusRestoreTargetRef = useRef<HTMLElement | null>(null);
   const documentFocusRestoreTargetRef = useRef<HTMLElement | null>(null);
+  const versePointerEventsRef = useRef(new WeakSet<Event>());
   const retainOutsideFocusRef = useRef(false);
   const allowPriorFocusRestoration = (): void => {
     retainOutsideFocusRef.current = false;
   };
-
-  useEffect(() => {
-    const anchor = popoverAnchorRef.current;
-    if (!anchor || getOwnShadowRoot(anchor)) return;
-
-    const ownerDocument = anchor.ownerDocument;
-    const rememberFocusedElement = (target: EventTarget | null): void => {
-      if (
-        !isElementFromOwnerDocument(target, anchor, 'HTMLElement') ||
-        target.closest('[data-slot="verse-action-popover"]') ||
-        target.hasAttribute('data-radix-focus-guard')
-      ) {
-        return;
-      }
-      documentFocusRestoreTargetRef.current = target;
-    };
-    const handleFocusIn = (event: FocusEvent): void => rememberFocusedElement(event.target);
-
-    rememberFocusedElement(ownerDocument.activeElement);
-    ownerDocument.addEventListener('focusin', handleFocusIn);
-    return () => ownerDocument.removeEventListener('focusin', handleFocusIn);
-  }, []);
 
   // The swatch row is capped to the viewport width (see the Content max-width
   // below) and scrolls horizontally when it overflows. Track which edges have
@@ -302,13 +298,14 @@ export const VerseActionPopover: FC<VerseActionPopoverProps> = ({
     highlightedVerses,
   });
 
-  // Snapshot of everything the Content renders. While open we keep it fresh; the
-  // moment `open` flips false (apply / outside-click) the parent clears the
-  // selection and anchor synchronously, so without this the still-animating bar
+  // Snapshot of the anchor and everything the Content renders. While open we
+  // keep it fresh; the moment `open` flips false (apply / outside-click) the
+  // parent clears the selection and anchor, so the still-animating bar
   // would lose its anchor (jump to a fallback position) and flash the empty
   // layout. Freezing the last snapshot lets it simply fade out where it was.
   const dockSide: 'top' | 'bottom' = docked ? dockedSide : 'bottom';
   const live = {
+    anchorElement,
     virtualRef,
     side: dockSide,
     sideOffset: docked ? 24 : 20,
@@ -318,6 +315,51 @@ export const VerseActionPopover: FC<VerseActionPopoverProps> = ({
   const frozenView = useRef(live);
   if (open) frozenView.current = live;
   const view = open ? live : frozenView.current;
+
+  // Radix renders no Anchor element when given a virtual ref. Use the actual
+  // verse in that case, including the frozen anchor while closed, so document
+  // focus tracking survives the reader clearing its selection between opens.
+  const anchor = view.anchorElement ?? popoverAnchor;
+  const interactionRoot = anchor ? (getOwnShadowRoot(anchor) ?? anchor.ownerDocument) : null;
+  const ownerDocument = anchor && !getOwnShadowRoot(anchor) ? anchor.ownerDocument : null;
+
+  // Capture before Radix's passive autofocus, including a mount already open
+  // with a virtual anchor. Key on the document, not each newly selected verse,
+  // so re-anchoring doesn't replace the remembered control with document.body.
+  useLayoutEffect(() => {
+    if (!ownerDocument) return;
+
+    const rememberFocusedElement = (target: EventTarget | null): void => {
+      if (
+        !isElementFromOwnerDocument(target, ownerDocument.documentElement, 'HTMLElement') ||
+        target.closest('[data-slot="verse-action-popover"]') ||
+        target.hasAttribute('data-radix-focus-guard')
+      ) {
+        return;
+      }
+      documentFocusRestoreTargetRef.current = target;
+    };
+    const handleFocusIn = (event: FocusEvent): void => rememberFocusedElement(event.target);
+
+    rememberFocusedElement(ownerDocument.activeElement);
+    ownerDocument.addEventListener('focusin', handleFocusIn);
+    return () => ownerDocument.removeEventListener('focusin', handleFocusIn);
+  }, [ownerDocument]);
+
+  useEffect(() => {
+    if (!open || !interactionRoot) return;
+    const rememberVersePointer = (event: Event): void => {
+      const content = contentRef.current;
+      if (content && isVerseEvent(event, content)) {
+        versePointerEventsRef.current.add(event);
+      }
+    };
+    // Radix defers touch outside handling to click, after pointerdown's composed
+    // path is cleared and its target may be retargeted to the shadow host. Keep
+    // only a verdict keyed to that event, not DOM paths or a sticky pointer flag.
+    interactionRoot.addEventListener('pointerdown', rememberVersePointer, true);
+    return () => interactionRoot.removeEventListener('pointerdown', rememberVersePointer, true);
+  }, [open, interactionRoot]);
 
   // Measure the swatch row's overflow and keep the fade in sync. Keyed on the
   // state-held node so it (re)attaches the listener the moment Radix commits the
@@ -352,7 +394,7 @@ export const VerseActionPopover: FC<VerseActionPopoverProps> = ({
 
   return (
     <PopoverPrimitive.Root open={portal.open} onOpenChange={portal.onOpenChange}>
-      <PopoverPrimitive.Anchor ref={popoverAnchorRef} virtualRef={view.virtualRef} />
+      <PopoverPrimitive.Anchor ref={setPopoverAnchor} virtualRef={view.virtualRef} />
       {!portal.awaitingPortalTarget && (
         <PopoverPrimitive.Portal container={portal.container}>
           <PopoverPrimitive.Content
@@ -406,13 +448,9 @@ export const VerseActionPopover: FC<VerseActionPopoverProps> = ({
               const content = contentRef.current;
               if (!content) return;
               const originalEvent = event.detail.originalEvent;
-              const interactedWithVerse = originalEvent
-                .composedPath()
-                .some(
-                  (target) =>
-                    isElementFromOwnerDocument(target, content, 'Element') &&
-                    target.matches('.yv-v[v]'),
-                );
+              const interactedWithVerse =
+                versePointerEventsRef.current.has(originalEvent) ||
+                isVerseEvent(originalEvent, content);
               if (interactedWithVerse) {
                 event.preventDefault();
                 return;


### PR DESCRIPTION
## Summary

Targets `journey-to-the-shadow-dom` after PR #381.

- Preserve verse selection and re-anchoring on touch in light and shadow DOM by capturing an event-keyed verse verdict before Radix defers outside handling.
- Restore focus for initially anchored and conditionally mounted verse actions, while preserving ordinary reader and outside-focus behavior.
- Let the actual reader settings body scroll within the existing popover collision-height cap.
- Reconcile ADR 0007, rollout-plan and README guidance on document-owned fonts, root-font/rem sizing, CSS customization, and deferred overlay coordination. Add a patch changeset.

## Verification

- Forced build, typecheck and lint pass; 1,291 package tests pass.
- All 25 focused Chromium shadow/regression stories pass, including PR #381's eight scenarios.
- Eight native Chromium checks pass: touch/mouse selection in both DOM scopes, focus restoration, and real 800×360 settings scrolling/hit testing. The identical checks reproduce all five bug cases on the untouched base.
- Public declarations are unchanged; bundle budgets, tree-shaking and i18n checks pass (existing i18n warnings remain).
- Independent Standards, Spec and Compatibility reviews found no required changes. Compatibility coverage limits remain for external/Expo layouts, standalone/demo composition and popover-specific iframe behavior; no new regression was demonstrated.

The broader 39-story run passed every test but exited nonzero for the previously reproduced Default-story font-load rejection with a placeholder app key. The focused 25-story run exits cleanly.

## Scope

No public API expansion, new overlay manager, font loader, unit rewrite, or broader automatic-isolation rollout. PR #381's documented peer-concurrency and rapid/nested final-focus gaps remain production gates for YPE-5356.






<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses touch re-anchoring, focus restoration, and constrained settings scrolling regressions while reconciling Shadow DOM documentation.
- Captures verse-pointer verdicts before deferred outside-interaction handling.
- Preserves focus targets across virtual anchors and conditional mounting.
- Makes the reader settings body scroll within the popover’s collision-height cap.
- Adds focused browser stories, unit coverage, documentation updates, and a patch changeset.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/ui/src/components/verse-action-popover.tsx | Adds event-keyed touch handling and lifecycle-aware focus capture and restoration for verse-action popovers. |
| packages/ui/src/components/bible-reader.tsx | Makes the reader settings body shrinkable and vertically scrollable within the existing popover height constraint. |
| packages/ui/src/components/verse-action-popover.test.tsx | Expands focus-restoration coverage for virtual anchors, conditional mounting, document roots, and shadow roots. |
| packages/ui/src/components/bible-reader.stories.tsx | Adds browser coverage for touch selection re-anchoring, outside dismissal, and focus preservation. |
| packages/ui/src/components/bible-theme-settings.stories.tsx | Adds constrained-viewport coverage proving settings controls remain scrollable and hit-testable. |
| docs/adr/0007-prototype-shadow-dom-style-isolation.md | Clarifies document-owned font loading, root-font sizing, and the prototype’s overlay-coordination boundaries. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Verse pointer interaction] --> B{Pointer targets verse?}
  B -->|Yes| C[Record event-keyed verse verdict]
  B -->|No| D[Allow outside dismissal]
  C --> E[Radix deferred outside handling]
  E --> F[Prevent dismissal and re-anchor]
  D --> G[Close popover and retain outside focus]
  F --> H[Keep verse actions open]
  G --> I[Clear selection]
  J[Popover opens] --> K[Capture prior focus target]
  K --> L[Focus action content]
  L --> M[Popover closes]
  M --> N{Outside interaction retained focus?}
  N -->|No| O[Restore captured target]
  N -->|Yes| P[Preserve newly focused outside element]
```

<sub>Reviews (3): Last reviewed commit: ["test(ui): wait for placement before meas..."](https://github.com/youversion/platform-sdk-react/commit/0df3443f5625add6008047b100633778d4207914) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62182129)</sub>

<!-- /greptile_comment -->