### PR TITLE
feat(core): add getStyledPassageElement for vanilla Bible HTML (YPE-5721)

### DIFF
--- a/.changeset/ype-4857-fonts-helper.md
+++ b/.changeset/ype-4857-fonts-helper.md
@@ -1,0 +1,5 @@
+---
+'@youversion/platform-core': patch
+---
+
+Add `getFontStylesheetUrl` so partners can build the Fonts API stylesheet URL from an app key and font id (Untitled Serif / `fontId` 1 by default).

--- a/.changeset/ype-5721-styled-passage.md
+++ b/.changeset/ype-5721-styled-passage.md
@@ -1,0 +1,5 @@
+---
+'@youversion/platform-core': patch
+---
+
+Add `BibleClient.getStyledPassageElement` so vanilla JS partners can fetch a passage, inject Bible CSS and the Fonts API stylesheet once, and append a ready DOM element with copyright.

--- a/packages/core/src/bible.ts
+++ b/packages/core/src/bible.ts
@@ -11,6 +11,12 @@ import {
   getVOTD,
 } from './bible-reads';
 import { getVersions, type GetVersionsOptions } from './bible-versions';
+import {
+  assertBrowserDocument,
+  createStyledPassageElement,
+  ensureStyledPassageStylesheets,
+  type GetStyledPassageElementOptions,
+} from './getStyledPassageElement';
 import type {
   BibleBook,
   BibleChapter,
@@ -22,6 +28,8 @@ import type {
   Collection,
   VOTD,
 } from './types';
+
+export type { GetStyledPassageElementOptions };
 
 /**
  * Client for interacting with Bible API endpoints.
@@ -204,6 +212,45 @@ export class BibleClient {
     parseBibleVersionId(versionId);
     await assertUsableVersion(this.client, versionId);
     return this.client.get<BibleIndex>(`/v1/bibles/${versionId}/index`);
+  }
+
+  /**
+   * Returns a detached DOM element with styled Bible HTML for vanilla JS partners.
+   *
+   * Fetches the passage (html + transform defaults) and version, injects the CDN
+   * Bible CSS sheet and Fonts API stylesheet into `document.head` once each
+   * (deduped by href), then builds an element with `data-yv-sdk` and
+   * `data-slot="yv-bible-renderer"`, passage HTML via `innerHTML`, and copyright
+   * via `textContent`. Does not mount the element — append it where you want.
+   *
+   * Requires a browser `document`. Reuses version-refuse and propagates
+   * `getPassage` / `getVersion` errors.
+   *
+   * @param options.versionId - Bible version id
+   * @param options.usfm - Passage USFM (e.g. `"JHN.3.16"`)
+   * @param options.fontId - Optional Fonts API font id (default `1`, Untitled Serif)
+   * @returns A detached `HTMLElement` ready to append
+   *
+   * @example
+   * ```ts
+   * const el = await bibleClient.getStyledPassageElement({
+   *   versionId: 3034,
+   *   usfm: "JHN.3.16",
+   * });
+   * mount.append(el);
+   * ```
+   */
+  async getStyledPassageElement(options: GetStyledPassageElementOptions): Promise<HTMLElement> {
+    assertBrowserDocument();
+
+    const { versionId, usfm, fontId = 1 } = options;
+    const [passage, version] = await Promise.all([
+      this.getPassage(versionId, usfm),
+      this.getVersion(versionId),
+    ]);
+
+    ensureStyledPassageStylesheets(this.client, fontId);
+    return createStyledPassageElement(passage.content, version.copyright);
   }
 
   /**

--- a/packages/core/src/bible.ts
+++ b/packages/core/src/bible.ts
@@ -12,9 +12,8 @@ import {
 } from './bible-reads';
 import { getVersions, type GetVersionsOptions } from './bible-versions';
 import {
-  assertBrowserDocument,
-  createStyledPassageElement,
-  ensureStyledPassageStylesheets,
+  assembleStyledPassageElement,
+  requireStyledPassageDocument,
   type GetStyledPassageElementOptions,
 } from './getStyledPassageElement';
 import type {
@@ -241,7 +240,7 @@ export class BibleClient {
    * ```
    */
   async getStyledPassageElement(options: GetStyledPassageElementOptions): Promise<HTMLElement> {
-    assertBrowserDocument();
+    requireStyledPassageDocument();
 
     const { versionId, usfm, fontId = 1 } = options;
     const [passage, version] = await Promise.all([
@@ -249,8 +248,7 @@ export class BibleClient {
       this.getVersion(versionId),
     ]);
 
-    ensureStyledPassageStylesheets(this.client, fontId);
-    return createStyledPassageElement(passage.content, version.copyright);
+    return assembleStyledPassageElement(this.client, passage.content, version.copyright, fontId);
   }
 
   /**

--- a/packages/core/src/getFontStylesheetUrl.test.ts
+++ b/packages/core/src/getFontStylesheetUrl.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { getFontStylesheetUrl } from './getFontStylesheetUrl';
+
+describe('getFontStylesheetUrl', () => {
+  it('builds the Fonts API stylesheet URL for a font id and app key', () => {
+    expect(getFontStylesheetUrl({ appKey: 'test-app-key' })).toBe(
+      'https://api.youversion.com/v1/fonts/1/stylesheet?app_key=test-app-key',
+    );
+
+    expect(getFontStylesheetUrl({ fontId: 7, appKey: 'test-app-key' })).toBe(
+      'https://api.youversion.com/v1/fonts/7/stylesheet?app_key=test-app-key',
+    );
+
+    expect(
+      getFontStylesheetUrl({
+        fontId: 1,
+        appKey: 'test-app-key',
+        apiHost: 'https://api-staging.youversion.com/',
+      }),
+    ).toBe('https://api-staging.youversion.com/v1/fonts/1/stylesheet?app_key=test-app-key');
+
+    expect(
+      getFontStylesheetUrl({
+        appKey: 'test-app-key',
+        apiHost: 'api-staging.youversion.com',
+      }),
+    ).toBe('https://api-staging.youversion.com/v1/fonts/1/stylesheet?app_key=test-app-key');
+
+    expect(getFontStylesheetUrl({ appKey: 'key encode/+chars' })).toBe(
+      'https://api.youversion.com/v1/fonts/1/stylesheet?app_key=key%20encode%2F%2Bchars',
+    );
+  });
+});

--- a/packages/core/src/getFontStylesheetUrl.ts
+++ b/packages/core/src/getFontStylesheetUrl.ts
@@ -1,0 +1,16 @@
+export type GetFontStylesheetUrlOptions = {
+  fontId?: number;
+  appKey: string;
+  apiHost?: string;
+};
+
+/** Default `fontId` is 1 (Untitled Serif). `apiHost` is hostname-only, like `ApiClient`. See ADR-0004. */
+export function getFontStylesheetUrl({
+  fontId = 1,
+  appKey,
+  apiHost = 'api.youversion.com',
+}: GetFontStylesheetUrlOptions): string {
+  const trimmed = apiHost.replace(/\/+$/, '');
+  const host = trimmed.includes('://') ? trimmed : `https://${trimmed}`;
+  return `${host}/v1/fonts/${fontId}/stylesheet?app_key=${encodeURIComponent(appKey)}`;
+}

--- a/packages/core/src/getStyledPassageElement.test.ts
+++ b/packages/core/src/getStyledPassageElement.test.ts
@@ -1,0 +1,179 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { ApiClient } from './client';
+import { BibleClient } from './bible';
+import { getFontStylesheetUrl } from './getFontStylesheetUrl';
+import { YouVersionPlatformConfiguration } from './YouVersionPlatformConfiguration';
+import { mockVersionKJV } from './__tests__/MockVersions';
+import { mockNIVGen1Verse1PassageHTML } from './__tests__/MockPassages';
+import { server } from './__tests__/setup';
+
+const apiHost = process.env.YVP_API_HOST || 'api.youversion.com';
+const appKey = 'test-styled-passage-app-key';
+const BIBLE_CSS_HREF = 'https://cdn.youversion.com/platform/1/bible.css';
+
+function bibleClient(overrides?: { apiHost?: string; appKey?: string }): BibleClient {
+  return new BibleClient(
+    new ApiClient({
+      apiHost: overrides?.apiHost ?? apiHost,
+      appKey: overrides?.appKey ?? appKey,
+      installationId: 'test-installation',
+    }),
+  );
+}
+
+function stylesheetHrefs(): string[] {
+  return [...document.head.querySelectorAll('link[rel="stylesheet"]')].map(
+    (link) => link.getAttribute('href') ?? '',
+  );
+}
+
+function clearHeadStylesheets(): void {
+  for (const link of document.head.querySelectorAll('link[rel="stylesheet"]')) {
+    link.remove();
+  }
+}
+
+function clearVersionFilters(): void {
+  YouVersionPlatformConfiguration.permittedVersionIds = undefined;
+  YouVersionPlatformConfiguration.excludedVersionIds = undefined;
+  YouVersionPlatformConfiguration.permittedLanguageTags = undefined;
+}
+
+describe('BibleClient.getStyledPassageElement', () => {
+  it('returns a detached element with reader tokens, passage HTML, copyright text, and injects stylesheets once', async () => {
+    clearHeadStylesheets();
+
+    const client = bibleClient();
+    const el = await client.getStyledPassageElement({ versionId: 1, usfm: 'GEN.1.1' });
+
+    expect(el.isConnected).toBe(false);
+    expect(el.hasAttribute('data-yv-sdk')).toBe(true);
+    expect(el.getAttribute('data-slot')).toBe('yv-bible-renderer');
+    expect(el.innerHTML).toContain('data-yv-transformed');
+    expect(el.innerHTML).toContain('In the beginning God created the heavens and the earth');
+
+    const copyrightChild = el.lastElementChild;
+    expect(copyrightChild).not.toBeNull();
+    expect(copyrightChild?.textContent).toBe(mockVersionKJV.copyright);
+
+    const fontHref = getFontStylesheetUrl({ fontId: 1, appKey, apiHost });
+    expect(stylesheetHrefs()).toEqual([BIBLE_CSS_HREF, fontHref]);
+
+    const second = await client.getStyledPassageElement({ versionId: 1, usfm: 'GEN.1.1' });
+    expect(second).not.toBe(el);
+    expect(second.isConnected).toBe(false);
+    expect(stylesheetHrefs()).toEqual([BIBLE_CSS_HREF, fontHref]);
+    expect(stylesheetHrefs().filter((href) => href === BIBLE_CSS_HREF)).toHaveLength(1);
+    expect(stylesheetHrefs().filter((href) => href === fontHref)).toHaveLength(1);
+  });
+
+  it('sets copyright via textContent even when the API copyright string contains markup', async () => {
+    clearHeadStylesheets();
+    const markupCopyright = 'Rights <script>alert(1)</script> & more <b>bold</b>';
+    server.use(
+      http.get(`https://${apiHost}/v1/bibles/:id`, () => {
+        return HttpResponse.json({ ...mockVersionKJV, copyright: markupCopyright });
+      }),
+    );
+
+    const el = await bibleClient().getStyledPassageElement({ versionId: 1, usfm: 'GEN.1.1' });
+    const copyrightChild = el.lastElementChild;
+    expect(copyrightChild?.textContent).toBe(markupCopyright);
+    expect(copyrightChild?.querySelector('script')).toBeNull();
+    expect(copyrightChild?.querySelector('b')).toBeNull();
+    expect(copyrightChild?.childNodes).toHaveLength(1);
+    expect(copyrightChild?.childNodes[0]?.nodeType).toBe(Node.TEXT_NODE);
+  });
+
+  it('uses an empty copyright text child when version.copyright is missing', async () => {
+    clearHeadStylesheets();
+    server.use(
+      http.get(`https://${apiHost}/v1/bibles/:id`, () => {
+        return HttpResponse.json({ ...mockVersionKJV, copyright: null });
+      }),
+    );
+
+    const el = await bibleClient().getStyledPassageElement({ versionId: 1, usfm: 'GEN.1.1' });
+    expect(el.lastElementChild?.textContent).toBe('');
+  });
+
+  it('throws a clear browser-only error when document is unavailable', async () => {
+    clearHeadStylesheets();
+    const originalDocument = globalThis.document;
+    // Simulate a non-browser runtime while keeping the rest of the globals.
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      value: undefined,
+    });
+
+    try {
+      await expect(
+        bibleClient().getStyledPassageElement({ versionId: 1, usfm: 'GEN.1.1' }),
+      ).rejects.toThrow(/browser document/i);
+    } finally {
+      Object.defineProperty(globalThis, 'document', {
+        configurable: true,
+        value: originalDocument,
+      });
+    }
+  });
+
+  it('propagates version-refuse without calling the passage endpoint', async () => {
+    clearHeadStylesheets();
+    clearVersionFilters();
+    YouVersionPlatformConfiguration.excludedVersionIds = [111];
+
+    let passageCalls = 0;
+    server.use(
+      http.get(`https://${apiHost}/v1/bibles/111/passages/:usfm`, () => {
+        passageCalls += 1;
+        return HttpResponse.json(mockNIVGen1Verse1PassageHTML);
+      }),
+    );
+
+    try {
+      await expect(
+        bibleClient().getStyledPassageElement({ versionId: 111, usfm: 'GEN.1.1' }),
+      ).rejects.toMatchObject({ status: 403 });
+      expect(passageCalls).toBe(0);
+    } finally {
+      clearVersionFilters();
+    }
+  });
+
+  it('propagates API errors from getPassage', async () => {
+    clearHeadStylesheets();
+    server.use(
+      http.get(`https://${apiHost}/v1/bibles/:bible_id/passages/GEN.1.1`, () => {
+        return HttpResponse.json(
+          { error: 'not_found', error_description: 'Passage not found' },
+          { status: 404 },
+        );
+      }),
+    );
+
+    await expect(
+      bibleClient().getStyledPassageElement({ versionId: 1, usfm: 'GEN.1.1' }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('optional fontId changes only the font stylesheet href', async () => {
+    clearHeadStylesheets();
+    const client = bibleClient();
+
+    await client.getStyledPassageElement({ versionId: 1, usfm: 'GEN.1.1' });
+    const defaultFontHref = getFontStylesheetUrl({ fontId: 1, appKey, apiHost });
+    expect(stylesheetHrefs()).toEqual([BIBLE_CSS_HREF, defaultFontHref]);
+
+    await client.getStyledPassageElement({ versionId: 1, usfm: 'GEN.1.1', fontId: 7 });
+    const altFontHref = getFontStylesheetUrl({ fontId: 7, appKey, apiHost });
+    expect(stylesheetHrefs()).toEqual([BIBLE_CSS_HREF, defaultFontHref, altFontHref]);
+    expect(stylesheetHrefs().filter((href) => href === BIBLE_CSS_HREF)).toHaveLength(1);
+    expect(altFontHref).toContain('/v1/fonts/7/stylesheet');
+    expect(altFontHref).not.toBe(defaultFontHref);
+  });
+});

--- a/packages/core/src/getStyledPassageElement.ts
+++ b/packages/core/src/getStyledPassageElement.ts
@@ -1,0 +1,64 @@
+import type { ApiClient } from './client';
+import { getFontStylesheetUrl } from './getFontStylesheetUrl';
+
+/** CDN major matches `packages/ui/CDN_CSS_MAJOR_VERSION` (bible.css upload path). */
+const BIBLE_CSS_STYLESHEET_HREF = 'https://cdn.youversion.com/platform/1/bible.css';
+
+export type GetStyledPassageElementOptions = {
+  versionId: number;
+  usfm: string;
+  /** Fonts API font id. Defaults to 1 (Untitled Serif). */
+  fontId?: number;
+};
+
+export function assertBrowserDocument(): Document {
+  const doc = globalThis.document;
+  if (!doc?.createElement || !doc.head) {
+    throw new Error(
+      'getStyledPassageElement requires a browser document. It cannot run where document is unavailable (for example Node without a DOM).',
+    );
+  }
+  return doc;
+}
+
+function ensureStylesheetLink(doc: Document, href: string): void {
+  for (const link of doc.head.querySelectorAll('link[rel="stylesheet"]')) {
+    if (link.getAttribute('href') === href) {
+      return;
+    }
+  }
+  const link = doc.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = href;
+  doc.head.append(link);
+}
+
+/** Inject CDN bible.css + Fonts API stylesheet once each (dedupe by href). */
+export function ensureStyledPassageStylesheets(client: ApiClient, fontId: number): void {
+  const doc = assertBrowserDocument();
+  const fontHref = getFontStylesheetUrl({
+    fontId,
+    appKey: client.config.appKey,
+    apiHost: client.config.apiHost ?? 'api.youversion.com',
+  });
+  ensureStylesheetLink(doc, BIBLE_CSS_STYLESHEET_HREF);
+  ensureStylesheetLink(doc, fontHref);
+}
+
+/** Detached element with reader tokens, passage HTML, and copyright text child. */
+export function createStyledPassageElement(
+  passageContent: string,
+  copyright: string | null | undefined,
+): HTMLElement {
+  const doc = assertBrowserDocument();
+  const root = doc.createElement('div');
+  root.setAttribute('data-yv-sdk', '');
+  root.setAttribute('data-slot', 'yv-bible-renderer');
+  root.innerHTML = passageContent;
+
+  const copyrightEl = doc.createElement('div');
+  copyrightEl.textContent = copyright ?? '';
+  root.append(copyrightEl);
+
+  return root;
+}

--- a/packages/core/src/getStyledPassageElement.ts
+++ b/packages/core/src/getStyledPassageElement.ts
@@ -11,7 +11,7 @@ export type GetStyledPassageElementOptions = {
   fontId?: number;
 };
 
-export function assertBrowserDocument(): Document {
+function assertBrowserDocument(): Document {
   const doc = globalThis.document;
   if (!doc?.createElement || !doc.head) {
     throw new Error(
@@ -33,8 +33,7 @@ function ensureStylesheetLink(doc: Document, href: string): void {
   doc.head.append(link);
 }
 
-/** Inject CDN bible.css + Fonts API stylesheet once each (dedupe by href). */
-export function ensureStyledPassageStylesheets(client: ApiClient, fontId: number): void {
+function ensureStyledPassageStylesheets(client: ApiClient, fontId: number): void {
   const doc = assertBrowserDocument();
   const fontHref = getFontStylesheetUrl({
     fontId,
@@ -45,8 +44,7 @@ export function ensureStyledPassageStylesheets(client: ApiClient, fontId: number
   ensureStylesheetLink(doc, fontHref);
 }
 
-/** Detached element with reader tokens, passage HTML, and copyright text child. */
-export function createStyledPassageElement(
+function createStyledPassageElement(
   passageContent: string,
   copyright: string | null | undefined,
 ): HTMLElement {
@@ -61,4 +59,20 @@ export function createStyledPassageElement(
   root.append(copyrightEl);
 
   return root;
+}
+
+/** Throws if `document` is missing; call before fetching so failures stay browser-local. */
+export function requireStyledPassageDocument(): void {
+  assertBrowserDocument();
+}
+
+/** Inject stylesheets (deduped) and build the detached passage element. */
+export function assembleStyledPassageElement(
+  client: ApiClient,
+  passageContent: string,
+  copyright: string | null | undefined,
+  fontId: number,
+): HTMLElement {
+  ensureStyledPassageStylesheets(client, fontId);
+  return createStyledPassageElement(passageContent, copyright);
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -51,6 +51,7 @@ export {
 export * from './types';
 export * from './utils/constants';
 export { getAdjacentChapter } from './getAdjacentChapter';
+export { getFontStylesheetUrl, type GetFontStylesheetUrlOptions } from './getFontStylesheetUrl';
 export {
   transformBibleHtml,
   type TransformBibleHtmlOptions,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 export { ApiClient, getHttpStatus } from './client';
-export { BibleClient } from './bible';
+export { BibleClient, type GetStyledPassageElementOptions } from './bible';
 export { getChapter, getVersion } from './bible-chapter';
 export {
   getAllVOTDs,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes [YPE-5721](https://lifechurch.atlassian.net/browse/YPE-5721).

## Summary

Adds `BibleClient.getStyledPassageElement({ versionId, usfm, fontId? })` so vanilla JS partners can append a styled Scripture DOM node without assembling Bible CSS, font stylesheet URLs, or copyright markup themselves.

Also lands `getFontStylesheetUrl` from closed (unmerged) PR #391 so this helper can reuse the Fonts API URL builder. That helper stays public.

## Status

- [x] T1: `getFontStylesheetUrl` (from PR #391) merged onto this branch
- [ ] T2: `getStyledPassageElement` + tests + changeset (in progress)

## Behavior

- Fetches via existing `getPassage` (html + transform default) and `getVersion`
- Returns a detached element with `data-yv-sdk` and `data-slot="yv-bible-renderer"`
- Sets passage HTML via `innerHTML`; copyright via `textContent` (`""` if missing)
- Injects CDN `bible.css` + font stylesheet into `document.head` once (deduped by href)
- Reads `appKey` / `apiHost` from the existing `ApiClient`; default `fontId` is `1`
- Throws a clear browser-only error when `document` is missing
- Propagates version-refuse / API errors from the underlying clients

## Out of scope

- Does **not** close YPE-4857 or rewrite hub DevDocs
- Does **not** replace or rewrite the `getFontStylesheetUrl` API from PR #391
- No React/hooks/UI, theme option, SSR, or CDN upload changes

## Test plan

- [ ] Unit/MSW + jsdom: element tokens, passage HTML, copyright textContent
- [ ] Stylesheet inject once; second call does not duplicate links but returns a fresh element
- [ ] Missing `document` throws; refuse/API errors propagate; optional `fontId` changes font href only
- [ ] `pnpm --filter @youversion/platform-core test`
- [ ] Patch changeset for `@youversion/platform-core`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39d6a981-76f2-4e4b-ae73-ae61e3bfcdd9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39d6a981-76f2-4e4b-ae73-ae61e3bfcdd9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[YPE-5721]: https://lifechurch.atlassian.net/browse/YPE-5721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ