### PR TITLE
fix(ui): enforce Shadow DOM custom property contract (YPE-5400)

### DIFF
--- a/.changeset/fuzzy-spiders-check.md
+++ b/.changeset/fuzzy-spiders-check.md
@@ -1,0 +1,5 @@
+---
+'@youversion/platform-react-ui': patch
+---
+
+Audit the compiled Shadow DOM stylesheet custom-property contract and fail builds on unexplained ambient references.

--- a/docs/adr/0007-prototype-shadow-dom-style-isolation.md
+++ b/docs/adr/0007-prototype-shadow-dom-style-isolation.md
@@ -27,8 +27,9 @@ scales SDK text, spacing, and controls. That sizing input is accepted for the
 prototype; it is not reset by a shadow boundary.
 Known ambient custom-property dependencies are closed by using SDK-owned
 `--yv-spacing` and `--yv-radius` values and by defining a local `--spacing`
-compatibility alias for `tw-animate-css`. YPE-5400 owns the full custom-property
-inventory and a compiled-CSS prevention guard.
+compatibility alias for `tw-animate-css`. The completed YPE-5400 inventory,
+exact runtime-input exceptions, and compiled-CSS prevention guard are documented
+in the rollout plan.
 
 Constructable stylesheets are cached per owning `Document`, because a sheet from
 the top-level document cannot be adopted into a same-origin iframe's shadow

--- a/docs/shadow-dom-isolation-plan.md
+++ b/docs/shadow-dom-isolation-plan.md
@@ -93,13 +93,13 @@ decision. YPE-5356 owns whether and how to implement that coordination.
 
 ## Custom-property contract
 
-YPE-5400 audited authored UI CSS and TSX class inputs, the embedded core reader
-CSS, Tailwind and `tw-animate-css` inputs, and the resulting
+YPE-5400 audited authored UI CSS and TSX class inputs, the embedded core theme
+and Bible reader CSS, Tailwind and `tw-animate-css` inputs, and the resulting
 `packages/ui/dist/tailwind.css`. After removing an accidental `--radius`
-reference introduced by a test-only Tailwind class, the compiled stylesheet has
-201 declared or initialized names and 151 referenced names. The declarations
-are 137 SDK-owned `--yv-*` names, 63 generated `--tw-*` names, and the local
-`--spacing` compatibility alias.
+reference introduced by a test-only Tailwind class, the compiled stylesheet at
+the completion of YPE-5400 contained 201 declared or initialized names and 151
+referenced names. The declarations comprised 137 SDK-owned `--yv-*` names, 63
+generated `--tw-*` names, and the local `--spacing` compatibility alias.
 
 | Name or namespace | Classification and ownership |
 | --- | --- |
@@ -116,7 +116,7 @@ reference-only exceptions:
 
 | Property | Supplier and rationale |
 | --- | --- |
-| `--yv-reader-max-width` | `BibleCard` supplies it inline when configured; the embedded reader CSS otherwise falls back to `65ch`. |
+| `--yv-reader-max-width` | `BibleCard` always supplies `none` inline so scripture fills its card content; other uses of the embedded or published reader CSS fall back to `65ch` when the property is unset. |
 | `--radix-accordion-content-height` | Radix Accordion supplies its measured content height inline. |
 | `--radix-popover-content-available-height` | Radix Popover supplies the available height inline. |
 | `--radix-popover-content-available-width` | Radix Popover supplies the available width inline. |

--- a/docs/shadow-dom-isolation-plan.md
+++ b/docs/shadow-dom-isolation-plan.md
@@ -87,10 +87,58 @@ decision. YPE-5356 owns whether and how to implement that coordination.
   trigger-time peer dismissal as well as overlay order and restore targets;
   ADR 0007 records the gaps but does not select a coordination design.
   Cross-browser and assistive-technology coverage still remain.
-- Complete the package-wide custom-property inventory and prevention guard in
-  YPE-5400. The known `BibleVersionPicker`, `InputGroup`, and `tw-animate-css`
-  dependencies now resolve through locally-defined SDK-owned spacing and radius
-  values, but `all: initial` does not reset unknown custom properties.
+- Keep the YPE-5400 custom-property contract and compiled-stylesheet prevention
+  guard green as component styles change. The audit below closes the known
+  ambient dependency; `all: initial` still does not reset custom properties.
+
+## Custom-property contract
+
+YPE-5400 audited authored UI CSS and TSX class inputs, the embedded core reader
+CSS, Tailwind and `tw-animate-css` inputs, and the resulting
+`packages/ui/dist/tailwind.css`. After removing an accidental `--radius`
+reference introduced by a test-only Tailwind class, the compiled stylesheet has
+201 declared or initialized names and 151 referenced names. The declarations
+are 137 SDK-owned `--yv-*` names, 63 generated `--tw-*` names, and the local
+`--spacing` compatibility alias.
+
+| Name or namespace | Classification and ownership |
+| --- | --- |
+| `--yv-*` | SDK-owned properties. The README's documented overrides are supported consumer inputs for light-DOM components under `[data-yv-sdk]`. They are not a public document-level override API for the automatically isolated `YouVersionAuthButton`. |
+| `--tw-*` | Tailwind and `tw-animate-css` implementation state that is declared or initialized in the compiled stylesheet. It is not a supported consumer input. |
+| `--spacing` | SDK-owned local compatibility alias for `--yv-spacing`, used by generated Tailwind utilities. |
+| Authored `--font-*`, `--color-*`, and `--radius-*` theme aliases | Compile-time Tailwind inputs that produce utilities backed by `--yv-*` values. They are not runtime consumer inputs. |
+| Exact `--radix-*` exceptions below | Third-party runtime inputs supplied inline by the corresponding Radix primitive. |
+| Exact cross-framework accordion exceptions below | Optional inputs in `tw-animate-css`'s fallback chain. The chain first checks the Radix value and ultimately falls back to `auto`. |
+| Any other reference-only name | Forbidden ambient dependency until it is locally supplied or added below with a reviewed owner and rationale. |
+
+The compiled guard has no namespace wildcards. These are its exact reviewed
+reference-only exceptions:
+
+| Property | Supplier and rationale |
+| --- | --- |
+| `--yv-reader-max-width` | `BibleCard` supplies it inline when configured; the embedded reader CSS otherwise falls back to `65ch`. |
+| `--radix-accordion-content-height` | Radix Accordion supplies its measured content height inline. |
+| `--radix-popover-content-available-height` | Radix Popover supplies the available height inline. |
+| `--radix-popover-content-available-width` | Radix Popover supplies the available width inline. |
+| `--radix-popover-content-transform-origin` | Radix Popover supplies the transform origin inline. |
+| `--bits-accordion-content-height` | Optional `tw-animate-css` cross-framework fallback; the chain ends at `auto`. |
+| `--reka-accordion-content-height` | Optional `tw-animate-css` cross-framework fallback; the chain ends at `auto`. |
+| `--kb-accordion-content-height` | Optional `tw-animate-css` cross-framework fallback; the chain ends at `auto`. |
+| `--ngp-accordion-content-height` | Optional `tw-animate-css` cross-framework fallback; the chain ends at `auto`. |
+
+`scripts/verify-styles.js` parses the real compiled stylesheet and fails the UI
+build when a referenced custom-property name is neither declared/initialized
+there nor present in that exact allowlist. This is deliberately a name-level
+artifact check: a declaration somewhere in the stylesheet does not prove that
+the cascade makes it available to every selector. Focused contract tests and
+component tests preserve that boundary without pretending to perform full
+selector-reachability analysis.
+
+The source audit also found that `VerseActionPopover` assigns the source-only
+names `--tw-animate-duration` and `--tw-animate-easing`, while the installed
+animation CSS consumes differently named properties. Those inert assignments
+are not ambient stylesheet dependencies; their behavior change is tracked
+separately in YPE-5749.
 
 ## Functional and compatibility audits
 

--- a/docs/shadow-dom-isolation-plan.md
+++ b/docs/shadow-dom-isolation-plan.md
@@ -196,7 +196,7 @@ forms, labels, ARIA relationships, events, refs, queries, and overlays.
 
 ## Rollout sequence
 
-1. Complete YPE-5400's custom-property inventory and prevention guard.
+1. Maintain YPE-5400's completed custom-property inventory and prevention guard.
 2. Resolve SSR/hydration in YPE-5354 and overlay ownership in YPE-5355, then
    reconcile those findings and YPE-5436's consumer contract in YPE-5356.
 3. Select the next public component and add component-specific compatibility,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -93,6 +93,7 @@
     "@vitest/browser-playwright": "4.0.4",
     "@vitest/coverage-v8": "4.0.4",
     "concurrently": "9.2.1",
+    "css-tree": "^3.2.1",
     "dotenv-cli": "7.4.2",
     "jsdom": "27.0.1",
     "markdown-to-jsx": "^9.6.1",

--- a/packages/ui/scripts/custom-property-contract.d.ts
+++ b/packages/ui/scripts/custom-property-contract.d.ts
@@ -1,0 +1,7 @@
+export interface CustomPropertyAudit {
+  declarations: string[];
+  references: string[];
+  unexplainedReferences: string[];
+}
+
+export function auditCustomProperties(css: string): CustomPropertyAudit;

--- a/packages/ui/scripts/custom-property-contract.js
+++ b/packages/ui/scripts/custom-property-contract.js
@@ -80,12 +80,10 @@ export function auditCustomProperties(css) {
 
     if (node.type === 'Atrule' && node.name.toLowerCase() === 'property') {
       const name = node.prelude?.children.first;
-      let hasInitialValue = false;
-      node.block?.children.forEach((child) => {
-        if (child.type === 'Declaration' && child.property === 'initial-value') {
-          hasInitialValue = true;
-        }
-      });
+      const hasInitialValue =
+        node.block?.children.some(
+          (child) => child.type === 'Declaration' && child.property === 'initial-value',
+        ) ?? false;
 
       if (name?.type === 'Identifier' && name.name.startsWith('--') && hasInitialValue) {
         declarations.add(name.name);

--- a/packages/ui/scripts/custom-property-contract.js
+++ b/packages/ui/scripts/custom-property-contract.js
@@ -1,0 +1,113 @@
+import { parse, walk } from 'css-tree';
+
+const referenceOnlyExceptions = new Map([
+  [
+    '--yv-reader-max-width',
+    {
+      category: 'SDK-owned component input',
+      supplier: 'BibleCard inline style or the 65ch literal fallback',
+      reason: 'The core reader stylesheet is also published for configurable light-DOM use.',
+    },
+  ],
+  [
+    '--radix-accordion-content-height',
+    {
+      category: 'third-party runtime input',
+      supplier: '@radix-ui/react-accordion',
+      reason: 'Radix sets the measured content height on its accordion content element.',
+    },
+  ],
+  [
+    '--radix-popover-content-available-height',
+    {
+      category: 'third-party runtime input',
+      supplier: '@radix-ui/react-popover',
+      reason: 'Radix sets the available height on the popover content element.',
+    },
+  ],
+  [
+    '--radix-popover-content-available-width',
+    {
+      category: 'third-party runtime input',
+      supplier: '@radix-ui/react-popover',
+      reason: 'Radix sets the available width on the popover content element.',
+    },
+  ],
+  [
+    '--radix-popover-content-transform-origin',
+    {
+      category: 'third-party runtime input',
+      supplier: '@radix-ui/react-popover',
+      reason: 'Radix sets the transform origin on the popover content element.',
+    },
+  ],
+  ...[
+    '--bits-accordion-content-height',
+    '--reka-accordion-content-height',
+    '--kb-accordion-content-height',
+    '--ngp-accordion-content-height',
+  ].map((name) => [
+    name,
+    {
+      category: 'third-party generated fallback input',
+      supplier: 'tw-animate-css',
+      reason: 'The imported cross-framework accordion fallback chain terminates in auto.',
+    },
+  ]),
+]);
+
+function sorted(values) {
+  return [...values].sort();
+}
+
+/**
+ * Inventory custom-property names in one compiled stylesheet.
+ *
+ * This is intentionally a name-level check: a declaration or @property
+ * registration explains a reference, but does not prove selector-level cascade
+ * reachability. The reviewed exceptions cover reference-only runtime inputs.
+ */
+export function auditCustomProperties(css) {
+  const ast = parse(css, { context: 'stylesheet', parseCustomProperty: true });
+  const declarations = new Set();
+  const references = new Set();
+
+  walk(ast, (node) => {
+    if (node.type === 'Declaration' && node.property.startsWith('--')) {
+      declarations.add(node.property);
+      return;
+    }
+
+    if (node.type === 'Atrule' && node.name.toLowerCase() === 'property') {
+      const name = node.prelude?.children.first;
+      let hasInitialValue = false;
+      node.block?.children.forEach((child) => {
+        if (child.type === 'Declaration' && child.property === 'initial-value') {
+          hasInitialValue = true;
+        }
+      });
+
+      if (name?.type === 'Identifier' && name.name.startsWith('--') && hasInitialValue) {
+        declarations.add(name.name);
+      }
+      return;
+    }
+
+    if (node.type === 'Function' && node.name.toLowerCase() === 'var') {
+      const name = node.children.first;
+      if (name?.type === 'Identifier' && name.name.startsWith('--')) {
+        references.add(name.name);
+      }
+    }
+  });
+
+  const unexplainedReferences = [...references].filter(
+    (name) => !declarations.has(name) && !referenceOnlyExceptions.has(name),
+  );
+
+  return {
+    declarations: sorted(declarations),
+    references: sorted(references),
+    unexplainedReferences: sorted(unexplainedReferences),
+  };
+}

--- a/packages/ui/scripts/verify-styles.js
+++ b/packages/ui/scripts/verify-styles.js
@@ -27,7 +27,7 @@ if (!css.trim()) {
   const { unexplainedReferences } = auditCustomProperties(css);
   if (unexplainedReferences.length > 0) {
     errors.push(
-      `dist/tailwind.css contains unexplained custom-property references: ${unexplainedReferences.join(', ')}`,
+      `dist/tailwind.css contains unexplained custom-property references: ${unexplainedReferences.join(', ')}. Add a local declaration or document an exact reviewed runtime exception in packages/ui/scripts/custom-property-contract.js`,
     );
   }
 }

--- a/packages/ui/scripts/verify-styles.js
+++ b/packages/ui/scripts/verify-styles.js
@@ -1,6 +1,7 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { auditCustomProperties } from './custom-property-contract.js';
 import { stripLayerBlocks } from './strip-layer-blocks.js';
 
 const dist = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'dist');
@@ -20,6 +21,13 @@ if (!css.trim()) {
   if (!unlayered.includes('-webkit-appearance:revert-layer')) {
     errors.push(
       'dist/tailwind.css missing -webkit-appearance:revert-layer on the unlayered A2 rule',
+    );
+  }
+
+  const { unexplainedReferences } = auditCustomProperties(css);
+  if (unexplainedReferences.length > 0) {
+    errors.push(
+      `dist/tailwind.css contains unexplained custom-property references: ${unexplainedReferences.join(', ')}`,
     );
   }
 }

--- a/packages/ui/src/components/ui/input-group.test.tsx
+++ b/packages/ui/src/components/ui/input-group.test.tsx
@@ -5,7 +5,7 @@ import { render } from '@testing-library/react';
 import { expect, it } from 'vitest';
 import { InputGroup, InputGroupAddon } from './input-group';
 
-it('uses --yv-radius for kbd rounding, not --radius', () => {
+it('uses the SDK-owned --yv-radius for kbd rounding', () => {
   const { container } = render(
     <InputGroup>
       <InputGroupAddon />
@@ -14,5 +14,4 @@ it('uses --yv-radius for kbd rounding, not --radius', () => {
   const addon = container.querySelector('[data-slot="input-group-addon"]');
 
   expect(addon).toHaveClass('yv:[&>kbd]:rounded-[calc(var(--yv-radius)-5px)]');
-  expect(addon).not.toHaveClass('yv:[&>kbd]:rounded-[calc(var(--radius)-5px)]');
 });

--- a/packages/ui/src/styles/custom-property-contract.test.ts
+++ b/packages/ui/src/styles/custom-property-contract.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { auditCustomProperties } from '../../scripts/custom-property-contract.js';
+
+describe('auditCustomProperties', () => {
+  it('inventories declarations, registrations, and nested references structurally', () => {
+    const audit = auditCustomProperties(`
+      /* var(--comment-lookalike) */
+      @property --registered-duration {
+        syntax: "<time>";
+        inherits: false;
+        initial-value: 0s;
+      }
+      @property --uninitialized-input {
+        syntax: "*";
+        inherits: true;
+      }
+      .example {
+        --local-color: var(--registered-duration);
+        color: var(--local-color);
+        width: var(--outer-input, var(--inner-input, 1rem));
+        height: var(--uninitialized-input);
+        content: "var(--string-lookalike)";
+      }
+    `);
+
+    expect(audit.declarations).toEqual(['--local-color', '--registered-duration']);
+    expect(audit.references).toEqual([
+      '--inner-input',
+      '--local-color',
+      '--outer-input',
+      '--registered-duration',
+      '--uninitialized-input',
+    ]);
+    expect(audit.unexplainedReferences).toEqual([
+      '--inner-input',
+      '--outer-input',
+      '--uninitialized-input',
+    ]);
+  });
+
+  it('accepts exact reviewed exceptions and rejects a new ambient reference', () => {
+    const audit = auditCustomProperties(`
+      .reader { max-width: var(--yv-reader-max-width, 65ch); }
+      .popover { width: var(--radix-popover-content-available-width); }
+      .unknown { border-radius: var(--radius); }
+    `);
+
+    expect(audit.unexplainedReferences).toEqual(['--radius']);
+  });
+});

--- a/packages/ui/src/styles/custom-property-contract.test.ts
+++ b/packages/ui/src/styles/custom-property-contract.test.ts
@@ -42,9 +42,13 @@ describe('auditCustomProperties', () => {
     const audit = auditCustomProperties(`
       .reader { max-width: var(--yv-reader-max-width, 65ch); }
       .popover { width: var(--radix-popover-content-available-width); }
+      .near-match { width: var(--radix-popover-content-available-width-extra); }
       .unknown { border-radius: var(--radius); }
     `);
 
-    expect(audit.unexplainedReferences).toEqual(['--radius']);
+    expect(audit.unexplainedReferences).toEqual([
+      '--radius',
+      '--radix-popover-content-available-width-extra',
+    ]);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -344,6 +344,9 @@ importers:
       concurrently:
         specifier: 9.2.1
         version: 9.2.1
+      css-tree:
+        specifier: ^3.2.1
+        version: 3.2.1
       dotenv-cli:
         specifier: 7.4.2
         version: 7.4.2
@@ -4050,6 +4053,10 @@ packages:
     resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
@@ -5230,6 +5237,9 @@ packages:
 
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -6748,7 +6758,7 @@ snapshots:
     dependencies:
       '@asamuzakjp/nwsapi': 2.3.9
       bidi-js: 1.0.3
-      css-tree: 3.1.0
+      css-tree: 3.2.1
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.2.2
 
@@ -10368,6 +10378,11 @@ snapshots:
       mdn-data: 2.12.2
       source-map-js: 1.2.1
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   css.escape@1.5.1: {}
 
   cssesc@3.0.0: {}
@@ -10376,7 +10391,7 @@ snapshots:
     dependencies:
       '@asamuzakjp/css-color': 4.0.5
       '@csstools/css-syntax-patches-for-csstree': 1.0.14(postcss@8.5.6)
-      css-tree: 3.1.0
+      css-tree: 3.2.1
     transitivePeerDependencies:
       - postcss
 
@@ -11506,6 +11521,8 @@ snapshots:
   math-intrinsics@1.1.0: {}
 
   mdn-data@2.12.2: {}
+
+  mdn-data@2.27.1: {}
 
   media-typer@1.1.0: {}
 


### PR DESCRIPTION
## Summary

- audit authored and compiled UI custom properties across SDK, embedded core, Tailwind, `tw-animate-css`, and Radix inputs
- remove the test-only Tailwind class that accidentally emitted an ambient `--radius` dependency
- parse the real compiled stylesheet during `verify:styles` and fail builds on unexplained reference-only custom properties
- document the light-DOM consumer contract, exact runtime-input exceptions, ownership, and the guard's intentional name-level limitation
- add a UI patch changeset

## Requirement evidence

| Jira acceptance area | Evidence |
| --- | --- |
| Source and compiled inventory | The rollout plan records the authored audit and compiled totals: 201 declared/initialized names, 151 referenced names, and zero unexplained references after the fix. |
| Property classification | The contract classifies SDK-owned `--yv-*`, supported light-DOM inputs, generated Tailwind state, compile-time theme aliases, Radix runtime inputs, `tw-animate-css` fallbacks, and forbidden ambient names. |
| Existing customization behavior | The README remains unchanged: document-level `--yv-*` overrides are supported for light-DOM `[data-yv-sdk]` components, while the automatically isolated `YouVersionAuthButton` gains no public shadow-root token API. |
| Local fixes versus follow-up | The accidental compiled `--radius` dependency is removed. The separate inert VerseActionPopover animation-property behavior is linked and documented under YPE-5749. |
| Compiled prevention guard | `verify-styles.js` parses `dist/tailwind.css` with `css-tree`, accepts only locally supplied names or nine exact reviewed exceptions, and fails on new unexplained references. Focused tests cover nested references, registrations, parser lookalikes, exact exceptions, and rejection. |
| Durable documentation | The rollout plan owns the complete contract and exception rationale; ADR 0007 points to that completed evidence. |

## Review scope

Required outcomes:

- inventory and classify custom-property declarations and references in authored UI inputs and the actual compiled stylesheet, including embedded core and third-party CSS
- preserve the documented light-DOM customization contract without introducing a public shadow-root token API
- remove local forbidden ambient dependencies and enforce the compiled contract with a documented exact allowlist
- document the contract, exceptions, and guard limitation in the Shadow DOM rollout record

Permitted support work:

- a focused `css-tree` validator and adjacent declaration file
- wiring through the existing compiled-style verifier
- consolidated unit tests, removal of the test-only negative Tailwind scan input, a minimal ADR pointer update, dependency metadata, and a UI patch changeset

Non-goals:

- selector- or cascade-reachability analysis; the guard is intentionally name-level
- a public shadow-root customization API, broader Shadow DOM rollout, third-party CSS rewrites, namespace wildcard exceptions, or a permanent TypeScript source scanner
- changing the VerseActionPopover animation custom properties; that behavior is tracked in YPE-5749
- changing the existing README customization promise

Please treat a finding as blocking only when it identifies an unmet in-scope requirement, a documented repository-standard violation in added or modified code, or a concrete regression or defect caused or worsened by this diff. Label other valid improvements as non-blocking follow-ups.

## Verification

- `pnpm --filter @youversion/platform-react-ui exec vitest run --project unit src/styles/custom-property-contract.test.ts src/components/ui/input-group.test.tsx` — 3/3 passed
- `pnpm --filter @youversion/platform-react-ui build` — passed; compiled style verification reports zero unexplained references
- `pnpm lint` — passed
- `pnpm typecheck` — passed
- `pnpm turbo test --concurrency=1 -- --maxWorkers=1` — passed: core 432/432, hooks 318/318, UI 543/543
- `pnpm turbo build --force` — passed, 4/4 build tasks uncached
- final independent Standards, Spec, and Compatibility audits at `9bcb473` — no required findings

The default concurrent test invocation twice exposed existing five-second timeouts in `bible-reader-controlled.test.tsx`; the affected file passed 33/33 in isolation and the complete sequential repository suite passed 1,293/1,293.

## Compatibility and limitations

- Published runtime code, public exports, component DOM, and the README contract are unchanged.
- The generated stylesheet loses exactly one orphan selector created by the removed negative test literal; the production `--yv-radius` InputGroup selector remains.
- The exact exception ledger is intentionally duplicated in executable code and durable documentation so both builds and reviewers can enforce ownership without adding generation machinery.
- The guard proves artifact-wide name ownership, not that each declaration reaches each reference through the cascade.

## Jira

- [YPE-5400](https://lifechurch.atlassian.net/browse/YPE-5400)
- Follow-up: [YPE-5749](https://lifechurch.atlassian.net/browse/YPE-5749)


[YPE-5400]: https://lifechurch.atlassian.net/browse/YPE-5400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR establishes and documents the Shadow DOM custom-property ownership contract and enforces it against the compiled UI stylesheet.
- Adds a css-tree-based inventory of declarations, registrations, and references.
- Integrates unexplained-reference validation into the existing compiled-style verifier.
- Documents the exact runtime exceptions and the intentional name-level limitation.
- Removes the test-only ambient `--radius` input and adds focused contract coverage.
- Adds the required UI patch changeset and dependency metadata.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/ui/scripts/custom-property-contract.js | Structurally inventories compiled custom-property declarations and references, then applies an exact reviewed exception set. |
| packages/ui/scripts/verify-styles.js | Runs the new custom-property audit against the compiled stylesheet and reports unexplained references through the existing verifier. |
| packages/ui/src/styles/custom-property-contract.test.ts | Covers nested references, registrations, parser lookalikes, exact exceptions, near matches, and forbidden ambient names. |
| docs/shadow-dom-isolation-plan.md | Records property ownership, runtime suppliers, exceptions, audit totals, and the guard’s deliberate name-level scope. |
| packages/ui/package.json | Adds a Node-compatible build-time parser dependency consistent with repository dependency and lockfile conventions. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Authored UI and imported CSS] --> B[Tailwind compilation]
  B --> C[dist/tailwind.css]
  C --> D[css-tree custom-property audit]
  D --> E{Every reference declared or allowlisted?}
  E -->|Yes| F[Style verification passes]
  E -->|No| G[UI build fails with unexplained names]
```

<sub>Reviews (5): Last reviewed commit: ["refactor(ui): simplify custom property e..."](https://github.com/youversion/platform-sdk-react/commit/dfcfca043b3b4b93bc4eeb58c8946823c533297f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62686976)</sub>

<!-- /greptile_comment -->