### PR TITLE
feat(core): add getFontStylesheetUrl helper

### DIFF
--- a/.changeset/ype-4857-fonts-helper.md
+++ b/.changeset/ype-4857-fonts-helper.md
@@ -1,0 +1,5 @@
+---
+'@youversion/platform-core': patch
+---
+
+Add `getFontStylesheetUrl` so partners can build the Fonts API stylesheet URL from an app key and font id (Untitled Serif / `fontId` 1 by default).

--- a/packages/core/src/getFontStylesheetUrl.test.ts
+++ b/packages/core/src/getFontStylesheetUrl.test.ts
@@ -19,6 +19,13 @@ describe('getFontStylesheetUrl', () => {
       }),
     ).toBe('https://api-staging.youversion.com/v1/fonts/1/stylesheet?app_key=test-app-key');
 
+    expect(
+      getFontStylesheetUrl({
+        appKey: 'test-app-key',
+        apiHost: 'api-staging.youversion.com',
+      }),
+    ).toBe('https://api-staging.youversion.com/v1/fonts/1/stylesheet?app_key=test-app-key');
+
     expect(getFontStylesheetUrl({ appKey: 'key encode/+chars' })).toBe(
       'https://api.youversion.com/v1/fonts/1/stylesheet?app_key=key%20encode%2F%2Bchars',
     );

--- a/packages/core/src/getFontStylesheetUrl.test.ts
+++ b/packages/core/src/getFontStylesheetUrl.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { getFontStylesheetUrl } from './getFontStylesheetUrl';
+
+describe('getFontStylesheetUrl', () => {
+  it('builds the Fonts API stylesheet URL for a font id and app key', () => {
+    expect(getFontStylesheetUrl({ appKey: 'test-app-key' })).toBe(
+      'https://api.youversion.com/v1/fonts/1/stylesheet?app_key=test-app-key',
+    );
+
+    expect(getFontStylesheetUrl({ fontId: 7, appKey: 'test-app-key' })).toBe(
+      'https://api.youversion.com/v1/fonts/7/stylesheet?app_key=test-app-key',
+    );
+
+    expect(
+      getFontStylesheetUrl({
+        fontId: 1,
+        appKey: 'test-app-key',
+        apiHost: 'https://api-staging.youversion.com/',
+      }),
+    ).toBe('https://api-staging.youversion.com/v1/fonts/1/stylesheet?app_key=test-app-key');
+
+    expect(getFontStylesheetUrl({ appKey: 'key encode/+chars' })).toBe(
+      'https://api.youversion.com/v1/fonts/1/stylesheet?app_key=key%20encode%2F%2Bchars',
+    );
+  });
+});

--- a/packages/core/src/getFontStylesheetUrl.ts
+++ b/packages/core/src/getFontStylesheetUrl.ts
@@ -10,6 +10,7 @@ export function getFontStylesheetUrl({
   appKey,
   apiHost = 'https://api.youversion.com',
 }: GetFontStylesheetUrlOptions): string {
-  const host = apiHost.replace(/\/+$/, '');
+  const trimmed = apiHost.replace(/\/+$/, '');
+  const host = trimmed.includes('://') ? trimmed : `https://${trimmed}`;
   return `${host}/v1/fonts/${fontId}/stylesheet?app_key=${encodeURIComponent(appKey)}`;
 }

--- a/packages/core/src/getFontStylesheetUrl.ts
+++ b/packages/core/src/getFontStylesheetUrl.ts
@@ -1,0 +1,15 @@
+export type GetFontStylesheetUrlOptions = {
+  fontId?: number;
+  appKey: string;
+  apiHost?: string;
+};
+
+/** Default `fontId` is 1 (Untitled Serif). See ADR-0004. */
+export function getFontStylesheetUrl({
+  fontId = 1,
+  appKey,
+  apiHost = 'https://api.youversion.com',
+}: GetFontStylesheetUrlOptions): string {
+  const host = apiHost.replace(/\/+$/, '');
+  return `${host}/v1/fonts/${fontId}/stylesheet?app_key=${encodeURIComponent(appKey)}`;
+}

--- a/packages/core/src/getFontStylesheetUrl.ts
+++ b/packages/core/src/getFontStylesheetUrl.ts
@@ -4,11 +4,11 @@ export type GetFontStylesheetUrlOptions = {
   apiHost?: string;
 };
 
-/** Default `fontId` is 1 (Untitled Serif). See ADR-0004. */
+/** Default `fontId` is 1 (Untitled Serif). `apiHost` is hostname-only, like `ApiClient`. See ADR-0004. */
 export function getFontStylesheetUrl({
   fontId = 1,
   appKey,
-  apiHost = 'https://api.youversion.com',
+  apiHost = 'api.youversion.com',
 }: GetFontStylesheetUrlOptions): string {
   const trimmed = apiHost.replace(/\/+$/, '');
   const host = trimmed.includes('://') ? trimmed : `https://${trimmed}`;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -52,6 +52,10 @@ export * from './types';
 export * from './utils/constants';
 export { getAdjacentChapter } from './getAdjacentChapter';
 export {
+  getFontStylesheetUrl,
+  type GetFontStylesheetUrlOptions,
+} from './getFontStylesheetUrl';
+export {
   transformBibleHtml,
   type TransformBibleHtmlOptions,
   type TransformedBibleHtml,


### PR DESCRIPTION
I want to make it easier for people to be able to get the font URL and get the font properly, so this is just an easy helper to make that possible 

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

YPE-4857 (platform-core fonts helper only). Adds a URL builder so core-only partners can load a YouVersion font stylesheet without assembling `app_key` by hand.

```ts
getFontStylesheetUrl({ fontId?: number; appKey: string; apiHost?: string }): string
```

- Default `fontId` is `1` (Untitled Serif)
- Default `apiHost` is `api.youversion.com` (hostname-only, same as `ApiClient` / `YvFonts` / ADR-0004)
- Returns `{origin}/v1/fonts/{fontId}/stylesheet?app_key={appKey}` with `encodeURIComponent` on the app key
- Hostname-only values get `https://` prefixed; full origins pass through
- Exported from `@youversion/platform-core`
- Patch changeset for `@youversion/platform-core`

## Scope lock

URL builder only. This PR does **not**:

- Add `@font-face`, `FontsClient`, or wire `schemas/font.ts`
- Change CDN `bible.css`, `release.yml`, or UI (`YvFonts` stays as-is)
- Touch hub DevDocs (remaining YPE-4857 work)
- Touch PR 384, 385, 382 or `cp/core-split`

ADR-0004 is unchanged: the helper encodes the same stylesheet URL the ADR already describes. No ADR edit (decision unchanged).

## Test plan

- [x] Unit: exact URL for default font/host, custom `fontId`, origin `apiHost`, hostname-only `apiHost`, and query encoding
- [x] `pnpm --filter @youversion/platform-core test` — 22 files / 433 tests passed after the hostname-only default
- [x] CI on `f6a5949` was 15 green / 1 skipped; `62b82c1` re-running

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57b4d89c-5c29-458b-8480-72cbe98f7fa2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57b4d89c-5c29-458b-8480-72cbe98f7fa2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a framework-neutral helper to construct YouVersion font stylesheet URLs and exports it from the core package.
- Defaults to Untitled Serif and the production API host.
- Supports hostname-only and full-origin custom hosts.
- Encodes app keys and removes trailing host slashes.
- Adds unit coverage and a patch changeset.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported hostname-only custom-host issue is fixed at the current head.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/core/src/getFontStylesheetUrl.ts | Adds the URL builder and correctly fixes hostname-only custom hosts by prefixing HTTPS. |
| packages/core/src/getFontStylesheetUrl.test.ts | Covers defaults, custom font IDs, full-origin and hostname-only hosts, trailing slashes, and app-key encoding. |
| packages/core/src/index.ts | Exposes the helper and its options type through the core package entry point. |
| .changeset/ype-4857-fonts-helper.md | Records the public helper as a patch release for the core package. |

<sub>Reviews (3): Last reviewed commit: ["fix(core): default getFontStylesheetUrl ..."](https://github.com/youversion/platform-sdk-react/commit/62b82c19eab684672edeb452a1b816c9ff8d910d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62259348)</sub>

**Context used:**

- Knowledge Base — [Core platform SDK](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/core-platform.md)
- Knowledge Base — [Monorepo build, validation, and release](https://app.greptile.com/youversion/-/custom-context/knowledge-base/youversion/platform-sdk-react/-/docs/monorepo-build-release.md)

<!-- /greptile_comment -->